### PR TITLE
Disable GLM_FORCE_DEFAULT_ALIGNED_GENTYPES to fix graphics corruption

### DIFF
--- a/betterRenderer/CMakeLists.txt
+++ b/betterRenderer/CMakeLists.txt
@@ -71,7 +71,6 @@ target_compile_definitions(${LIBMANUL_NAME} PRIVATE
         GLM_FORCE_SWIZZLE
         GLM_FORCE_CTOR_INIT
         GLM_FORCE_INLINE
-        GLM_FORCE_DEFAULT_ALIGNED_GENTYPES
         GLM_FORCE_INTRINSICS)
 
 target_compile_definitions(${LIBMANUL_NAME} PRIVATE

--- a/stdafx.h
+++ b/stdafx.h
@@ -99,7 +99,6 @@
 #define GLM_FORCE_CTOR_INIT
 #ifdef _MSC_VER
 #define GLM_FORCE_INLINE
-#define GLM_FORCE_DEFAULT_ALIGNED_GENTYPES
 #endif
 #define GLM_FORCE_INTRINSICS
 #include <glm/glm.hpp>


### PR DESCRIPTION
This is a regression introduced in 7525b54f (merged via df5a8a89). `GLM_FORCE_DEFAULT_ALIGNED_GENTYPES` causes visible screen corruption, particularly in the smoke from chimneys or vehicles.

You can see the corruption in these screenshots:
<img width="800" height="800" alt="smoke-good" src="https://github.com/user-attachments/assets/fbacffdc-beb2-492a-81ca-7aa1ce8421dd" />
<img width="800" height="800" alt="smoke-bad" src="https://github.com/user-attachments/assets/a5acb659-b487-4d68-a220-d23e3396192d" />

I don't know how to fix it for real but for now disabling `GLM_FORCE_DEFAULT_ALIGNED_GENTYPES` works around this bug. Note that it is already disabled on Linux to workaround a different issue, see PR #136. But it seems that it doesn't work on Windows either.

Since this is not a game breaking bug, I guess if we want to keep it enabled on master for debugging that is an option too. But I think it should be fixed or disabled before release.