### PR TITLE
state_manager: Optimize computation of pressure flow for Oerlikon ESt valves

### DIFF
--- a/McZapkie/Oerlikon_ESt.cpp
+++ b/McZapkie/Oerlikon_ESt.cpp
@@ -471,12 +471,14 @@ void TNESt3::SetSize( int const size, std::string const &params ) // ustawianie 
     else
     {
         Podskok = -1.0;
-        Przekladniki[1] = PrzekRapid = std::make_shared<TRapid>();
+        PrzekRapid = std::make_shared<TRapid>();
+        Przekladniki[1] = PrzekRapid;
 
         if (contains( params,"-ED") )
         {
             PrzekRapid->SetRapidParams(2, 18);
-            Przekladniki[3] = PrzekED = std::make_shared<TPrzekED>();
+            PrzekED = std::make_shared<TPrzekED>();
+            Przekladniki[3] = PrzekED;
         }
         else
         {
@@ -484,14 +486,21 @@ void TNESt3::SetSize( int const size, std::string const &params ) // ustawianie 
                 PrzekRapid->SetRapidParams(2, 16);
             else
                 PrzekRapid->SetRapidParams(2, 0);
-            Przekladniki[3] = PrzekPoslizg = std::make_shared<TPrzeciwposlizg>();
+            PrzekPoslizg = std::make_shared<TPrzeciwposlizg>();
+            Przekladniki[3] = PrzekPoslizg;
         }
     }
 
     if (contains(params,"AL2") )
-        Przekladniki[2] = PrzekCiagly = std::make_shared<TPrzekCiagly>();
+    {
+        PrzekCiagly = std::make_shared<TPrzekCiagly>();
+        Przekladniki[2] = PrzekCiagly;
+    }
     else if (contains(params,"PZZ") )
-        Przekladniki[2] = PrzekPZZ = std::make_shared<TPrzek_PZZ>();
+    {
+        PrzekPZZ = std::make_shared<TPrzek_PZZ>();
+        Przekladniki[2] = PrzekPZZ;
+    }
     else
         Przekladniki[2] = std::make_shared<TRura>();
 

--- a/McZapkie/Oerlikon_ESt.cpp
+++ b/McZapkie/Oerlikon_ESt.cpp
@@ -237,26 +237,24 @@ double TNESt3::GetPF( double const PP, double const dt, double const Vel ) // pr
     BrakeRes->Flow(dV);
 
     for (int i = 1; i < 4; ++i)
