### PR TITLE
opengl33renderer: Don't render stars with strong fog

### DIFF
--- a/rendering/opengl33renderer.cpp
+++ b/rendering/opengl33renderer.cpp
@@ -1912,7 +1912,7 @@ bool opengl33_renderer::Render(world_environment *Environment)
     ::glBlendFunc( GL_SRC_ALPHA, GL_ONE );
 
     // stars
-	if (Environment->m_stars.m_stars != nullptr)
+	if (Environment->m_stars.m_stars != nullptr && Global.fFogEnd > 500.f)
 	{
 		// setup
 		::glPushMatrix();


### PR DESCRIPTION
Stars aren't currently affected by fog. Band-aid it and don't render them at all when fog is stronger than 500m.