### PR TITLE
stdafx: Only use GLM_FORCE_DEFAULT_ALIGNED_GENTYPES on MSVC

### DIFF
--- a/stdafx.h
+++ b/stdafx.h
@@ -98,7 +98,9 @@
 #define GLM_ENABLE_EXPERIMENTAL
 #define GLM_FORCE_CTOR_INIT
 #define GLM_FORCE_INLINE
+#ifdef _MSC_VER
 #define GLM_FORCE_DEFAULT_ALIGNED_GENTYPES
+#endif
 #define GLM_FORCE_INTRINSICS
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>


### PR DESCRIPTION
It causes the game to crash on launch while attempting to use SIMD instructions when compiled with GCC or Clang.

Since it's known to work on MSVC and was enabled due to performance improvement, leave it enabled there.