### PR TITLE
drivermode: Make sure to draw the first frame before pausing

### DIFF
--- a/application/drivermode.cpp
+++ b/application/drivermode.cpp
@@ -171,7 +171,7 @@ bool driver_mode::update()
 	simulation::State.update_scripting_interface();
 	simulation::Environment.update();
 
-	if (deltatime != 0.0)
+	if (deltatime != 0.0 || false == simulation::is_ready)
 	{
 		// jak pauza, to nie ma po co tego przeliczać
 		simulation::Time.update(deltatime);


### PR DESCRIPTION
Otherwise the screen stays empty when the game is launched paused.