### PR TITLE
uilayer: Implement ui.bg.opacity setting

### DIFF
--- a/application/uilayer.cpp
+++ b/application/uilayer.cpp
@@ -141,7 +141,7 @@ void ui_layer::imgui_style()
 
 	colors[ImGuiCol_Text] = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
 	colors[ImGuiCol_TextDisabled] = ImVec4(0.35f, 0.35f, 0.35f, 1.00f);
-	colors[ImGuiCol_WindowBg] = ImVec4(0.04f, 0.04f, 0.04f, 0.94f);
+	colors[ImGuiCol_WindowBg] = ImVec4(0.04f, 0.04f, 0.04f, Global.UIBgOpacity); // ui.bg.opacity from config file
 	colors[ImGuiCol_ChildBg] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
 	colors[ImGuiCol_PopupBg] = ImVec4(0.06f, 0.06f, 0.06f, 0.94f);
 	colors[ImGuiCol_Border] = ImVec4(0.31f, 0.34f, 0.31f, 0.50f);

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -123,7 +123,7 @@ struct global_settings {
     int PythonScreenUpdateRate{ 200 }; // delay between python-based screen updates, in milliseconds
     int iTextMode{ 0 }; // tryb pracy wyświetlacza tekstowego
     glm::vec4 UITextColor{ glm::vec4( 225.f / 255.f, 225.f / 255.f, 225.f / 255.f, 1.f ) }; // base color of UI text
-    float UIBgOpacity{ 0.65f }; // opacity of ui windows
+    float UIBgOpacity{ 0.94f }; // opacity of ui windows
     std::string asLang{ "pl" }; // domyślny język - http://tools.ietf.org/html/bcp47
     // gfx
     glm::ivec2 window_size; // main window size in platform-specific virtual pixels

--- a/widgets/map.cpp
+++ b/widgets/map.cpp
@@ -299,7 +299,23 @@ void ui::map_panel::render_contents()
 
 	ImVec2 window_origin = ImGui::GetCursorPos();
 	ImVec2 screen_origin = ImGui::GetCursorScreenPos();
-	ImGui::ImageButton((ImTextureID)(intptr_t)(m_tex->id), surface_size_im, ImVec2(0, surface_size.y / fb_size), ImVec2(surface_size.x / fb_size, 0), 0);
+
+	// Specify alpha for the map image tint so the map window
+	// honors the ui.bg.opacity setting like other windows.
+	// Make the button frame fully transparent so ImageButton's
+	// ImGuiCol_Button background (green and opaque on hover) doesn't
+	// show behind the tinted image.
+	ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+	ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+	ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+	ImGui::ImageButton((ImTextureID)(intptr_t)(m_tex->id),
+					   surface_size_im,
+					   ImVec2(0, surface_size.y / fb_size),
+					   ImVec2(surface_size.x / fb_size, 0),
+					   0,
+					   ImVec4(0.0f, 0.0f, 0.0f, 0.0f),
+					   ImVec4(1.0f, 1.0f, 1.0f, Global.UIBgOpacity));
+	ImGui::PopStyleColor(3);
 
 	if (ImGui::IsItemHovered())
 	{


### PR DESCRIPTION
This setting was already available in the config file but it did not do anything. Hook it up to the window background opacity in uilayer.cpp.

The map window required some special handling, see comments in map.cpp.

Also, change the default opacity from (unused until now) 0.65f to 0.94f to match the previously hardcoded value (so no change in the default behavior).