### PR TITLE
Feat/avx2 support + reduce cache misses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ option(WITH_BETTER_RENDERER "Experimental multi-backend renderer based on NVRHI"
 option(GENERATE_PDB "Generate executable with program debugging symbols" ON)
 option(ENABLE_MCC "Enable multicore compilation" ON)
 option(WITHDUMPGEN "Enable generating DMP files on crash" ON)
+option(ENABLE_AVX2 "Enable AVX2 instruction set (requires AVX2-capable CPU, Haswell/2013 or newer)" ON)
 
 set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
@@ -508,7 +509,6 @@ else()
 	target_compile_definitions(${PROJECT_NAME} PUBLIC WITH_DISCORD_RPC=0)
 endif()
 
-
 find_package(OpenAL REQUIRED)
 if (TARGET OpenAL::OpenAL)
 	target_link_libraries(${PROJECT_NAME} OpenAL::OpenAL)
@@ -582,4 +582,13 @@ endif()
 if(ENABLE_MCC AND MSVC)
     message(STATUS "Enabling multi-processor compilation for MSVC.")
 	add_compile_options(/MP)
+endif()
+
+if(ENABLE_AVX2)
+    message(STATUS "Enabling AVX2 instruction set.")
+    if (MSVC)
+        target_compile_options(${PROJECT_NAME} PRIVATE /arch:AVX2)
+    else()
+        target_compile_options(${PROJECT_NAME} PRIVATE -mavx2)
+    endif()
 endif()

--- a/betterRenderer/CMakeLists.txt
+++ b/betterRenderer/CMakeLists.txt
@@ -67,7 +67,11 @@ target_include_directories(${LIBMANUL_NAME} PRIVATE
 
 target_compile_definitions(${LIBMANUL_NAME} PRIVATE
         GLM_ENABLE_EXPERIMENTAL
-        GLM_FORCE_SWIZZLE)
+        GLM_FORCE_SWIZZLE
+        GLM_FORCE_CTOR_INIT
+        GLM_FORCE_INLINE
+        GLM_FORCE_DEFAULT_ALIGNED_GENTYPES
+        GLM_FORCE_INTRINSICS)
 
 target_compile_definitions(${LIBMANUL_NAME} PRIVATE
         _USE_MATH_DEFINES)
@@ -99,12 +103,13 @@ else ()
     target_compile_definitions(${LIBMANUL_NAME} PUBLIC "LIBMANUL_WITH_VULKAN=0")
 endif ()
 
-## For double-precision vector goodness
-#if (WIN32)
-#    target_compile_options(${LIBMANUL_NAME} PRIVATE "/arch:AVX2")
-#elseif (UNIX)
-#    target_compile_options(${LIBMANUL_NAME} PRIVATE "-mavx2")
-#endif ()
+if(ENABLE_AVX2)
+    if (WIN32)
+        target_compile_options(${LIBMANUL_NAME} PRIVATE "/arch:AVX2")
+    elseif (UNIX)
+        target_compile_options(${LIBMANUL_NAME} PRIVATE "-mavx2")
+    endif ()
+endif()
 
 target_sources(${LIBMANUL_NAME} INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/eu07_source/register.cpp")
 set_target_properties(nvrhi yaml-cpp fmt EnTT glfw yaml-cpp-parse yaml-cpp-read yaml-cpp-sandbox PROPERTIES FOLDER "libraries")

--- a/gl/ubo.h
+++ b/gl/ubo.h
@@ -3,8 +3,17 @@
 #include "object.h"
 #include "bindable.h"
 #include "buffer.h"
+#include <glm/glm.hpp>
 
 #define UBS_PAD(x) uint8_t PAD[x]
+
+// 12-byte vec3 for structs that must match an exact binary layout (UBOs, vertex data).
+// Stays packed regardless of GLM_FORCE_DEFAULT_ALIGNED_GENTYPES.
+// Guard prevents redefinition when stdafx.h also defines it.
+#ifndef PACKED_VEC3_DEFINED
+#define PACKED_VEC3_DEFINED
+using packed_vec3 = glm::vec<3, float, glm::packed_highp>;
+#endif
 
 namespace gl
 {
@@ -43,7 +52,7 @@ namespace gl
         glm::mat4 projection;
         glm::mat4 inv_view;
         glm::mat4 lightview[MAX_CASCADES];
-        glm::vec3 cascade_end;
+        packed_vec3 cascade_end;
         float time;
     	glm::vec4 rain_params;
     	glm::vec4 wiper_pos;
@@ -88,13 +97,13 @@ namespace gl
             HEADLIGHTS
         };
 
-        glm::vec3 pos;
+        packed_vec3 pos;
         type_e type;
 
-        glm::vec3 dir;
+        packed_vec3 dir;
         float in_cutoff;
 
-        glm::vec3 color;
+        packed_vec3 color;
         float out_cutoff;
 
         float linear;
@@ -113,10 +122,10 @@ namespace gl
 
     struct light_ubs
     {
-        glm::vec3 ambient;
+        packed_vec3 ambient;
 		UBS_PAD(4);
 
-        glm::vec3 fog_color;
+        packed_vec3 fog_color;
         uint32_t lights_count;
 
         light_element_ubs lights[MAX_LIGHTS];

--- a/rendering/opengl33renderer.cpp
+++ b/rendering/opengl33renderer.cpp
@@ -3101,7 +3101,7 @@ bool opengl33_renderer::Render_cab(TDynamicObject const *Dynamic, float const Li
             auto const luminance { Global.fLuminance * ( Dynamic->fShade > 0.0f ? Dynamic->fShade : 1.0f ) };
             if( Lightlevel > 0.f ) {
                 // crude way to light the cabin, until we have something more complete in place
-                light_ubs.ambient += ( Dynamic->InteriorLight * Lightlevel ) * std::clamp( 1.25f - (float)luminance, 0.f, 1.f );
+                light_ubs.ambient += packed_vec3( ( Dynamic->InteriorLight * Lightlevel ) * std::clamp( 1.25f - (float)luminance, 0.f, 1.f ) );
                 light_ubo->update( light_ubs );
             }
 

--- a/scene/scenenode.h
+++ b/scene/scenenode.h
@@ -48,7 +48,7 @@ operator!=( lighting_data const &Left, lighting_data const &Right ) {
 namespace scene {
 
 struct bounding_area {
-    glm::highp_dvec3 center; // mid point of the rectangle
+    glm::dvec3 center; // mid point of the rectangle
     float radius { -1.0f }; // radius of the bounding sphere
 
     bounding_area() = default;
@@ -94,7 +94,7 @@ public:
         material_handle material { null_handle };
         lighting_data lighting;
         // geometry data
-        glm::highp_dvec3 origin; // world position of the relative coordinate system origin
+        glm::dvec3 origin; // world position of the relative coordinate system origin
         gfx::geometry_handle geometry { 0, 0 }; // relative origin-centered chunk of geometry held by gfx renderer
         std::vector<world_vertex> vertices; // world space source data of the geometry
 		gfx::userdata_array userdata;

--- a/stdafx.h
+++ b/stdafx.h
@@ -94,6 +94,7 @@
 #define GLM_ENABLE_EXPERIMENTAL
 #define GLM_FORCE_CTOR_INIT
 #define GLM_FORCE_INLINE
+#define GLM_FORCE_DEFAULT_ALIGNED_GENTYPES
 #define GLM_FORCE_INTRINSICS
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
@@ -107,6 +108,12 @@
 #include <glm/gtx/norm.hpp>
 #include <glm/gtx/string_cast.hpp>
 
+#ifndef PACKED_VEC3_DEFINED
+#define PACKED_VEC3_DEFINED
+// 12-byte vec3 that stays packed regardless of GLM_FORCE_DEFAULT_ALIGNED_GENTYPES.
+// Use in structs that must match an exact binary layout (UBOs, vertex data, serialized formats).
+using packed_vec3 = glm::vec<3, float, glm::packed_highp>;
+#endif
 
 
 #include "rendering/openglmatrixstack.h"

--- a/stdafx.h
+++ b/stdafx.h
@@ -93,6 +93,8 @@
 #define GLM_FORCE_SWIZZLE
 #define GLM_ENABLE_EXPERIMENTAL
 #define GLM_FORCE_CTOR_INIT
+#define GLM_FORCE_INLINE
+#define GLM_FORCE_INTRINSICS
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtx/matrix_transform_2d.hpp>


### PR DESCRIPTION
Added 
```cpp
#define GLM_FORCE_INLINE
#define GLM_FORCE_INTRINSICS
#define GLM_FORCE_DEFAULT_ALIGNED_GENTYPES
```

So far from current master to these improvements we have
+12% for min. FPS
+3% for average FPS
+7% for max. FPS
+7% for 1% low FPS

AVX2 can be disabled using cmake flag `-DENABLE_AVX2=OFF` if someone really want to use this simulator on very old PC