### PR TITLE
drivermode: Allow to (un)set picking mode by combining Alt with Shift/Ctrl

### DIFF
--- a/application/drivermode.cpp
+++ b/application/drivermode.cpp
@@ -496,7 +496,7 @@ void driver_mode::on_key(int const Key, int const Scancode, int const Action, in
 		if (Action == GLFW_PRESS)
 		{
 			// toggle picking mode
-			set_picking(!Global.ControlPicking);
+			set_picking(Global.shiftState ? true : (Global.ctrlState ? false : !Global.ControlPicking));
 		}
 	}
 


### PR DESCRIPTION
Pressing Alt toggles picking mode. This is fine for keyboard and mouse usage, but some use cases, such as disabling picking mode when a finger is placed on a thumbstick and enabling it back when it's lifted, require finer control. Allow to always enable picking mode when pressing Alt with Shift, and to always disable picking mode when pressing Alt with Ctrl.