### PR TITLE
Fix a segfault when closing on Wayland

### DIFF
--- a/application/application.cpp
+++ b/application/application.cpp
@@ -678,6 +678,7 @@ void eu07_application::exit()
 		glfwDestroyWindow(window);
 	}
 	m_taskqueue.exit();
+	glfwPollEvents(); // TODO: This fixes a segfault on Wayland when closing. Remove after updating glfw to 3.5.
 	glfwTerminate();
 
 	if (!Global.exec_on_exit.empty())


### PR DESCRIPTION
According to https://github.com/glfw/glfw/issues/2744, this will be fixed in GLFW 3.5.