### PR TITLE
Trainset spawning, various Lua scripting changes

### DIFF
--- a/scripting/lua.cpp
+++ b/scripting/lua.cpp
@@ -30,6 +30,7 @@ lua::lua()
 		{"isolated_isoccupied_n", scriptapi_isolated_isoccupied_n},
 		{"train_getname", scriptapi_train_getname},
 		{"dynobj_putvalues", scriptapi_dynobj_putvalues},
+		{"spawn_trainset", scriptapi_spawn_trainset},
 		{"memcell_find", scriptapi_memcell_find},
 		{"memcell_read", scriptapi_memcell_read},
 		{"memcell_read_n", scriptapi_memcell_read_n},
@@ -293,6 +294,13 @@ int lua::scriptapi_dynobj_putvalues(lua_State *L)
 		dyn->Mechanik->PutCommand(str, num1, num2, loc);
 	else
 		dyn->MoverParameters->PutCommand(str, num1, num2, loc);
+	return 0;
+}
+
+int lua::scriptapi_spawn_trainset(lua_State *L)
+{
+	std::string trainset = lua_tostring(L, 1);
+	simulation::State.create_trainset(trainset);
 	return 0;
 }
 

--- a/scripting/lua.cpp
+++ b/scripting/lua.cpp
@@ -64,7 +64,7 @@ void lua::interpret(const std::string& file) const
 
 int lua::atpanic(lua_State *s)
 {
-	std::string err = lua_tostring(s, 1);
+	std::string err = lua_tostring(s, -1);
 	ErrorLog("lua: Runtime error: " + err, logtype::lua);
     return 0;
 }

--- a/scripting/lua.cpp
+++ b/scripting/lua.cpp
@@ -64,7 +64,7 @@ void lua::interpret(const std::string& file) const
 
 int lua::atpanic(lua_State *s)
 {
-	std::string err = lua_tostring(s, -1);
+	std::string err = lua_tostring(s, 1);
 	ErrorLog("lua: Runtime error: " + err, logtype::lua);
     return 0;
 }

--- a/scripting/lua.h
+++ b/scripting/lua.h
@@ -46,6 +46,4 @@ public:
 	static void dispatch_event(lua_State *L, int handler, basic_event *event, const TDynamicObject *activator);
 	static void push_memcell_values(lua_State *L, const TMemCell *mc);
 	static memcell_values get_memcell_values(lua_State *L, int idx);
-
-	struct memcell_values { const char *str; double num1; double num2; };
 };

--- a/scripting/lua.h
+++ b/scripting/lua.h
@@ -46,4 +46,6 @@ public:
 	static void dispatch_event(lua_State *L, int handler, basic_event *event, const TDynamicObject *activator);
 	static void push_memcell_values(lua_State *L, const TMemCell *mc);
 	static memcell_values get_memcell_values(lua_State *L, int idx);
+
+	struct memcell_values { const char *str; double num1; double num2; };
 };

--- a/scripting/lua.h
+++ b/scripting/lua.h
@@ -27,6 +27,7 @@ class lua
 	static int scriptapi_isolated_isoccupied_n(lua_State *L);
 	static int scriptapi_train_getname(lua_State *L);
 	static int scriptapi_dynobj_putvalues(lua_State *L);
+	static int scriptapi_spawn_trainset(lua_State *L);
 	static int scriptapi_memcell_find(lua_State *L);
 	static int scriptapi_memcell_read(lua_State *L);
 	static int scriptapi_memcell_read_n(lua_State *L);

--- a/simulation/simulation.cpp
+++ b/simulation/simulation.cpp
@@ -492,6 +492,10 @@ TEventLauncher * state_manager::create_eventlauncher(const std::string &src, con
 	return m_serializer.create_eventlauncher(src, name, position);
 }
 
