### PR TITLE
feat(overheat): Add overheat indicator lamps for oil, water, water_aux, and engine

### DIFF
--- a/McZapkie/MOVER.h
+++ b/McZapkie/MOVER.h
@@ -1066,6 +1066,9 @@ class TMoverParameters
 		float temperatura1{50.0};
 		float temperatura2{40.0};
 		float powerfactor{1.0}; // coefficient of heat generation for engines other than su45
+		// engine overheat threshold
+		float engine_max_temp{-1}; // maximum acceptable engine temperature, triggers overheat lamp when exceeded
+		bool engine_is_hot{false}; // engine temperature crossed cooling threshold
 	};
 
 	struct spring_brake

--- a/McZapkie/Mover.cpp
+++ b/McZapkie/Mover.cpp
@@ -8174,6 +8174,10 @@ void TMoverParameters::dizel_Heat( double const dt ) {
     dizel_heat.oil.is_hot = (
         ( dizel_heat.oil.config.temp_max > 0 )
      && ( dizel_heat.To > dizel_heat.oil.config.temp_max - ( dizel_heat.oil.is_hot ? 8 : 0 ) ) );
+    // engine overheat check
+    dizel_heat.engine_is_hot = (
+        ( dizel_heat.engine_max_temp > 0 )
+     && ( dizel_heat.Ts > dizel_heat.engine_max_temp - ( dizel_heat.engine_is_hot ? 8 : 0 ) ) );
 
     auto const PT = (
         ( false == dizel_heat.water.is_cold )
@@ -11254,6 +11258,7 @@ void TMoverParameters::LoadFIZ_Engine( std::string const &Input ) {
         extract_value( dizel_heat.water_aux.config.shutters, "WaterAuxShutters", Input, "" );
         extract_value( dizel_heat.oil.config.temp_min, "OilMinTemperature", Input, "" );
         extract_value( dizel_heat.oil.config.temp_max, "OilMaxTemperature", Input, "" );
+        extract_value( dizel_heat.engine_max_temp, "EngineMaxTemperature", Input, "" );
         extract_value( dizel_heat.fan_speed, "WaterCoolingFanSpeed", Input, "" );
         // water heater
         extract_value( WaterHeater.config.temp_min, "HeaterMinTemperature", Input, "" );

--- a/vehicle/Train.cpp
+++ b/vehicle/Train.cpp
@@ -7926,6 +7926,11 @@ bool TTrain::Update( double const Deltatime )
         btLampkaRearRightEndLight.Turn( ( mvOccupied->iLights[ end::rear ] & light::redmarker_right ) != 0 );
         // others
         btLampkaMalfunction.Turn( mvControlled->dizel_heat.PA );
+        // overheat indicator lamps
+        btLampkaOilOverheat.Turn( mvControlled->dizel_heat.oil.is_hot );
+        btLampkaWaterOverheat.Turn( mvControlled->dizel_heat.water.is_hot );
+        btLampkaWaterAuxOverheat.Turn( mvControlled->dizel_heat.water_aux.is_hot );
+        btLampkaEngineOverheat.Turn( mvControlled->dizel_heat.engine_is_hot );
         btLampkaMotorBlowers.Turn( ( mvControlled->MotorBlowers[ end::front ].is_active ) && ( mvControlled->MotorBlowers[ end::rear ].is_active ) );
         btLampkaCoolingFans.Turn( mvControlled->RventRot > 1.0 );
         btLampkaTempomat.Turn( mvOccupied->SpeedCtrlUnit.IsActive );
@@ -7966,6 +7971,11 @@ bool TTrain::Update( double const Deltatime )
         btLampkaBrakeProfileR.Turn( false );
 		btLampkaSpringBrakeActive.Turn( false );
 		btLampkaSpringBrakeInactive.Turn( false );
+        // overheat indicator lamps off
+        btLampkaOilOverheat.Turn( false );
+        btLampkaWaterOverheat.Turn( false );
+        btLampkaWaterAuxOverheat.Turn( false );
+        btLampkaEngineOverheat.Turn( false );
         btLampkaMaxSila.Turn( false );
         btLampkaPrzekrMaxSila.Turn( false );
         btLampkaRadio.Turn( false );
@@ -9756,6 +9766,11 @@ void TTrain::clear_cab_controls()
     btLampkaNadmWent.Clear(9);
     btLampkaWysRozr.Clear(((mvControlled->TrainType & dt_ET22) != 0) ? -1 : 10); // ET22 nie ma tej lampki
     btLampkaOgrzewanieSkladu.Clear(11);
+    // overheat indicator lamps
+    btLampkaOilOverheat.Clear(-1);
+    btLampkaWaterOverheat.Clear(-1);
+    btLampkaWaterAuxOverheat.Clear(-1);
+    btLampkaEngineOverheat.Clear(-1);
     btHaslerBrakes.Clear(12); // ciśnienie w cylindrach do odbijania na haslerze
     btHaslerCurrent.Clear(13); // prąd na silnikach do odbijania na haslerze
     // Numer 14 jest używany dla buczka SHP w update_sounds()
@@ -10425,6 +10440,11 @@ bool TTrain::initialize_button(cParser &Parser, std::string const &Label, int co
         { "i-mainbreakerblinking:", btLampkaMainBreakerBlinkingIfReady },
         { "i-vent_ovld:", btLampkaNadmWent },
         { "i-comp_ovld:", btLampkaNadmSpr },
+        // overheat indicator lamps
+        { "i-oil_overheat:", btLampkaOilOverheat },
+        { "i-water_overheat:", btLampkaWaterOverheat },
+        { "i-wateraux_overheat:", btLampkaWaterAuxOverheat },
+        { "i-engine_overheat:", btLampkaEngineOverheat },
         { "i-resistors:", btLampkaOpory },
         { "i-no_resistors:", btLampkaBezoporowa },
         { "i-no_resistors_b:", btLampkaBezoporowaB },

--- a/vehicle/Train.h
+++ b/vehicle/Train.h
@@ -761,6 +761,11 @@ public: // reszta może by?publiczna
     TButton btLampkaBrakeProfileR; // rapid brake acting speed
 	TButton btLampkaSpringBrakeActive;
 	TButton btLampkaSpringBrakeInactive;
+    // overheat indicator lamps
+    TButton btLampkaOilOverheat;
+    TButton btLampkaWaterOverheat;
+    TButton btLampkaWaterAuxOverheat;
+    TButton btLampkaEngineOverheat;
     // KURS90
     TButton btLampkaBoczniki;
     TButton btLampkaMaxSila;


### PR DESCRIPTION
## Summary
This PR implements issue #77 - adding overheat indicator lamps for diesel engines.

## Changes
- Added `engine_max_temp` and `engine_is_hot` fields to `heat_data` structure in MOVER.h
- Added `EngineMaxTemperature` field extraction from .fiz files in Mover.cpp
- Added engine overheat check comparing `Ts` with `engine_max_temp` in Mover.cpp
- Added four new overheat lamp indicators in Train.h and Train.cpp:
  - `i-oil_overheat`
  - `i-water_overheat`
  - `i-wateraux_overheat`
  - `i-engine_overheat`
- Added lamp update logic to turn on/off based on `is_hot` flags
- Added lamp initialization in `clear_cab_controls()`

## Implementation Details
The lamps will turn on when:
- Oil temperature exceeds `OilMaxTemperature`
- Water temperature exceeds `WaterMaxTemperature`
- Auxiliary water temperature exceeds `WaterAuxMaxTemperature`
- Engine temperature exceeds `EngineMaxTemperature`

Each check includes 8-degree hysteresis to prevent rapid on/off cycling.

## Related
Closes #77