### PR TITLE
AgX fixups

### DIFF
--- a/environment/skydome.cpp
+++ b/environment/skydome.cpp
@@ -185,7 +185,7 @@ float CSkyDome::PerezFunctionO2( float Perezcoeffs[ 5 ], const float Icostheta, 
 void CSkyDome::RebuildColors() {
 
     float twilightfactor = std::clamp( -simulation::Environment.sun().getAngle(), 0.0f, 18.0f ) / 18.0f;
-    auto gammacorrection = glm::mix( glm::vec3( 0.45f ), glm::vec3( 1.0f ), twilightfactor );
+    auto gammacorrection = glm::mix( glm::vec3( 1.0f ), glm::vec3( 0.45f ), twilightfactor );
 
 	// get zenith luminance
 	float const chi = ( (4.0f / 9.0f) - (m_turbidity / 120.0f) ) * ( M_PI - (2.0f * m_thetasun) );
@@ -211,7 +211,7 @@ void CSkyDome::RebuildColors() {
 
 	// trough all vertices
 	glm::vec3 vertex;
-	glm::vec3 color, colorconverter, shiftedcolor;
+	glm::vec3 color, colorconverter;
 
 	for ( unsigned int i = 0; i < m_vertices.size(); ++i ) {
 		// grab it
@@ -258,9 +258,7 @@ void CSkyDome::RebuildColors() {
 			colorconverter.z = 1.0f - std::exp( -m_expfactor * colorconverter.z );  
 		}
 
-        if( colorconverter.z > 0.85f ) {
-            colorconverter.z = 0.85f + ( colorconverter.z - 0.85f ) * 0.35f;
-        }
+        colorconverter.z = std::pow( std::max( colorconverter.z, 0.0f ), gammacorrection.x );
 
         colorconverter.y = std::clamp( colorconverter.y * Global.m_skysaturationcorrection, 0.0f, 1.0f );
         // desaturate sky colour, based on overcast level
@@ -277,12 +275,10 @@ void CSkyDome::RebuildColors() {
         // this height-based factor is reduced the farther the sun is up in the sky
         float const shiftfactor = std::clamp( std::lerp(heightbasedphase, sunbasedphase, sunbasedphase), 0.0f, 1.0f );
         // h = 210 makes for 'typical' sky tone
-        shiftedcolor = glm::vec3( 210.0f, colorconverter.y, colorconverter.z );
-        shiftedcolor = colors::HSVtoRGB( shiftedcolor );
+        glm::vec3 const skytonecolor = colors::HSVtoRGB( glm::vec3( 210.0f, 0.5f, colorconverter.z ) );
 
-		color = colors::HSVtoRGB(colorconverter);
-
-        color = glm::mix( color, shiftedcolor, shiftfactor * Global.m_skyhuecorrection );
+        color = colors::HSVtoRGB( colorconverter );
+        color = glm::mix( color, skytonecolor, shiftfactor * Global.m_skyhuecorrection );
 
         // crude correction for the times where the model breaks (late night)
         // TODO: use proper night sky calculation for these times instead
@@ -295,10 +291,15 @@ void CSkyDome::RebuildColors() {
             color.y = 0.65f * color.z;
         }
         // simple gradient, darkening towards the top
-        color *= std::clamp( ( 1.0f - vertex.y ), 0.2f, 1.f );
+        color *= std::clamp( ( 1.0f - vertex.y * 0.75f ), 0.0f, 1.f );
+
+        float const horizonboost = 1.5f + m_overcast;
+        float const horizonbandwidth = 0.2f; // boost tapers to 0 by ~11.5 degrees elevation
+        float const horizonband = std::clamp( 1.0f - vertex.y / horizonbandwidth, 0.0f, 1.0f );
+
+        color *= std::lerp( 1.0, horizonboost, horizonband );
+
         //color *= ( 0.25f - vertex.y );
-        // gamma correction
-        color = glm::pow( color, gammacorrection );
         m_colours[ i ] = color;
         averagecolor += color;
         if( ( m_vertices.size() - i ) <= ( m_tesselation * 10 + 10 ) ) {

--- a/rendering/opengl33renderer.cpp
+++ b/rendering/opengl33renderer.cpp
@@ -2047,7 +2047,7 @@ bool opengl33_renderer::Render(world_environment *Environment)
 		// write cloud color into material
 		TSubModel *mdl = Environment->m_clouds.mdCloud->Root;
 		if (mdl->m_material != null_handle)
-			m_materials.material(mdl->m_material).params[0] = glm::vec4(color, 1.0f);
+			m_materials.material(mdl->m_material).params[0] = glm::vec4(color * 2.5f, 1.0f);
 
 		// render
 		Render(Environment->m_clouds.mdCloud, nullptr, 100.0);

--- a/rendering/opengl33renderer.cpp
+++ b/rendering/opengl33renderer.cpp
@@ -1875,7 +1875,7 @@ void opengl33_renderer::setup_environment_light(TEnvironmentType const Environme
 void opengl33_renderer::setup_sunlight_intensity( float const Factor ) {
 
     m_sunlight.apply_intensity( Factor );
-    light_ubs.lights[ 0 ].intensity = m_sunlight.factor;
+    light_ubs.lights[ 0 ].intensity = m_sunlight.factor * (1.0f - Global.Overcast * 0.33f);
     light_ubs.ambient = m_sunlight.ambient * m_sunlight.factor;
     light_ubo->update( light_ubs );
 }

--- a/shaders/light_common.glsl
+++ b/shaders/light_common.glsl
@@ -27,8 +27,8 @@ float metalic = 0.0;
 //                       = sharper terminator (more contrast between
 //                       lit and shaded faces of the same surface).
 // ---------------------------------------------------------------------
-const float AMBIENT_SCALE       = 0.3;
-const float SUN_DIFFUSE_SCALE   = 0.4;
+const float AMBIENT_SCALE       = 0.65;
+const float SUN_DIFFUSE_SCALE   = 1.5;
 const float SUN_NDOTL_SHARPNESS = 1.25;
 
 float length2(vec3 v)

--- a/shaders/tonemapping.glsl
+++ b/shaders/tonemapping.glsl
@@ -69,12 +69,12 @@ vec3 Agx(vec3 val)
         0.0423756549057051, 0.0784336, 0.879142973793104
     );
 
-    // DEFAULT_LOG2_MIN = -10.0
-    // DEFAULT_LOG2_MAX = +6.5
+    // DEFAULT_LOG2_MIN = -6.0
+    // DEFAULT_LOG2_MAX = +4.5
     // MIDDLE_GRAY = 0.18
     // log2(pow(2, VALUE) * MIDDLE_GRAY)
-    const float min_ev = -12.47393;
-    const float max_ev = 0.526069;
+    const float min_ev = -8.47393;
+    const float max_ev = 2.026069;
     const float agx_eps = 1e-6;
 
     // Input transform (inset)
@@ -99,10 +99,7 @@ vec3 AgxEotf(vec3 val)
     // Inverse input transform (outset)
     val = agx_mat_inv * val;
 
-    // sRGB IEC 61966-2-1 2.2 Exponent Reference EOTF Display.
-    // If your render target already applies sRGB conversion, replace this with:
-    // return max(val, vec3(0.0));
-    return pow(max(val, vec3(0.0)), vec3(2.2));
+    return max(val, vec3(0.0));
 }
 
 vec3 AgxLook(vec3 val)

--- a/shaders/tonemapping.glsl
+++ b/shaders/tonemapping.glsl
@@ -121,7 +121,7 @@ vec3 AgxLook(vec3 val)
     // Punchy
     slope = vec3(1.0);
     power = vec3(1.35);
-    sat = 1.4;
+    sat = 1.1;
 #endif
 
     // ASC CDL


### PR DESCRIPTION
We're supposed to output linear values there, as sRGB transfer function gets applied either by GL framebuffer or FBOUT later on.
    
min_ev and max_ev also need to be adjusted, as they're tweaked for a pipeline with exposure compensation. The current values lead to a very washed-out image, which was "hidden" by subsequently applying gamma twice.
It may make sense to revisit these values in the future to better match the rendering pipeline.

Also, reduce saturation boost, adjust ambient and sun diffuse scale and adjust sun intensity based on overcast. The skydome color calculation needs to be changed to work well with external tone mapping as well.