### PR TITLE
refactor: extract user_config_path() helper

### DIFF
--- a/application/application.cpp
+++ b/application/application.cpp
@@ -15,6 +15,7 @@ http://mozilla.org/MPL/2.0/.
 #include "launcher/launchermode.h"
 
 #include "utilities/Globals.h"
+#include "utilities/utilities.h"
 #include "simulation/simulation.h"
 #include "simulation/simulationsounds.h"
 #include "vehicle/Train.h"
@@ -1104,19 +1105,7 @@ int eu07_application::init_settings(int Argc, char *Argv[])
 {
 	Global.asVersion = VERSION_INFO;
 
-	fs::path iniPath;
-
-#ifdef _WIN32
-	if (const char *appdata = std::getenv("APPDATA"))
-	{
-		iniPath = fs::path(appdata) / "MaSzyna" / "eu07.ini";
-	}
-#else
-	if (const char *home = std::getenv("HOME"))
-	{
-		iniPath = fs::path(home) / ".config" / "MaSzyna" / "eu07.ini";
-	}
-#endif
+	fs::path iniPath = user_config_path("eu07.ini");
 
 	if (!iniPath.empty() && fs::exists(iniPath))
 	{

--- a/editor/editorSettings.cpp
+++ b/editor/editorSettings.cpp
@@ -10,6 +10,7 @@ http://mozilla.org/MPL/2.0/.
 #include "stdafx.h"
 #include "editor/editorSettings.hpp"
 #include "utilities/Logs.h"
+#include "utilities/utilities.h"
 
 #include <cstdlib>
 #include <filesystem>
@@ -23,14 +24,8 @@ namespace fs = std::filesystem;
 
 fs::path settings_path()
 {
-#ifdef _WIN32
-	if (const char *appdata = std::getenv("APPDATA"))
-		return fs::path(appdata) / "MaSzyna" / "eu07_editor.ini";
-#else
-	if (const char *home = std::getenv("HOME"))
-		return fs::path(home) / ".config" / "MaSzyna" / "eu07_editor.ini";
-#endif
-	return fs::path("eu07_editor.ini");
+	fs::path p = user_config_path("eu07_editor.ini");
+	return p.empty() ? fs::path("eu07_editor.ini") : p;
 }
 
 const char *scheme_to_string(editorSettings::movement_scheme scheme)

--- a/input/drivermouseinput.cpp
+++ b/input/drivermouseinput.cpp
@@ -20,6 +20,7 @@ http://mozilla.org/MPL/2.0/.
 #include "rendering/renderer.h"
 #include "application/uilayer.h"
 #include "utilities/Logs.h"
+#include "utilities/utilities.h"
 
 auto const EU07_CONTROLLER_MOUSESLIDERSIZE{ 0.6 };
 
@@ -181,21 +182,9 @@ drivermouse_input::recall_bindings() {
 
     std::string filePath = "eu07_input-mouse.ini";
 
-#ifdef _WIN32
-	if (const char *appdata = std::getenv("APPDATA"))
-	{
-		fs::path appPath = fs::path(appdata) / "MaSzyna" / "eu07_input-mouse.ini";
-		if (fs::exists(appPath))
-			filePath = appPath.string();
-	}
-#else
-	if (const char *home = std::getenv("HOME"))
-	{
-		fs::path appPath = fs::path(home) / ".config" / "MaSzyna" / "eu07_input-mouse.ini";
-		if (fs::exists(appPath))
-			filePath = appPath.string();
-	}
-#endif 
+	fs::path appPath = user_config_path("eu07_input-mouse.ini");
+	if (!appPath.empty() && fs::exists(appPath))
+		filePath = appPath.string();
 
     cParser bindingparser(filePath.c_str(), cParser::buffer_FILE);
 

--- a/input/gamepadinput.cpp
+++ b/input/gamepadinput.cpp
@@ -156,21 +156,9 @@ bool
 gamepad_input::recall_bindings() {
 	std::string filePath = "eu07_input-gamepad.ini";
 
-#ifdef _WIN32
-	if (const char *appdata = std::getenv("APPDATA"))
-	{
-		fs::path appPath = fs::path(appdata) / "MaSzyna" / "eu07_input-gamepad.ini";
-		if (fs::exists(appPath))
-			filePath = appPath.string();
-	}
-#else
-	if (const char *home = std::getenv("HOME"))
-	{
-		fs::path appPath = fs::path(home) / ".config" / "MaSzyna" / "eu07_input-gamepad.ini";
-		if (fs::exists(appPath))
-			filePath = appPath.string();
-	}
-#endif
+	fs::path appPath = user_config_path("eu07_input-gamepad.ini");
+	if (!appPath.empty() && fs::exists(appPath))
+		filePath = appPath.string();
 
 	// bindingparser tworzony zawsze, z wybran� �cie�k�
 	cParser bindingparser(filePath.c_str(), cParser::buffer_FILE);

--- a/input/keyboardinput.cpp
+++ b/input/keyboardinput.cpp
@@ -12,6 +12,7 @@ http://mozilla.org/MPL/2.0/.
 #include "utilities/Globals.h"
 #include "utilities/Logs.h"
 #include "utilities/parser.h"
+#include "utilities/utilities.h"
 
 namespace input {
 
@@ -122,19 +123,8 @@ namespace fs = std::filesystem;
 bool
 keyboard_input::recall_bindings() {
 
-    fs::path iniPath;
+    fs::path iniPath = user_config_path("eu07_input-keyboard.ini");
 	std::string path = "";
-#ifdef _WIN32
-	if (const char *appdata = std::getenv("APPDATA"))
-	{
-		iniPath = fs::path(appdata) / "MaSzyna" / "eu07_input-keyboard.ini";
-	}
-#else
-	if (const char *home = std::getenv("HOME"))
-	{
-		iniPath = fs::path(home) / ".config" / "MaSzyna" / "eu07_input-keyboard.ini";
-	}
-#endif
 
 	if (!iniPath.empty() && fs::exists(iniPath))
 	{

--- a/utilities/uart.cpp
+++ b/utilities/uart.cpp
@@ -6,6 +6,7 @@
 #include "vehicle/Train.h"
 #include "utilities/parser.h"
 #include "utilities/Logs.h"
+#include "utilities/utilities.h"
 #include "simulation/simulationtime.h"
 #include "application/application.h"
 
@@ -194,21 +195,9 @@ uart_input::recall_bindings() {
     m_inputbindings.clear();
 	std::string filePath = "eu07_input-uart.ini";
 
-#ifdef _WIN32
-	if (const char *appdata = std::getenv("APPDATA"))
-	{
-		fs::path appPath = fs::path(appdata) / "MaSzyna" / "eu07_input-uart.ini";
-		if (fs::exists(appPath))
-			filePath = appPath.string();
-	}
-#else
-	if (const char *home = std::getenv("HOME"))
-	{
-		fs::path appPath = fs::path(home) / ".config" / "MaSzyna" / "eu07_input-uart.ini";
-		if (fs::exists(appPath))
-			filePath = appPath.string();
-	}
-#endif
+	fs::path appPath = user_config_path("eu07_input-uart.ini");
+	if (!appPath.empty() && fs::exists(appPath))
+		filePath = appPath.string();
 	cParser bindingparser(filePath.c_str(), cParser::buffer_FILE);
 	if (false == bindingparser.ok())
 	{

--- a/utilities/utilities.cpp
+++ b/utilities/utilities.cpp
@@ -55,6 +55,22 @@ std::string Now()
 #endif
 }
 
+std::filesystem::path user_config_path(const std::string &filename)
+{
+	namespace fs = std::filesystem;
+#if defined(_WIN32)
+	if (const char *appdata = std::getenv("APPDATA"))
+		return fs::path(appdata) / "MaSzyna" / filename;
+#elif defined(__APPLE__)
+	if (const char *home = std::getenv("HOME"))
+		return fs::path(home) / "Library" / "Application Support" / "MaSzyna" / filename;
+#else
+	if (const char *home = std::getenv("HOME"))
+		return fs::path(home) / ".config" / "MaSzyna" / filename;
+#endif
+	return {}; // env var missing → caller falls back to CWD-relative filename
+}
+
 // zwraca różnicę czasu
 // jeśli pierwsza jest aktualna, a druga rozkładowa, to ujemna oznacza opóżnienie
 // na dłuższą metę trzeba uwzględnić datę, jakby opóżnienia miały przekraczać 12h (towarowych)

--- a/utilities/utilities.h
+++ b/utilities/utilities.h
@@ -25,6 +25,10 @@ template <typename T> constexpr T sq(T v)
 	return v * v;
 }
 
+// returns the per-user config path for `filename` (platform-specific dir),
+// or an empty path if the home/appdata env var is unavailable
+std::filesystem::path user_config_path(const std::string &filename);
+
 // TODO: Shouldn't this be in globals?
 namespace paths
 {


### PR DESCRIPTION
Replaces duplicated platform-specific config-directory `#ifdef` blocks with a single `user_config_path(filename)` helper declared in `utilities/utilities.h`.

**Before:** each of the six call sites (application.cpp, editorSettings.cpp, keyboardinput.cpp, gamepadinput.cpp, drivermouseinput.cpp, uart.cpp) contained an identical `#ifdef _WIN32 / #else` block expanding `APPDATA` or `HOME`.

**After:** one function handles the platform dispatch:
- Windows → `%APPDATA%\MaSzyna\<filename>`
- macOS → `~/Library/Application Support/MaSzyna/<filename>`
- Linux → `~/.config/MaSzyna/<filename>`

No behavior change on Windows or Linux. macOS config is now stored in the canonical `~/Library/Application Support/` location instead of `~/.config/`.