+void state_manager::create_trainset(const std::string &src) {
+	return m_serializer.create_trainset(src);
+}
+
 void state_manager::delete_model(TAnimModel *model) {
 	Region->erase(model);
 	Instances.purge(model);

--- a/simulation/simulation.h
+++ b/simulation/simulation.h
@@ -43,6 +43,8 @@ public:
 	// create eventlauncher from node string
 	TEventLauncher *
 	    create_eventlauncher(const std::string &src, const std::string &name, const glm::dvec3 &position);
+	// create trainset from trainset string
+	void create_trainset(const std::string &src);
 	// delete TAnimModel instance
 	void
 	    delete_model(TAnimModel *model);

--- a/simulation/simulationstateserializer.cpp
+++ b/simulation/simulationstateserializer.cpp
@@ -31,21 +31,8 @@ http://mozilla.org/MPL/2.0/.
 
 namespace simulation {
 
-std::shared_ptr<deserializer_state>
-state_serializer::deserialize_begin( std::string const &Scenariofile ) {
-
-    crashreport_add_info("scenario", Scenariofile);
-
-    // drop any streamed editor terrain from a previously loaded scenery before the old region (and
-    // its sections, which those chunks referenced) is destroyed below
-    EditorTerrain.reset();
-
-    // TODO: move initialization to separate routine so we can reuse it
-    SafeDelete( Region );
-    Region = new scene::basic_region();
-
-    simulation::State.init_scripting_interface();
-
+std::shared_ptr<deserializer_state> state_serializer::make_deserializer_state(std::string const &Scenariofile)
+{
 	// NOTE: for the time being import from text format is a given, since we don't have full binary serialization
 	std::shared_ptr<deserializer_state> state =
 	        std::make_shared<deserializer_state>(Scenariofile, cParser::buffer_FILE, Global.asCurrentSceneryPath, Global.bLoadTraction);
@@ -53,26 +40,18 @@ state_serializer::deserialize_begin( std::string const &Scenariofile ) {
     // TODO: check first for presence of serialized binary files
     // if this fails, fall back on the legacy text format
 	state->scratchpad.name = Scenariofile;
-    if( true == Global.file_binary_terrain
-     && Scenariofile != "$.scn" ) {
+    if (Global.file_binary_terrain && Scenariofile != "$.scn") {
         // compilation to binary file isn't supported for rainsted-created overrides
         // NOTE: we postpone actual loading of the scene until we process time, season and weather data
-		state->scratchpad.binary.terrain = Region->is_scene( Scenariofile ) ;
+		state->scratchpad.binary.terrain = Region->is_scene(Scenariofile);
     }
 
-	if (false != state->scratchpad.binary.terrain)
-	{
-		Global.file_binary_terrain_state = true;
+	if (state->scratchpad.binary.terrain)
 		WriteLog("Default SBT present");
-    }
 	else
-	{
-		Global.file_binary_terrain_state = false;
 		WriteLog("Default SBT absent");
-    }
-    scene::Groups.create();
 
-	if( false == state->input.ok() )
+	if( !state->input.ok() )
 		throw invalid_scenery_exception();
 
 	// prepare deserialization function table
@@ -112,6 +91,30 @@ state_serializer::deserialize_begin( std::string const &Scenariofile ) {
 	for( auto &function : functionlist ) {
 		state->functionmap.emplace( function.first, std::bind( function.second, this, std::ref( state->input ), std::ref( state->scratchpad ) ) );
 	}
+
+	return state;
+}
+
+std::shared_ptr<deserializer_state>
+state_serializer::deserialize_begin( std::string const &Scenariofile ) {
+
+    crashreport_add_info("scenario", Scenariofile);
+
+    // drop any streamed editor terrain from a previously loaded scenery before the old region (and
+    // its sections, which those chunks referenced) is destroyed below
+    EditorTerrain.reset();
+
+    // TODO: move initialization to separate routine so we can reuse it
+    SafeDelete( Region );
+    Region = new scene::basic_region();
+
+    State.init_scripting_interface();
+
+	// NOTE: for the time being import from text format is a given, since we don't have full binary serialization
+	std::shared_ptr<deserializer_state> state = make_deserializer_state(Scenariofile);
+
+	Global.file_binary_terrain_state = state->scratchpad.binary.terrain;
+    scene::Groups.create();
 
     if (!Global.prepend_scn.empty()) {
         state->input.injectString(Global.prepend_scn);

--- a/simulation/simulationstateserializer.cpp
+++ b/simulation/simulationstateserializer.cpp
@@ -1351,6 +1351,31 @@ TEventLauncher *state_serializer::create_eventlauncher(const std::string &src, c
 	return launcher;
 }
 
+void state_serializer::create_trainset(const std::string &src) {
+	cParser parser(src);
+	parser.getTokens(); // "trainset"
+
+	scene::scratch_data scratch;
+
+	deserialize_trainset(parser, scratch);
+
+	// deserialize content from the provided input
+	auto token = parser.getToken<std::string>();
+	while (!token.empty()) {
+		if (token == "node")
+			deserialize_node(parser, scratch);
+		else if (token == "endtrainset")
+			deserialize_endtrainset(parser, scratch);
+		else {
+			deserialize_endtrainset(parser, scratch);
+			ErrorLog( "Bad scenario: encountered invalid token \"" + token + "\" in file \"" + parser.Name() + "\" (line " + std::to_string( parser.Line() ) + ")" );
+			break;
+		}
+
+		token = parser.getToken<std::string>();
+	}
+}
+
 } // simulation
 
   //---------------------------------------------------------------------------

--- a/simulation/simulationstateserializer.cpp
+++ b/simulation/simulationstateserializer.cpp
@@ -1371,7 +1371,7 @@ void state_serializer::create_trainset(const std::string &src) {
 			deserialize_endtrainset(parser, scratch);
 		else {
 			deserialize_endtrainset(parser, scratch);
-			ErrorLog( "Bad scenario: encountered invalid token \"" + token + "\" in file \"" + parser.Name() + "\" (line " + std::to_string( parser.Line() ) + ")" );
+			ErrorLog( std::format(R"(Bad scenario: encountered invalid token "{}" in file "{}" (line {}))", token, parser.Name(), std::to_string(parser.Line())));
 			break;
 		}
 

--- a/simulation/simulationstateserializer.cpp
+++ b/simulation/simulationstateserializer.cpp
@@ -437,31 +437,12 @@ state_serializer::deserialize_node( cParser &Input, scene::scratch_data &Scratch
     if( nodedata.name == "none" ) { nodedata.name.clear(); }
     // type-based deserialization. not elegant but it'll do
     if( nodedata.type == "dynamic" ) {
-
         auto *vehicle { deserialize_dynamic( Input, Scratchpad, nodedata ) };
         // vehicle import can potentially fail
-        if( vehicle == nullptr ) { return; }
-
-        //
-        if( vehicle->mdModel != nullptr ) {
-            for( auto const &smokesource : vehicle->mdModel->smoke_sources() ) {
-                Particles.insert(
-                    smokesource.first,
-                    vehicle,
-                    smokesource.second );
-            }
-        }
-
-        if( false == simulation::Vehicles.insert( vehicle ) ) {
-
+        if (!vehicle)
+        	return;
+        if (!Vehicles.insert(vehicle))
             ErrorLog( "Bad scenario: duplicate vehicle name \"" + vehicle->name() + "\" defined in file \"" + Input.Name() + "\" (line " + std::to_string( inputline ) + ")" );
-        }
-
-        if( vehicle->MoverParameters->CategoryFlag == 1 // trains only
-         && ( (vehicle->LightList(end::front) & (light::headlight_left | light::headlight_right | light::headlight_upper)) != 0
-           || (vehicle->LightList(end::rear) & (light::headlight_left | light::headlight_right | light::headlight_upper)) != 0 ) ) {
-            simulation::Lights.insert( vehicle );
-        }
     }
     else if( nodedata.type == "track" ) {
 

--- a/simulation/simulationstateserializer.h
+++ b/simulation/simulationstateserializer.h
@@ -41,10 +41,12 @@ public:
     // stores class data in specified file, in legacy (text) format
     void
         export_as_text( std::string const &Scenariofile ) const;
-	// create new model from node stirng
+	// create new model from node string
 	TAnimModel * create_model(std::string const &src, std::string const &name, const glm::dvec3 &position);
-	// create new eventlauncher from node stirng
+	// create new eventlauncher from node string
 	TEventLauncher * create_eventlauncher(std::string const &src, std::string const &name, const glm::dvec3 &position);
+	// create new trainset from trainset string
+	void create_trainset(std::string const &src);
 
 private:
 // methods

--- a/simulation/simulationstateserializer.h
+++ b/simulation/simulationstateserializer.h
@@ -50,6 +50,7 @@ public:
 
 private:
 // methods
+	std::shared_ptr<deserializer_state> make_deserializer_state(std::string const &Scenariofile);
     // restores class data from provided stream
     void deserialize_area( cParser &Input, scene::scratch_data &Scratchpad );
     void deserialize_isolated( cParser &Input, scene::scratch_data &Scratchpad );

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -81,7 +81,7 @@ struct global_settings {
     int iConvertModels{ 0 }; // tworzenie plików binarnych
     int iConvertIndexRange{ 1000 }; // range of duplicate vertex scan
     bool file_binary_terrain{ true }; // enable binary terrain (de)serialization
-	bool file_binary_terrain_state{true};
+	bool file_binary_terrain_state{true}; // binary terrain (de)serialization is enabled and the current scenery supports it
     // logs
 	bool priorityLoadText3D{false}; // ladowanie T3D priorytetowo
     int iWriteLogEnabled{ 3 }; // maska bitowa: 1-zapis do pliku, 2-okienko, 4-nazwy torów

--- a/vehicle/DynObj.cpp
+++ b/vehicle/DynObj.cpp
@@ -2374,6 +2374,10 @@ TDynamicObject::Init(std::string Name, // nazwa pojazdu, np. "EU07-424"
     }
     TurnOff(); // resetowanie zmiennych submodeli
 
+	// Trains only: Initialize lights
+	if (MoverParameters->CategoryFlag == 1 && (LightList(front) & (headlight_left | headlight_right | headlight_upper)) != 0
+	                                       || (LightList(rear)  & (headlight_left | headlight_right | headlight_upper)) != 0)
+		simulation::Lights.insert(this);
     if( mdLowPolyInt != nullptr ) {
         // check the low poly interior for potential compartments of interest, ie ones which can be individually lit
         // TODO: definition of relevant compartments in the .mmd file
@@ -2396,13 +2400,11 @@ TDynamicObject::Init(std::string Name, // nazwa pojazdu, np. "EU07-424"
             init_sections( mdLowPolyInt, nameprefix, MoverParameters->CompartmentLights.start_type == start_t::manual );
         }
     }
-    // destination sign
-    if( mdModel ) {
-        init_destination( mdModel );
-    }
-    // 'external_load' is an optional special section in the main model, pointing to submodel of external load
-    if( mdModel ) {
-        init_sections( mdModel, "external_load", false );
+    if (mdModel) {
+        init_destination(mdModel); // Destination sign
+    	init_smoke_sources(mdModel); // Smoke sources
+		// 'external_load' is an optional special section in the main model, pointing to submodel of external load
+        init_sections(mdModel, "external_load", false);
     }
     update_load_sections();
     update_load_visibility();
@@ -2543,6 +2545,11 @@ TDynamicObject::init_destination( TModel3d *Model ) {
     std::tie( DestinationSign.sign, DestinationSign.has_light ) = Model->GetSMRoot()->find_replacable4();
 
     return DestinationSign.sign != nullptr;
+}
+
+void TDynamicObject::init_smoke_sources(const TModel3d *Model) const {
+	for (auto const &smokesource : Model->smoke_sources())
+		simulation::Particles.insert(smokesource.first, this, smokesource.second);
 }
 
 void

--- a/vehicle/DynObj.cpp
+++ b/vehicle/DynObj.cpp
@@ -2375,8 +2375,8 @@ TDynamicObject::Init(std::string Name, // nazwa pojazdu, np. "EU07-424"
     TurnOff(); // resetowanie zmiennych submodeli
 
 	// Trains only: Initialize lights
-	if (MoverParameters->CategoryFlag == 1 && (LightList(front) & (headlight_left | headlight_right | headlight_upper)) != 0
-	                                       || (LightList(rear)  & (headlight_left | headlight_right | headlight_upper)) != 0)
+	if (MoverParameters->CategoryFlag == 1 && ((LightList(front) & (headlight_left | headlight_right | headlight_upper)) != 0
+	                                       ||  (LightList(rear)  & (headlight_left | headlight_right | headlight_upper)) != 0))
 		simulation::Lights.insert(this);
     if( mdLowPolyInt != nullptr ) {
         // check the low poly interior for potential compartments of interest, ie ones which can be individually lit
@@ -2548,8 +2548,8 @@ TDynamicObject::init_destination( TModel3d *Model ) {
 }
 
 void TDynamicObject::init_smoke_sources(const TModel3d *Model) const {
-	for (auto const &smokesource : Model->smoke_sources())
-		simulation::Particles.insert(smokesource.first, this, smokesource.second);
+	for (const auto &[sourcetemplate, location] : Model->smoke_sources())
+		simulation::Particles.insert(sourcetemplate, this, location);
 }
 
 void

--- a/vehicle/DynObj.h
+++ b/vehicle/DynObj.h
@@ -672,7 +672,8 @@ private:
         float Load, std::string LoadType, bool Reversed, std::string);
     int init_sections( TModel3d const *Model, std::string const &Nameprefix, bool const Overrideselfillum );
     bool init_destination( TModel3d *Model );
-    void create_controller( std::string const Type, bool const Trainset );
+	void init_smoke_sources(const TModel3d *Model) const;
+	void create_controller( std::string const Type, bool const Trainset );
     void AttachNext(TDynamicObject *Object, int iType = 1);
     bool UpdateForce(double dt);
     // initiates load change by specified amounts, with a platform on specified side


### PR DESCRIPTION
- Added a `spawn_trainset` function to Lua API.
  - Signature: `api.spawn_trainset(trainset)`
  - `trainset` is the entire trainset entry, for example exactly as copied from the Starter program. It specifies the track, placement and a few other parameters, so they are not given as separate function parameters.
- The scenario deserializer state creation has been extracted into a separate function.
- Smoke source and light initialization has been moved to DynObj.cpp instead of sitting in the scenario loading routine.

I am cherrypicking this from an April branch, and it seems something is fucked up with the order of commits. Some commits have contents which do not match what is actually being added. Please disregard that, I will do better next time. :P