### PR TITLE
Night lighting and skydome improvements

### DIFF
--- a/environment/moon.cpp
+++ b/environment/moon.cpp
@@ -60,9 +60,7 @@ cMoon::getAngle() const {
     return (float)m_body.elevref;
 }
 	
-float cMoon::getIntensity() {
-
-	irradiance();
+float cMoon::getIntensity() const {
     // NOTE: we don't have irradiance model for the moon so we cheat here
     // calculating intensity of the sun instead, and returning 15% of the value,
     // which roughly matches how much sunlight is reflected by the moon
@@ -227,6 +225,7 @@ void cMoon::move() {
 	m_body.zenetr = std::acos( cz ) * radtodeg;
 	m_body.elevetr = 90.0 - m_body.zenetr;
 	refract();
+	irradiance();
 }
 
 void cMoon::refract() {

--- a/environment/moon.h
+++ b/environment/moon.h
@@ -18,7 +18,7 @@ public:
 	// returns current elevation above horizon
 	float getAngle() const;
 	// returns current intensity of the sun
-	float getIntensity();
+	float getIntensity() const;
     // returns current phase of the moon
     float getPhase() const { return m_phase; }
     // sets current time, overriding one acquired from the system clock

--- a/environment/skydome.cpp
+++ b/environment/skydome.cpp
@@ -9,7 +9,7 @@
 // by A. J. Preetham Peter Shirley Brian Smits (University of Utah)
 
 float CSkyDome::m_distributionluminance[ 5 ][ 2 ] = {	// Perez distributions
-		{  0.17872f , -1.66303f },		// a = darkening or brightening of the horizon
+		{  0.17872f , -1.46303f },		// a = darkening or brightening of the horizon
 		{ -0.35540f ,  0.42750f },		// b = luminance gradient near the horizon,
 		{ -0.02266f ,  5.32505f },		// c = relative intensity of the circumsolar region
 		{  0.12064f , -2.57705f },		// d = width of the circumsolar region
@@ -185,7 +185,7 @@ float CSkyDome::PerezFunctionO2( float Perezcoeffs[ 5 ], const float Icostheta, 
 void CSkyDome::RebuildColors() {
 
     float twilightfactor = std::clamp( -simulation::Environment.sun().getAngle(), 0.0f, 18.0f ) / 18.0f;
-    auto gammacorrection = glm::mix( glm::vec3( 1.0f ), glm::vec3( 0.45f ), twilightfactor );
+    auto gammacorrection = std::lerp( 1.0f, 0.6f, twilightfactor );
 
 	// get zenith luminance
 	float const chi = ( 4.0f / 9.0f - m_turbidity / 120.0f ) * ( M_PI - 2.0f * m_thetasun );
@@ -258,7 +258,7 @@ void CSkyDome::RebuildColors() {
 			colorconverter.z = 1.0f - std::exp( -m_expfactor * colorconverter.z );  
 		}
 
-        colorconverter.z = std::pow( std::max( colorconverter.z, 0.0f ), gammacorrection.x );
+        colorconverter.z = std::pow( std::max( colorconverter.z, 0.0f ), gammacorrection );
 
         colorconverter.y = std::clamp( colorconverter.y * Global.m_skysaturationcorrection, 0.0f, 1.0f );
         // desaturate sky colour, based on overcast level
@@ -275,29 +275,32 @@ void CSkyDome::RebuildColors() {
         // this height-based factor is reduced the farther the sun is up in the sky
         float const shiftfactor = std::clamp( std::lerp(heightbasedphase, sunbasedphase, sunbasedphase), 0.0f, 1.0f );
         // h = 210 makes for 'typical' sky tone
-        glm::vec3 const skytonecolor = colors::HSVtoRGB( glm::vec3( 210.0f, 0.5f, colorconverter.z ) );
+        glm::vec3 const skytonecolor = colors::HSVtoRGB( glm::vec3( 210.0f, std::max(0.5f, colorconverter.y), colorconverter.z ) );
 
         color = colors::HSVtoRGB( colorconverter );
         color = glm::mix( color, skytonecolor, shiftfactor * Global.m_skyhuecorrection );
 
+        // not correct at all, but creates quite pleasing colors so let's keep that
+        color = glm::pow ( color, glm::vec3( 2.2f ) );
+
         // crude correction for the times where the model breaks (late night)
         // TODO: use proper night sky calculation for these times instead
-        if( color.x <= 0.05f
-         && color.y <= 0.05f ) {
+        if( color.x <= 0.02f
+         && color.y <= 0.02f ) {
             // darken the sky as the sun goes deeper below the horizon
             // 15:50:75 is picture-based night sky colour. it may not be accurate but looks 'right enough'
             color.z = 0.75f * std::max( color.z + m_sundirection.y, 0.075f );
             color.x = 0.20f * color.z; 
             color.y = 0.65f * color.z;
+            color *= m_overcast;
+            color *= 1.0f + simulation::Environment.moon().getIntensity() / 0.12;
         }
         // simple gradient, darkening towards the top
         color *= std::clamp( 1.0f - vertex.y * 0.75f, 0.0f, 1.f );
 
-        float const horizonboost = 1.5f + m_overcast;
         float const horizonbandwidth = 0.2f; // boost tapers to 0 by ~11.5 degrees elevation
         float const horizonband = std::clamp( 1.0f - vertex.y / horizonbandwidth, 0.0f, 1.0f );
-
-        color *= std::lerp( 1.0, horizonboost, horizonband );
+        color *= glm::vec3( std::lerp( 1.0, 2.0, horizonband ) );
 
         //color *= ( 0.25f - vertex.y );
         m_colours[ i ] = color;

--- a/environment/sun.cpp
+++ b/environment/sun.cpp
@@ -70,9 +70,7 @@ cSun::getHourAngle() const {
     return m_body.hrang;
 }
 
-float cSun::getIntensity() {
-
-	irradiance();
+float cSun::getIntensity() const {
 	return (float)( m_body.etr/ 1399.0 );	// arbitrary scaling factor taken from etrn value
 }
 
@@ -201,6 +199,7 @@ void cSun::move() {
     m_body.zenetr = std::acos( cz ) * radtodeg;
     m_body.elevetr = 90.0 - m_body.zenetr;
     refract();
+    irradiance();
 }
 
 void cSun::refract() {

--- a/environment/sun.h
+++ b/environment/sun.h
@@ -26,7 +26,7 @@ public:
     // return current hour angle
     double getHourAngle() const;
     // returns current intensity of the sun
-	float getIntensity();
+	float getIntensity() const;
     // sets current time, overriding one acquired from the system clock
     void setTime( int const Hour, int const Minute, int const Second );
 	// sets current geographic location

--- a/rendering/opengl33renderer.cpp
+++ b/rendering/opengl33renderer.cpp
@@ -2041,12 +2041,12 @@ bool opengl33_renderer::Render(world_environment *Environment)
 			    ( glm::vec3 { Global.DayLight.ambient }
                 + 0.35f * glm::vec3{ Global.DayLight.diffuse } ) * simulation::Environment.light_intensity()
                 * 0.5f,
-			    glm::vec3{ 0.f }, glm::vec3{ 1.f } ) };
+			    glm::vec3{ 0.f }, glm::vec3{ 1.f } ) * (2.5f + duskfactor)};
 
 		// write cloud color into material
 		TSubModel *mdl = Environment->m_clouds.mdCloud->Root;
 		if (mdl->m_material != null_handle)
-			m_materials.material(mdl->m_material).params[0] = glm::vec4(color * 2.5f, 1.0f);
+			m_materials.material(mdl->m_material).params[0] = glm::vec4(color, 1.0f);
 
 		// render
 		Render(Environment->m_clouds.mdCloud, nullptr, 100.0);

--- a/rendering/opengl33renderer.cpp
+++ b/rendering/opengl33renderer.cpp
@@ -1942,12 +1942,12 @@ bool opengl33_renderer::Render(world_environment *Environment)
 		glm::vec4 color(suncolor.x, suncolor.y, suncolor.z, std::clamp(1.5f - Global.Overcast, 0.f, 1.f) * fogfactor);
 		auto const sunvector = Environment->m_sun.getDirection();
 
-        /*float const size = std::lerp( // TODO: expose distance/scale factor from the moon object
-            0.0325f,
+        float const size = std::lerp( // TODO: expose distance/scale factor from the moon object
+            0.0650f,
             0.0275f,
-            std::clamp( Environment->m_sun.getAngle(), 0.f, 90.f ) / 90.f );*/
+            std::clamp( Environment->m_sun.getAngle(), 0.f, 90.f ) / 90.f );
 		model_ubs.param[0] = color;
-        model_ubs.param[1] = glm::vec4(glm::vec3(modelview * glm::vec4(sunvector, 1.0f)), 0.00463f /* size */);
+        model_ubs.param[1] = glm::vec4(glm::vec3(modelview * glm::vec4(sunvector, 1.0f)), size);
 		model_ubs.param[2] = glm::vec4(0.0f, 1.0f, 1.0f, 0.0f);
 		model_ubo->update(model_ubs);
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
@@ -2018,14 +2018,13 @@ bool opengl33_renderer::Render(world_environment *Environment)
 			moonu = 0.0f;
 		}
 
-        /*
         float const size = std::lerp( // TODO: expose distance/scale factor from the moon object
-            0.0160f,
+            0.0270f,
             0.0135f,
-            std::clamp( Environment->m_moon.getAngle(), 0.f, 90.f ) / 90.f );*/
+            std::clamp( Environment->m_moon.getAngle(), 0.f, 90.f ) / 90.f );
 
 		model_ubs.param[0] = color;
-        model_ubs.param[1] = glm::vec4(glm::vec3(modelview * glm::vec4(moonvector, 1.0f)), 0.00451f /* size */);
+        model_ubs.param[1] = glm::vec4(glm::vec3(modelview * glm::vec4(moonvector, 1.0f)), size);
 		model_ubs.param[2] = glm::vec4(moonu, moonv, 0.333f, 0.0f);
 		model_ubo->update(model_ubs);
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);

--- a/rendering/opengl33renderer.cpp
+++ b/rendering/opengl33renderer.cpp
@@ -3777,7 +3777,7 @@ void opengl33_renderer::Render(TSubModel *Submodel)
 			case rendermode::color:
 			case rendermode::reflections:
 			{
-				if (Global.fLuminance < Submodel->fLight)
+				if (Global.fLuminance < Submodel->fLight * 1.5f)
 				{
 					Bind_Material(Submodel->m_material, Submodel);
 

--- a/shaders/celestial.frag
+++ b/shaders/celestial.frag
@@ -13,7 +13,7 @@ layout(location = 1) out vec4 out_motion;
 
 void main()
 {
-	vec4 tex_color = texture(tex1, f_coord);
+	vec4 tex_color = texture(tex1, f_coord) * 2.0f;
 #if POSTFX_ENABLED
 	out_color = tex_color * param[0];
 #else

--- a/shaders/color.frag
+++ b/shaders/color.frag
@@ -12,7 +12,7 @@ layout(location = 1) out vec4 out_motion;
 
 void main()
 {
-	vec3 col = clamp(pow(f_color.rgb, vec3(2.2)),0, 1);
+	vec3 col = f_color.rgb;
 #if POSTFX_ENABLED
 	out_color = vec4(apply_fog(col), 1.0f);
 #else

--- a/shaders/mat_stars.frag
+++ b/shaders/mat_stars.frag
@@ -17,7 +17,7 @@ void main()
 		discard;
 
 	// color data space is shared with normals, ugh
-	vec4 color = vec4(pow(f_normal_raw.rgb, vec3(2.2)), 1.0f);
+	vec4 color = vec4(f_normal_raw.rgb, 1.0f);
 #if POSTFX_ENABLED
     out_color = color;
 #else

--- a/simulation/simulationenvironment.cpp
+++ b/simulation/simulationenvironment.cpp
@@ -185,9 +185,7 @@ world_environment::update() {
 
     // update the fog. setting it to match the average colour of the sky dome is cheap
     // but quite effective way to make the distant items blend with background better
-    Global.FogColor = m_skydome.GetAverageHorizonColor() * keylightcolor *
-	                  std::clamp((float)Global.fLuminance, 0.f, 1.f);
-	
+    Global.FogColor = glm::mix ( m_skydome.GetAverageHorizonColor(), glm::vec3 (1.0f), moonlightlevel * 0.1f);
 
     // weather-related simulation factors
     Global.FrictionWeatherFactor = Global.Weather == "rain:" ? 0.85f : Global.Weather == "snow:" ? 0.75f : 1.0f;

--- a/simulation/simulationenvironment.cpp
+++ b/simulation/simulationenvironment.cpp
@@ -115,7 +115,7 @@ world_environment::update() {
     float twilightfactor = std::clamp( -m_sun.getAngle(), 0.0f, 18.0f ) / 18.0f;
     // NOTE: sun light receives extra padding to prevent moon from kicking in too soon
     auto const sunlightlevel = m_sun.getIntensity() + 0.05f * ( 1.f - twilightfactor );
-    auto const moonlightlevel = m_moon.getIntensity() * 0.65f; // scaled down by arbitrary factor, it's pretty bright otherwise
+    auto const moonlightlevel = m_moon.getIntensity() * 1.5f * (1.0f - 0.5f * std::clamp( Global.Overcast, 0.0f, 1.0f ));
 
     // ...update skydome to match the current sun position as well...
     // twilight factor can be reset later down, so we do it here while it's still reflecting state of the sun

--- a/simulation/simulationenvironment.cpp
+++ b/simulation/simulationenvironment.cpp
@@ -69,15 +69,15 @@ world_environment::compute_weather() {
 	                 Global.AirTemperature > 1 ? "rain:" :
 	                                             "snow:";
 
-    Global.fTurbidity = Global.Overcast <= 0.10 ? 3 :
+    Global.fTurbidity = Global.Overcast <= 0.10 ? 4 :
 	                    Global.Overcast <= 0.20 ? 4 :
 	                    Global.Overcast <= 0.30 ? 5 :
 	                    Global.Overcast <= 0.40 ? 5 :
-	                    Global.Overcast <= 0.50 ? 5 :
-	                    Global.Overcast <= 0.60 ? 5 :
-	                    Global.Overcast <= 0.70 ? 6 :
-	                    Global.Overcast <= 0.80 ? 7 :
-	                    Global.Overcast <= 0.90 ? 8 :
+	                    Global.Overcast <= 0.50 ? 6 :
+	                    Global.Overcast <= 0.60 ? 6 :
+	                    Global.Overcast <= 0.70 ? 7 :
+	                    Global.Overcast <= 0.80 ? 8 :
+	                    Global.Overcast <= 0.90 ? 9 :
 	                    Global.Overcast > 0.90  ? 9 :
 	                                              9;
 }

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -342,7 +342,7 @@ struct global_settings {
 
 	std::unordered_map<int, std::string> trainset_overrides;
 
-    float m_skysaturationcorrection{ 1.65f };
+    float m_skysaturationcorrection{ 1.25f };
     float m_skyhuecorrection{ 0.5f };
 
 	// methods

--- a/utilities/color.h
+++ b/utilities/color.h
@@ -15,9 +15,9 @@ glm::vec3
 XYZtoRGB( glm::vec3 const &XYZ ) {
 
     // M^-1 for Adobe RGB from http://www.brucelindbloom.com/Eqn_RGB_XYZ_Matrix.html
-    float const mi[ 3 ][ 3 ] = { 2.041369f, -0.969266f, 0.0134474f, -0.5649464f, 1.8760108f, -0.1183897f, -0.3446944f, 0.041556f, 1.0154096f };
+//    float const mi[ 3 ][ 3 ] = { 2.041369f, -0.969266f, 0.0134474f, -0.5649464f, 1.8760108f, -0.1183897f, -0.3446944f, 0.041556f, 1.0154096f };
     // m^-1 for sRGB:
-//    float const mi[ 3 ][ 3 ] = { 3.240479f, -0.969256f, 0.055648f, -1.53715f, 1.875991f, -0.204043f, -0.49853f, 0.041556f, 1.057311f };
+    float const mi[ 3 ][ 3 ] = { 3.240479f, -0.969256f, 0.055648f, -1.53715f, 1.875991f, -0.204043f, -0.49853f, 0.041556f, 1.057311f };
 
     return glm::vec3{
         XYZ.x*mi[ 0 ][ 0 ] + XYZ.y*mi[ 1 ][ 0 ] + XYZ.z*mi[ 2 ][ 0 ],


### PR DESCRIPTION
The goal was to allow for varying night conditions. In the reality, direct moonlight can be pretty bright and the sky gets lighter when it's cloudy.

Still needs some cleaning up and small improvements (the sky should get darker again with heavy precipitation, and legacy renderer adjusted for skydome colors now being in linear colorspace), so posting as a draft.