### PR TITLE
Revert "Reduce string creations and deletions"

### DIFF
--- a/utilities/parser.cpp
+++ b/utilities/parser.cpp
@@ -190,17 +190,16 @@ bool cParser::getTokens(unsigned int Count, bool ToLower, const char *Break)
 	    this->str("");
 	    this->clear();
 	*/
-	std::string token; 
 	for (unsigned int i = tokens.size(); i < Count; ++i)
 	{
-		readToken(token, ToLower, Break);
-		if (token.empty())
+		std::string token = readToken(ToLower, Break);
+		if (true == token.empty())
 		{
 			// no more tokens
 			break;
 		}
-		tokens.emplace_back(std::move(token));
 		// collect parameters
+		tokens.emplace_back(token);
 		/*
 		        if (i == 0)
 		            this->str(token);
@@ -219,6 +218,18 @@ bool cParser::getTokens(unsigned int Count, bool ToLower, const char *Break)
 		return true;
 }
 
+std::string cParser::readTokenFromDelegate(bool ToLower, const char *Break)
+{
+	if (!mIncludeParser)
+		return {};
+	std::string token = mIncludeParser->readToken(ToLower, Break);
+	if (token.empty())
+	{
+		mIncludeParser = nullptr;
+	}
+	return token;
+}
+
 std::string cParser::readTokenFromStream(bool ToLower, const char *Break)
 {
 	std::string token;
@@ -229,7 +240,9 @@ std::string cParser::readTokenFromStream(bool ToLower, const char *Break)
 
 
 	while (token.empty() && mStream->peek() != EOF) {
-		while (mStream->get(c)) {
+		while (mStream->peek() != EOF) {
+			c = static_cast<char>(mStream->get());
+
 			if (c == '\n') {
 				++mLine;
 			}
@@ -267,7 +280,7 @@ void cParser::stripFirstTokenBOM(std::string& token, bool ToLower, const char* B
 
 	// if first "token" was standalone BOM, read the next real token (avoid recursion)
 	while (token.empty() && mStream->peek() != EOF) {
-		readToken(token, ToLower, Break);
+		token = readToken(ToLower, Break);
 		// readToken will not re-enter BOM stripping because mFirstToken is now false
 		break;
 	}
@@ -309,7 +322,7 @@ void cParser::skipIncludeBlock() {
 	// mimic original: while token != "end" readToken(true)
 	std::string t;
 	do {
-		readToken(t, true);
+		t = readToken(true);
 	} while (t != "end" && !t.empty());
 }
 
@@ -354,81 +367,72 @@ void cParser::startIncludeFromParser(cParser& srcParser, bool ToLower, std::stri
 bool cParser::handleIncludeIfPresent(std::string& token, bool ToLower, const char* Break) {
 	// token-mode include: token == "include"
 	if (expandIncludes && token == "include") {
-		std::string includefile;
-		if (allowRandomIncludes)
-			includefile = deserialize_random_set(*this);
-		else
-			readToken(includefile, ToLower);
+		std::string includefile =
+			allowRandomIncludes ? deserialize_random_set(*this) : readToken(ToLower);
 
 		startIncludeFromParser(*this, ToLower, std::move(includefile));
 
 		// after processing include, return next token from current parser
-		readToken(token, ToLower, Break);
+		token = readToken(ToLower, Break);
 		return true;
 	}
 
 	// line-mode HACK: Break == "\n\r" and line begins with "include"
 	if ((std::strcmp(Break, "\n\r") == 0) && token.compare(0, 7, "include") == 0) {
 		cParser includeparser(token.substr(7));
-		std::string includefile;
-		if (allowRandomIncludes)
-			includefile = deserialize_random_set(includeparser);
-		else
-			includeparser.readToken(includefile, ToLower);
+		std::string includefile =
+			allowRandomIncludes ? deserialize_random_set(includeparser) : includeparser.readToken(ToLower);
 
 		startIncludeFromParser(includeparser, ToLower, std::move(includefile));
 
-		readToken(token, ToLower, Break);
+		token = readToken(ToLower, Break);
 		return true;
 	}
 
 	return false;
 }
 
-void cParser::readToken(std::string &out, bool ToLower, const char *Break)
+std::string cParser::readToken(bool ToLower, const char *Break)
 {
-	if (mIncludeParser)
+	std::string token;
+
+	token = readTokenFromDelegate(ToLower, Break);
+	if (token.empty())
 	{
-		mIncludeParser->readToken(out, ToLower, Break);
-		if (out.empty())
-		{
-			mIncludeParser = nullptr;
-			out = readTokenFromStream(ToLower, Break);
-		}
-	}
-	else
-	{
-		out = readTokenFromStream(ToLower, Break);
+		token = readTokenFromStream(ToLower, Break);
 	}
 
-	stripFirstTokenBOM(out, ToLower, Break);
+	stripFirstTokenBOM(token, ToLower, Break);
 
-	substituteParameters(out, ToLower);
+	substituteParameters(token, ToLower);
 
-	handleIncludeIfPresent(out, ToLower, Break);
+	handleIncludeIfPresent(token, ToLower, Break);
+
+	return token;
 }
 
 std::vector<std::string> cParser::readParameters(cParser &Input)
 {
 
 	std::vector<std::string> includeparameters;
-	std::string parameter;
-	Input.readToken(parameter, false); // w parametrach nie zmniejszamy
+	std::string parameter = Input.readToken(false); // w parametrach nie zmniejszamy
 	while ((parameter.empty() == false) && (parameter != "end"))
 	{
 		includeparameters.emplace_back(parameter);
-		Input.readToken(parameter, false);
+		parameter = Input.readToken(false);
 	}
 	return includeparameters;
 }
 
 std::string cParser::readQuotes(char const Quote)
 { // read the stream until specified char or stream end
-	std::string token;
+	std::string token = "";
 	char c{0};
 	bool escaped = false;
-	while (mStream->get(c))
+	while (mStream->peek() != EOF)
 	{ // get all chars until the quote mark
+		c = mStream->get();
+
 		if (escaped)
 		{
 			escaped = false;
@@ -454,11 +458,13 @@ std::string cParser::readQuotes(char const Quote)
 
 void cParser::skipComment(std::string const &Endmark)
 { // pobieranie znaków aż do znalezienia znacznika końca
-	std::string input;
+	std::string input = "";
 	char c{0};
 	auto const endmarksize = Endmark.size();
-	while (mStream->get(c))
+	while (mStream->peek() != EOF)
 	{
+		// o ile nie koniec pliku
+		c = mStream->get(); // pobranie znaku
 		if (c == '\n')
 		{
 			// update line counter
@@ -549,8 +555,8 @@ std::size_t cParser::count()
 	size_t count{0};
 	do
 	{
-		token.clear();
-		readToken(token, false);
+		token = "";
+		token = readToken(false);
 		++count;
 	} while (false == token.empty());
 

--- a/utilities/parser.h
+++ b/utilities/parser.h
@@ -45,14 +45,11 @@ class cParser //: public std::stringstream
     inline
     void
         ignoreToken() {
-		std::string out;
-            readToken(out); };
+            readToken(); };
     inline
     bool
         expectToken( std::string const &Value ) {
-		std::string out;
-		readToken(out);
-            return out == Value; };
+            return readToken() == Value; };
     inline
     bool
         eof() {
@@ -69,6 +66,7 @@ class cParser //: public std::stringstream
             return m_autoclear; }
     bool
         getTokens( unsigned int Count = 1, bool ToLower = true, char const *Break = "\n\r\t ;" );
+	std::string readTokenFromDelegate(bool ToLower, const char *Break);
 	std::string readTokenFromStream(bool ToLower, const char *Break);
 	void stripFirstTokenBOM(std::string &token, bool ToLower, const char *Break);
 	void substituteParameters(std::string &token, bool ToLower);
@@ -105,7 +103,7 @@ class cParser //: public std::stringstream
 	void startIncludeFromParser(cParser &srcParser, bool ToLower, std::string includefile);
 	bool handleIncludeIfPresent(std::string &token, bool ToLower, const char *Break);
 	// methods:
-    void readToken(std::string& out, bool ToLower = true, const char *Break = "\n\r\t ;");
+    std::string readToken(bool ToLower = true, const char *Break = "\n\r\t ;");
 	static std::vector<std::string> readParameters( cParser &Input );
     std::string readQuotes( char const Quote = '\"' );
     void skipComment( std::string const &Endmark );


### PR DESCRIPTION
Reverts MaSzyna-EU07/maszyna#100

had to revert 
after changes it fails to load cars from example consist:
```
trainset rozklad start 0 0
node -1 0 EU07-462'20 dynamic pkp\303e_v1 303E-462'20 303E 0 headdriver 99 0 enddynamic
node -1 0 b10nouz_515120-71003-0#13 dynamic pkp\yb_v1 B10nouz_515120-71003-0 B84_PL_NS_2 -1 nobody 115 0 enddynamic
node -1 0 b10nouz_515120-71030-3#14 dynamic pkp\yb_v1 B10nouz_515120-71030-3 B84_PL_4 0 nobody 115 0 enddynamic
endtrainset
```
Probably fails if file contains `include .... end` and has immediate end of file - to fix needs to add new line and then end of file should occur