### PR TITLE
event names: fix registration/lookup casing mismatch for non-ASCII identifiers

### DIFF
--- a/world/Event.cpp
+++ b/world/Event.cpp
@@ -2195,7 +2195,13 @@ message_event::export_as_text_( std::ostream &Output ) const {
 basic_event *
 make_event( cParser &Input, scene::scratch_data &Scratchpad ) {
 
-    auto const name = ToLower( Input.getToken<std::string>() );
+    // getToken() already lowercases ASCII letters via the parser's toLowerChar(),
+    // which deliberately leaves bytes >= 0x80 untouched. The extra ToLower() here
+    // ran std::tolower() over every byte, so under a non-"C" global locale it
+    // remapped cp1250 uppercase accented letters (e.g. 0xAF -> 0xBF) - producing a
+    // registered name that no lookup site (Track::AssignEvents, child-event and
+    // launcher resolution) could match, since those normalize with the parser only.
+    auto const name = Input.getToken<std::string>();
     auto const type = Input.getToken<std::string>();
 
     basic_event *event { nullptr };


### PR DESCRIPTION
`make_event()` lowercased each event name twice: `cParser::getToken()` already folds ASCII via `toLowerChar()` (which intentionally passes bytes `>= 0x80` through untouched), and then `ToLower()` ran `std::tolower()` over every byte on top of that.

Under a non-`"C"` global locale the second pass remaps single-byte encodings of uppercase accented letters (cp1250: `0xAF` -> `0xBF`, etc.). Every place that resolves an event by name - `TTrack::AssignEvents()`, child-event resolution in `multi_event`, event-launcher name resolution - normalizes only through the parser. So an event whose name contains such a letter is registered under one key and looked up under another: the track logs `can't find assigned event "..."` and the binding is silently dropped.

In practice this hits any scenery event named with a capital accented letter - most visibly the auto-generated `<StationName>#N_stopinfo` events from the `w4*.inc` passenger-stop includes, when the station name starts with one (`Z`-with-dot, `S`-acute, `L`-stroke, `O`-acute, ...). The W32/W4 stop point never binds to its track, so AI trains scheduled to stop there roll straight through.

Fix: drop the redundant `ToLower()`. The token is already ASCII-lowercased by the parser; removing the second pass makes the registration key match every lookup site (ASCII-only folding, non-ASCII bytes compared verbatim), and lines up with the direction `toLowerChar()`'s own comment already sets out for UTF-8.

Not build-tested against the full engine locally; relying on CI.