### PR TITLE
Fix EP fuse auto-(dis)engaging

### DIFF
--- a/McZapkie/MOVER.h
+++ b/McZapkie/MOVER.h
@@ -1584,7 +1584,7 @@ class TMoverParameters
 	double BatteryVoltage = 0.0; /*Winger - baterie w elektrykach*/
 	bool Battery = false; /*Czy sa zalaczone baterie*/
 	start_t BatteryStart = start_t::manual;
-	bool EpFuse = true; /*Czy sa zalavzone baterie*/
+	bool EpFuse = true; /*Czy jest wlaczony hamulec EP*/
 	double EpForce = 0.0; /*Poziom zadanej sily EP*/
 	bool Signalling = false; /*Czy jest zalaczona sygnalizacja hamowania ostatniego wagonu*/
 	bool Radio = false; /*Czy jest zalaczony radiotelefon*/

--- a/vehicle/Driver.cpp
+++ b/vehicle/Driver.cpp
@@ -2236,7 +2236,10 @@ void TController::AutoRewident()
     }
 
     BrakeSystem = consist_brake_system();
-    mvOccupied->EpFuseSwitch( BrakeSystem == TBrakeSystem::ElectroPneumatic );
+	// Change the EP fuse state only when AI is in charge, don't fiddle with controls when the user is controlling the vehicle
+    if (AIControllFlag) {
+	    mvOccupied->EpFuseSwitch(BrakeSystem == TBrakeSystem::ElectroPneumatic);
+    }
 
     if( OrderCurrentGet() & ( Obey_train | Bank ) ) {
         // 4. Przeliczanie siły hamowania


### PR DESCRIPTION
When the Autorewident function is enabled, the EP fuse switch will no longer automatically engage or disengage if the player is controlling the train. This would happen for example when approaching a station.