### PR TITLE
Remember which modifiers were present on key press and use them on key release

### DIFF
--- a/input/keyboardinput.cpp
+++ b/input/keyboardinput.cpp
@@ -308,10 +308,20 @@ keyboard_input::key( int const Key, int const Action ) {
     }
 
     // include active modifiers for currently pressed key, except if the key is a modifier itself
-    auto const key =
+    auto key =
         Key
         | ( modifier ? 0 : ( input::key_shift ? keymodifier::shift   : 0 ) )
         | ( modifier ? 0 : ( input::key_ctrl  ? keymodifier::control : 0 ) );
+
+    if( Action == GLFW_RELEASE ) {
+        auto const stored = m_modsforkeys.find( Key );
+        if( stored != m_modsforkeys.end() ) {
+            key = stored->second;
+        }
+        m_modsforkeys.erase( Key );
+    } else {
+        m_modsforkeys[ Key ] = key;
+    }
 
     auto const lookup = m_bindings.find( key );
     if( lookup == m_bindings.end() ) {

--- a/input/keyboardinput.h
+++ b/input/keyboardinput.h
@@ -106,6 +106,7 @@ private:
 // members
     user_command m_command { user_command::none }; // last, if any, issued command
     usercommand_map m_bindings;
+    std::unordered_map<int, int> m_modsforkeys; // modifiers that were used with the active keys
     command_relay m_relay;
     bindings_cache m_bindingscache;
     glm::vec2 m_movementhorizontal { 0.f };


### PR DESCRIPTION
This fixes an issue where a triggered command stays indefinitely active when the user releases the modifier before releasing the triggering key.