### PR TITLE
skydome: Limit desaturation at the top

### DIFF
--- a/environment/skydome.cpp
+++ b/environment/skydome.cpp
@@ -295,7 +295,7 @@ void CSkyDome::RebuildColors() {
             color.y = 0.65f * color.z;
         }
         // simple gradient, darkening towards the top
-        color *= std::clamp( ( 1.0f - vertex.y ), 0.f, 1.f );
+        color *= std::clamp( ( 1.0f - vertex.y ), 0.2f, 1.f );
         //color *= ( 0.25f - vertex.y );
         // gamma correction
         color = glm::pow( color, gammacorrection );


### PR DESCRIPTION
Prevents a gray circle from forming at the dome's summit.