### PR TITLE
whois: fall back to the consist owner in the +0/+7 mode too

### DIFF
--- a/world/Event.cpp
+++ b/world/Event.cpp
@@ -1014,7 +1014,12 @@ whois_event::deserialize_( cParser &Input, scene::scratch_data &Scratchpad ) {
 void
 whois_event::run_() {
 
-    if( m_activator == nullptr ) { return; }
+    if( m_activator == nullptr ) {
+        // no triggering vehicle to report on - most likely whois was launched from a
+        // scenery event chain rather than a track/isolation crossing
+        WriteLog( "Type: WhoIs (" + std::to_string( m_input.flags ) + ") - no activator, event ignored" );
+        return;
+    }
 
     for( auto &target : m_targets ) {
         auto *targetcell { static_cast<TMemCell *>( std::get<scene::basic_node *>( target ) ) };

--- a/world/Event.cpp
+++ b/world/Event.cpp
@@ -1129,20 +1129,28 @@ whois_event::run_() {
                 + "[engine power: " + to_string( m_activator->MoverParameters->Power, 2 ) + "]" );
         }
         // +0
-        else if( m_activator->Mechanik ) {
-            if( m_activator->Mechanik->primary() ) { // tylko jeśli ktoś tam siedzi - nie powinno dotyczyć pasażera!
+        else {
+            // same owner selection as the +8/+16/+24/+32/+40/+48 branches above: fall back to
+            // the consist's controlling vehicle if the activator itself isn't one (e.g. a wagon
+            // triggered the event ahead of its locomotive) - +0 used to require the activator's
+            // own Mechanik and silently produce nothing for a wagon-triggered whois
+            auto const *owner { (
+                m_activator->Mechanik != nullptr && m_activator->Mechanik->primary() ?
+                    m_activator->Mechanik :
+                    m_activator->ctOwner ) };
+            if( owner != nullptr ) {
                 targetcell->UpdateValues(
-                    m_activator->Mechanik->TrainName(),
-                    m_activator->Mechanik->StationCount() - m_activator->Mechanik->StationIndex(), // ile przystanków do końca
-                    m_activator->Mechanik->IsStop() ?
+                    owner->TrainName(),
+                    owner->StationCount() - owner->StationIndex(), // ile przystanków do końca
+                    owner->IsStop() ?
                         1 :
                         0, // 1, gdy ma tu zatrzymanie
                     m_input.flags & ( flags::text | flags::value1 | flags::value2 ) );
                 WriteLog(
                     "Type: WhoIs (" + std::to_string( m_input.flags ) + ") - "
-                    + "[train: " + m_activator->Mechanik->TrainName() + "], "
-                    + "[stations left: " + std::to_string( m_activator->Mechanik->StationCount() - m_activator->Mechanik->StationIndex() ) + "], "
-                    + "[stop at next station: " + ( m_activator->Mechanik->IsStop() ? "yes" : "no") + "]" );
+                    + "[train: " + owner->TrainName() + "], "
+                    + "[stations left: " + std::to_string( owner->StationCount() - owner->StationIndex() ) + "], "
+                    + "[stop at next station: " + ( owner->IsStop() ? "yes" : "no") + "]" );
             }
         }
     }

--- a/world/Event.cpp
+++ b/world/Event.cpp
@@ -1014,6 +1014,8 @@ whois_event::deserialize_( cParser &Input, scene::scratch_data &Scratchpad ) {
 void
 whois_event::run_() {
 
+    if( m_activator == nullptr ) { return; }
+
     for( auto &target : m_targets ) {
         auto *targetcell { static_cast<TMemCell *>( std::get<scene::basic_node *>( target ) ) };
         if( targetcell == nullptr ) { continue; }


### PR DESCRIPTION
The +8/+16/+24/+32/+40 (and +48 from #167) modes all pick the reporting vehicle the same way: the activator's own `Mechanik` if it's the primary driver, otherwise the consist's controlling vehicle (`ctOwner`) - so the event still resolves correctly if a wagon happens to trigger it ahead of its locomotive.

`+0` (train name / stations left / stop flag) predates that pattern and never got it: it required `m_activator->Mechanik` directly and silently wrote nothing otherwise. A whois hook placed where the loco doesn't necessarily lead (a train that reverses direction, or one being propelled) can have a wagon trigger the event first, leaving the memcell empty with no error - hard to diagnose from the scenery side. This is what motivated the change: a dispatcher script reading a train number this way got nothing for exactly this reason.

**Note on behavior change:** unlike #167, this is not purely additive. Guard semantics are unchanged (still nothing written if neither the activator nor its consist has a controller), but any case that previously fell through silently because the activator itself lacked a primary `Mechanik` will now write the consist owner's data instead of staying empty. I don't think any scenery relies on that silence as intentional behavior, but flagging it explicitly since it's a real behavior change, not just a new code path.