### PR TITLE
feat: add EngineMaxTemperature support for diesel locomotive overheat detection

### DIFF
--- a/McZapkie/MOVER.h
+++ b/McZapkie/MOVER.h
@@ -1045,7 +1045,7 @@ class TMoverParameters
 			bool is_warm{false}; // fluid is too hot
 			bool is_hot{false}; // fluid temperature crossed cooling threshold
 			bool is_flowing{false}; // fluid is being pushed through the circuit
-		} water, water_aux, oil;
+		} water, water_aux, oil, engine;
 		// output, state of affected devices
 		bool PA{false}; // malfunction flag
 		float rpmw{0.0}; // current main circuit fan revolutions

--- a/McZapkie/Mover.cpp
+++ b/McZapkie/Mover.cpp
@@ -8174,6 +8174,9 @@ void TMoverParameters::dizel_Heat( double const dt ) {
     dizel_heat.oil.is_hot = (
         ( dizel_heat.oil.config.temp_max > 0 )
      && ( dizel_heat.To > dizel_heat.oil.config.temp_max - ( dizel_heat.oil.is_hot ? 8 : 0 ) ) );
+    dizel_heat.engine.is_hot = (
+        ( dizel_heat.engine.config.temp_max > 0 )
+     && ( dizel_heat.Ts > dizel_heat.engine.config.temp_max - ( dizel_heat.engine.is_hot ? 8 : 0 ) ) );
 
     auto const PT = (
         ( false == dizel_heat.water.is_cold )
@@ -8181,7 +8184,8 @@ void TMoverParameters::dizel_Heat( double const dt ) {
      && ( false == dizel_heat.water_aux.is_cold )
      && ( false == dizel_heat.water_aux.is_hot )
      && ( false == dizel_heat.oil.is_cold )
-     && ( false == dizel_heat.oil.is_hot ) /* && ( false == awaria_termostatow ) */ ) /* || PTp */;
+     && ( false == dizel_heat.oil.is_hot )
+     && ( false == dizel_heat.engine.is_hot ) /* && ( false == awaria_termostatow ) */ ) /* || PTp */;
     auto const PPT = ( false == PT ) /* && ( false == PPTp ) */;
     dizel_heat.PA = ( /* ( ( !zamkniecie or niedomkniecie ) and !WBD ) || */ PPT /* || nurnik || ( woda < 7 ) */ ) /* && ( !PAp ) */;
 
@@ -11254,6 +11258,7 @@ void TMoverParameters::LoadFIZ_Engine( std::string const &Input ) {
         extract_value( dizel_heat.water_aux.config.shutters, "WaterAuxShutters", Input, "" );
         extract_value( dizel_heat.oil.config.temp_min, "OilMinTemperature", Input, "" );
         extract_value( dizel_heat.oil.config.temp_max, "OilMaxTemperature", Input, "" );
+        extract_value( dizel_heat.engine.config.temp_max, "EngineMaxTemperature", Input, "" );
         extract_value( dizel_heat.fan_speed, "WaterCoolingFanSpeed", Input, "" );
         // water heater
         extract_value( WaterHeater.config.temp_min, "HeaterMinTemperature", Input, "" );


### PR DESCRIPTION
## Summary
Add engine temperature monitoring to diesel locomotive heat management system.

## Changes
- Add engine field to heat_data struct (fluid_circuit_t type)
- Add EngineMaxTemperature config extraction in .fiz files
- Add engine overheat detection logic (is_hot check)
- Include engine.is_hot in PT status check

## Motivation
Implements issue #77: Oil, water and engine overheat lamps for diesel locomotives.

This allows users to configure engine temperature thresholds in vehicle definition files, enabling proper overheat warnings for diesel locomotives.

## Testing
The changes follow the existing pattern for oil and water temperature monitoring, ensuring consistency with the current implementation.

Closes #77