### PR TITLE
widgets: time: Pass overcast to user_command::settemperature

### DIFF
--- a/widgets/time.cpp
+++ b/widgets/time.cpp
@@ -20,7 +20,7 @@ void ui::time_panel::render_contents()
 	{
         m_relay.post(user_command::setdatetime, (double)yearday, time * 60.0, 1, 0);
 		m_relay.post(user_command::setweather, fog, overcast, 1, 0);
-		m_relay.post(user_command::settemperature, temperature, 0.0, 1, 0);
+		m_relay.post(user_command::settemperature, temperature, overcast, 1, 0);
 	}
 }
 


### PR DESCRIPTION
Both setweather and settemperature expect overcast as their second parameter. Passing zero to settemperature always overwrites whatever gets passed to setweather.