-    {
         Przekladniki[i]->Update(dt);
-        if (typeid(*Przekladniki[i]) == typeid(TRapid))
-        {
-            RapidStatus = (BrakeDelayFlag & bdelay_R) == bdelay_R && (std::abs(Vel) > 70.0 || (std::abs(Vel) > 50.0 && RapidStatus) || RapidStaly);
-            Przekladniki[i]->SetRapidStatus(RapidStatus);
-        }
-        else if( typeid( *Przekladniki[i] ) == typeid( TPrzeciwposlizg ) )
-            Przekladniki[i]->SetPoslizg((BrakeStatus & b_asb) == b_asb);
-        else if( typeid( *Przekladniki[ i ] ) == typeid( TPrzekED ) ) {
-            if( Vel < -15.0 )
-                Przekladniki[ i ]->SetP( 0.0 );
-            else
-                Przekladniki[ i ]->SetP( MaxBP * 3.0 );
-        }
-        else if( typeid( *Przekladniki[i] ) == typeid( TPrzekCiagly ) )
-            Przekladniki[i]->SetMult(LoadC);
-        else if( typeid( *Przekladniki[i] ) == typeid( TPrzek_PZZ ) )
-            Przekladniki[i]->SetLBP(LBP);
+
+    if( PrzekRapid != nullptr ) {
+        RapidStatus = (BrakeDelayFlag & bdelay_R) == bdelay_R && (std::abs(Vel) > 70.0 || (std::abs(Vel) > 50.0 && RapidStatus) || RapidStaly);
+        PrzekRapid->SetRapidStatus(RapidStatus);
     }
+    if( PrzekPoslizg != nullptr )
+        PrzekPoslizg->SetPoslizg((BrakeStatus & b_asb) == b_asb);
+    if( PrzekED != nullptr ) {
+        if( Vel < -15.0 )
+            PrzekED->SetP( 0.0 );
+        else
+            PrzekED->SetP( MaxBP * 3.0 );
+    }
+    if( PrzekCiagly != nullptr )
+        PrzekCiagly->SetMult(LoadC);
+    if( PrzekPZZ != nullptr )
+        PrzekPZZ->SetLBP(LBP);
 
     // przeplyw testowy miedzypojemnosci
     dV = PF(MPP, VVP, BVs(BCP)) + PF(MPP, CVP, CVs(BCP));
@@ -458,6 +456,12 @@ void TNESt3::SetSize( int const size, std::string const &params ) // ustawianie 
     static double const dOO1l = 0.907;
     static double const dOT1l = 0.524;
 
+    PrzekRapid.reset();
+    PrzekPoslizg.reset();
+    PrzekED.reset();
+    PrzekCiagly.reset();
+    PrzekPZZ.reset();
+
     if (contains( params, "ESt3" ) )
     {
         Podskok = 0.7;
@@ -467,23 +471,27 @@ void TNESt3::SetSize( int const size, std::string const &params ) // ustawianie 
     else
     {
         Podskok = -1.0;
-        Przekladniki[1] = std::make_shared<TRapid>();
-        if (contains( params, "-s216" ) )
-            Przekladniki[1]->SetRapidParams(2, 16);
-        else
-            Przekladniki[1]->SetRapidParams(2, 0);
-        Przekladniki[3] = std::make_shared<TPrzeciwposlizg>();
+        Przekladniki[1] = PrzekRapid = std::make_shared<TRapid>();
+
         if (contains( params,"-ED") )
         {
-            Przekladniki[1]->SetRapidParams(2, 18);
-            Przekladniki[3] = std::make_shared<TPrzekED>();
+            PrzekRapid->SetRapidParams(2, 18);
+            Przekladniki[3] = PrzekED = std::make_shared<TPrzekED>();
+        }
+        else
+        {
+            if (contains( params, "-s216" ) )
+                PrzekRapid->SetRapidParams(2, 16);
+            else
+                PrzekRapid->SetRapidParams(2, 0);
+            Przekladniki[3] = PrzekPoslizg = std::make_shared<TPrzeciwposlizg>();
         }
     }
 
     if (contains(params,"AL2") )
-        Przekladniki[2] = std::make_shared<TPrzekCiagly>();
+        Przekladniki[2] = PrzekCiagly = std::make_shared<TPrzekCiagly>();
     else if (contains(params,"PZZ") )
-        Przekladniki[2] = std::make_shared<TPrzek_PZZ>();
+        Przekladniki[2] = PrzekPZZ = std::make_shared<TPrzek_PZZ>();
     else
         Przekladniki[2] = std::make_shared<TRura>();
 

--- a/McZapkie/Oerlikon_ESt.h
+++ b/McZapkie/Oerlikon_ESt.h
@@ -76,12 +76,6 @@ class TPrzekladnik : public TReservoir // przekladnik (powtarzacz)
 
 	TPrzekladnik() : TReservoir() {};
     virtual void Update(double dt);
-	virtual void SetPoslizg(bool flag) {};
-	virtual void SetP(double P) {};
-	virtual void SetMult(double m) {};
-	virtual void SetLBP(double P) {};
-	virtual void SetRapidParams(double mult, double size) {};
-	virtual void SetRapidStatus(bool rs) {};
 };
 
 class TRura : public TPrzekladnik // nieprzekladnik, rura laczaca
@@ -185,7 +179,13 @@ class TNESt3 : public TBrake {
   private:
 	std::shared_ptr<TReservoir> CntrlRes; // zbiornik sterujacy
 	std::shared_ptr<TReservoir> Miedzypoj; // pojemnosc posrednia (urojona) do napelniania ZP i ZS
-	std::shared_ptr<TPrzekladnik> Przekladniki[ 4 ];
+	std::shared_ptr<TPrzekladnik> Przekladniki[ 4 ]; // indeksowane od 1, indeks jest zarazem pojemnoscia
+	// bezposrednie wskazniki do przekladnikow dostrajanych w GetPF, inicjowane przy tworzeniu
+	std::shared_ptr<TRapid> PrzekRapid;
+	std::shared_ptr<TPrzeciwposlizg> PrzekPoslizg;
+	std::shared_ptr<TPrzekED> PrzekED;
+	std::shared_ptr<TPrzekCiagly> PrzekCiagly;
+	std::shared_ptr<TPrzek_PZZ> PrzekPZZ;
 	double Nozzles[ dMAX ]; // dysze
     double BVM = 0.0; // przelozenie PG-CH
     //        ValveFlag: byte;           //polozenie roznych zaworkow

--- a/McZapkie/Oerlikon_ESt.h
+++ b/McZapkie/Oerlikon_ESt.h
@@ -17,6 +17,7 @@ http://mozilla.org/MPL/2.0/.
     Copyright (C) 2007-2014 Maciej Cierniak
 */
 
+#include <array>
 #include <memory>
 #include "hamulce.h" // Pascal unit
 #include "friction.h" // Pascal unit
@@ -179,7 +180,7 @@ class TNESt3 : public TBrake {
   private:
 	std::shared_ptr<TReservoir> CntrlRes; // zbiornik sterujacy
 	std::shared_ptr<TReservoir> Miedzypoj; // pojemnosc posrednia (urojona) do napelniania ZP i ZS
-	std::shared_ptr<TPrzekladnik> Przekladniki[ 4 ]; // indeksowane od 1, indeks jest zarazem pojemnoscia
+	std::array<std::shared_ptr<TPrzekladnik>, 4> Przekladniki; // indeksowane od 1, indeks jest zarazem pojemnoscia
 	// bezposrednie wskazniki do przekladnikow dostrajanych w GetPF, inicjowane przy tworzeniu
 	std::shared_ptr<TRapid> PrzekRapid;
 	std::shared_ptr<TPrzeciwposlizg> PrzekPoslizg;


### PR DESCRIPTION
TNESt3::GetPF() is a *major* hotspot in simulation state update. The leading cause is the use of typeid (RTTI) which is implemented in the C++ runtime essentially as a string compare. This change eliminates the use of typeid and instead caches statically typed pointers for the few TPrzekladnik subclass objects that need their parameters adjusted in TNESt3::GetPF(). As a bonus some virtual methods on TPrzekladnik can now be removed. Overall this change reduces the TNESt3::GetPF() contribution from about 25% to 16%.