### PR TITLE
launcher: Open on scenery list panel

### DIFF
--- a/launcher/launcheruilayer.cpp
+++ b/launcher/launcheruilayer.cpp
@@ -12,7 +12,7 @@ launcher_ui::launcher_ui() : m_scenery_scanner(m_vehicles_bank), m_scenerylist_p
 	add_external_panel(&m_keymapper_panel);
 	add_external_panel(&m_vehiclepicker_panel);
 
-	open_panel(&m_vehiclepicker_panel);
+	open_panel(&m_scenerylist_panel);
 	m_suppress_menu = true;
 
 }


### PR DESCRIPTION
This is the panel that allow to quickly launch a selected scenario, so it makes sense to show it by default.