### PR TITLE
Multiplayer mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ set(SOURCES
 "network/entities.cpp"
 "network/session.cpp"
 "network/statehash.cpp"
+"network/snapshot.cpp"
 "network/backend/asio.cpp"
 
 "widgets/vehiclelist.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ set(SOURCES
 "network/message.cpp"
 "network/manager.cpp"
 "network/entities.cpp"
+"network/session.cpp"
 "network/backend/asio.cpp"
 
 "widgets/vehiclelist.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,11 @@ if (WITH_UART)
 	set(SOURCES ${SOURCES} "utilities/uart.cpp")
 endif()
 
+if (WITH_HARDWARE_PROTOCOL_V2 OR WITH_ZMQ)
+	# shared TrainState registry, used both by the hardware protocol and by the zmq interface
+	set(SOURCES ${SOURCES} "hardware/registry/state_registry.cpp")
+endif()
+
 if (WITH_HARDWARE_PROTOCOL_V2)
 	set(DEFINITIONS ${DEFINITIONS} "WITH_HARDWARE_PROTOCOL_V2")
 	set(SOURCES ${SOURCES}
@@ -278,7 +283,6 @@ if (WITH_HARDWARE_PROTOCOL_V2)
 		"hardware/protocol/protocol_session.cpp"
 		"hardware/registry/command_registry.cpp"
 		"hardware/registry/hardware_symbol_registry.cpp"
-		"hardware/registry/state_registry.cpp"
 		"hardware/subscriptions/subscription_manager.cpp")
 	if (WITH_UART)
 		# the serial transport is the only one which needs libserialport

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,10 +197,12 @@ set(SOURCES
 "network/session.cpp"
 "network/statehash.cpp"
 "network/snapshot.cpp"
+"network/chat.cpp"
 "network/backend/asio.cpp"
 
 "widgets/vehiclelist.cpp"
 "widgets/multiplayer_lobby.cpp"
+"widgets/chat_panel.cpp"
 "widgets/map.cpp"
 "widgets/map_objects.cpp"
 "widgets/popup.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ option(WITH_OPENGL_MODERN "Compile with OpenGL modern renderer" ON)
 option(WITH_OPENGL_LEGACY "Compile with OpenGL legacy renderer" ON)
 option(WITH_PYTHON "Python 3.14 embedded scripting" ON)
 option(WITH_UART "Compile with libserialport" ON)
+option(WITH_HARDWARE_PROTOCOL_V2 "Compile with MaSzyna Hardware Protocol v2 (UART v2)" ON)
 option(WITH_LUA "Compile with lua scripting support" ON)
 option(WITH_OPENVR "Compile with OpenVR" OFF)
 option(WITH_ZMQ "Compile with cppzmq" OFF)
@@ -265,6 +266,24 @@ endif()
 if (WITH_UART)
 	set(DEFINITIONS ${DEFINITIONS} "WITH_UART")
 	set(SOURCES ${SOURCES} "utilities/uart.cpp")
+endif()
+
+if (WITH_HARDWARE_PROTOCOL_V2)
+	set(DEFINITIONS ${DEFINITIONS} "WITH_HARDWARE_PROTOCOL_V2")
+	set(SOURCES ${SOURCES}
+		"hardware/hardware_manager.cpp"
+		"hardware/diagnostics/hardware_diagnostics.cpp"
+		"hardware/protocol/protocol_codec.cpp"
+		"hardware/protocol/protocol_defs.cpp"
+		"hardware/protocol/protocol_session.cpp"
+		"hardware/registry/command_registry.cpp"
+		"hardware/registry/hardware_symbol_registry.cpp"
+		"hardware/registry/state_registry.cpp"
+		"hardware/subscriptions/subscription_manager.cpp")
+	if (WITH_UART)
+		# the serial transport is the only one which needs libserialport
+		set(SOURCES ${SOURCES} "hardware/transport/serial_transport.cpp")
+	endif()
 endif()
 
 if (WITH_ZMQ)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,9 +193,11 @@ set(SOURCES
 "network/network.cpp"
 "network/message.cpp"
 "network/manager.cpp"
+"network/entities.cpp"
 "network/backend/asio.cpp"
 
 "widgets/vehiclelist.cpp"
+"widgets/multiplayer_lobby.cpp"
 "widgets/map.cpp"
 "widgets/map_objects.cpp"
 "widgets/popup.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ set(SOURCES
 "network/manager.cpp"
 "network/entities.cpp"
 "network/session.cpp"
+"network/statehash.cpp"
 "network/backend/asio.cpp"
 
 "widgets/vehiclelist.cpp"

--- a/McZapkie/hamulce.cpp
+++ b/McZapkie/hamulce.cpp
@@ -588,6 +588,21 @@ int TBrake::GetSoundFlag()
 	return result;
 }
 
+/// Returns the accumulated SoundFlag bitfield and leaves it alone. Reading the flags is
+/// what clears them, so anything that only watches - the network layer, for one - has to
+/// look this way or it steals the sound from the vehicle it is watching.
+int TBrake::PeekSoundFlag() const
+{
+	return SoundFlag;
+}
+
+/// Adds events to the pending bitfield. Used to hand a vehicle the brake sounds its
+/// physics did not produce here because somebody else is running it.
+void TBrake::RaiseSoundFlag(int const Flags)
+{
+	SoundFlag |= Flags;
+}
+
 /// <summary>Sets the anti-slip brake target pressure.</summary>
 /// <param name="Press">Pressure [bar].</param>
 void TBrake::SetASBP(double const Press)

--- a/McZapkie/hamulce.h
+++ b/McZapkie/hamulce.h
@@ -481,6 +481,12 @@ class TBrake
 	virtual void ForceLeak(double const Amount);
 	/// <summary>Returns and clears the accumulated SoundFlag bitfield.</summary>
 	int GetSoundFlag();
+	/// <summary>Returns the accumulated SoundFlag bitfield without clearing it, for an
+	/// observer that must not consume what the vehicle itself is about to play.</summary>
+	int PeekSoundFlag() const;
+	/// <summary>Adds events to the pending SoundFlag bitfield, so that what happened on
+	/// another peer is heard here as well.</summary>
+	void RaiseSoundFlag(int const Flags);
 	/// <summary>Returns the current brake status flags.</summary>
 	int GetBrakeStatus() const
 	{

--- a/application/application.cpp
+++ b/application/application.cpp
@@ -438,7 +438,9 @@ double eu07_application::generate_sync()
 
 void eu07_application::queue_quit(bool direct)
 {
-	if (direct || !m_modes[m_modestack.top()]->is_command_processor())
+	// a network client leaving is its own business; replicating the request would shut
+	// down everybody else's session as well
+	if (direct || is_client() || !m_modes[m_modestack.top()]->is_command_processor())
 	{
 		glfwSetWindowShouldClose(m_windows[0], GLFW_TRUE);
 		return;
@@ -510,6 +512,10 @@ int eu07_application::run()
 				// if we're the server
 				if (m_network && m_network->servers)
 				{
+					// our own input goes through the same authority layer as everybody
+					// else's, only without the transport in between
+					network::filter_commands(network::PEER_HOST, local_commands);
+
 					// fetch from network layer command requests received from clients
 					command_queue::commands_map remote_commands = m_network->servers->pop_commands();
 

--- a/application/application.cpp
+++ b/application/application.cpp
@@ -461,6 +461,15 @@ void eu07_application::request_vehicle_leave(network::NetworkEntityId const Enti
 		m_network->request_leave(Entity);
 }
 
+namespace {
+
+// how many steps in a row may disagree with the authority before we ask to be corrected,
+// and how long to leave the correction alone before asking again
+uint64_t const NETWORK_RESYNC_THRESHOLD = 120;
+uint64_t const NETWORK_RESYNC_COOLDOWN = 600;
+
+} // namespace
+
 void eu07_application::network_scenario_loaded()
 {
 	if (m_network)
@@ -595,6 +604,16 @@ int eu07_application::run()
 								         logtype::net);
 							}
 							Global.desync = (float)m_statemismatches;
+
+							// a short disagreement rides itself out; a lasting one will not,
+							// and calls for the authoritative state rather than a restart
+							if ((m_statemismatches >= NETWORK_RESYNC_THRESHOLD) &&
+							    (m_lastresynctick == 0 || authoritative.tick > m_lastresynctick + NETWORK_RESYNC_COOLDOWN))
+							{
+								m_lastresynctick = authoritative.tick;
+								WriteLog("net: resync requested at tick " + std::to_string(authoritative.tick), logtype::net);
+								m_network->request_resync(authoritative.tick, statehash);
+							}
 						}
 						else
 						{

--- a/application/application.cpp
+++ b/application/application.cpp
@@ -1517,6 +1517,11 @@ bool eu07_application::init_network()
 	{
 		// create network manager
 		m_network.emplace();
+
+		// the host takes part in the session like any other peer, with an identity of its
+		// own, so that crew and permission handling needs no special case for it
+		if (!Global.network_client)
+			Global.network_peer_id = network::PEER_HOST;
 	}
 
 	for (auto const &pair : Global.network_servers)
@@ -1526,14 +1531,15 @@ bool eu07_application::init_network()
 		m_network->create_server(pair.first, pair.second);
 	}
 
+	if (!Global.local_start_vehicle_override && (Global.network_client || !Global.network_servers.empty()))
+	{
+		// in a multiplayer session the vehicle is picked in the lobby, so both the host
+		// and the joining clients start out as observers rather than in a random cab
+		Global.local_start_vehicle = "ghostview";
+	}
+
 	if (Global.network_client)
 	{
-		if (!Global.local_start_vehicle_override)
-		{
-			// in a multiplayer session the vehicle is assigned by the server;
-			// until the lobby exists the client simply starts out as an observer
-			Global.local_start_vehicle = "ghostview";
-		}
 
 		Global.network_status = "Connecting to " + Global.network_client->second + "...";
 		WriteLog("net: connecting to " + Global.network_client->second + " (" + Global.network_client->first + ")", logtype::net);

--- a/application/application.cpp
+++ b/application/application.cpp
@@ -30,6 +30,7 @@ http://mozilla.org/MPL/2.0/.
 #include "utilities/Timer.h"
 #include "utilities/dictionary.h"
 #include "version_info.h"
+#include "network/statehash.h"
 #include <chrono>
 #include "utilities/translation.h"
 
@@ -422,20 +423,6 @@ int eu07_application::init(int Argc, char *Argv[])
 	return result;
 }
 
-double eu07_application::generate_sync()
-{
-	if (Timer::GetDeltaTime() == 0.0)
-		return 0.0;
-	double sync = 0.0;
-	for (const TDynamicObject *vehicle : simulation::Vehicles.sequence())
-	{
-		auto const pos{vehicle->GetPosition()};
-		sync += pos.x + pos.y + pos.z;
-	}
-	sync += Random(1.0, 100.0);
-	return sync;
-}
-
 void eu07_application::queue_quit(bool direct)
 {
 	// a network client leaving is its own business; replicating the request would shut
@@ -507,7 +494,7 @@ int eu07_application::run()
 			{
 				command_queue::commands_map commands_to_exec;
 				command_queue::commands_map local_commands = simulation::Commands.pop_intercept_queue();
-				double slave_sync;
+				network::frame_delta authoritative;
 
 				// if we're the server
 				if (m_network && m_network->servers)
@@ -527,18 +514,20 @@ int eu07_application::run()
 				if (m_network && m_network->client)
 				{
 					// fetch frame info from network layer,
-					auto frame_info = m_network->client->get_next_delta(MAX_NETWORK_PER_FRAME - loop_remaining);
+					authoritative = m_network->client->get_next_delta(MAX_NETWORK_PER_FRAME - loop_remaining);
 
 					// use delta and commands received from master
-					double delta = std::get<0>(frame_info);
-					Timer::set_delta_override(delta);
-					slave_sync = std::get<1>(frame_info);
-					add_to_dequemap(commands_to_exec, std::get<2>(frame_info));
+					Timer::set_delta_override(authoritative.dt);
+					add_to_dequemap(commands_to_exec, authoritative.commands);
+
+					// the authority owns the timeline, so we take its step number as ours
+					if (authoritative.valid)
+						Global.simulation_tick = authoritative.tick;
 
 					// and send our local commands to master
 					m_network->client->send_commands(local_commands);
 
-					if (delta == 0.0)
+					if (!authoritative.valid)
 						loop_remaining = -1;
 				}
 				// if we're master
@@ -546,6 +535,9 @@ int eu07_application::run()
 				{
 					// just push local commands to execution
 					add_to_dequemap(commands_to_exec, local_commands);
+
+					// we are the one counting the steps of this world
+					++Global.simulation_tick;
 
 					loop_remaining = -1;
 				}
@@ -560,26 +552,51 @@ int eu07_application::run()
 				// update continuous commands
 				simulation::Commands.update();
 
-				double sync = generate_sync();
+				auto const statehash = (m_network ? network::state_hash() : 0);
 
 				// if we're the server
 				if (m_network && m_network->servers)
 				{
-					// send delta, sync, and commands we just executed to clients
+					// send delta, state digest, and commands we just executed to clients
 					double delta = Timer::GetDeltaTime();
 					double render = Timer::GetDeltaRenderTime();
-					m_network->servers->push_delta(render, delta, sync, commands_to_exec);
+					m_network->servers->push_delta(render, delta, Global.simulation_tick, statehash, commands_to_exec);
 				}
 
 				// if we're slave
 				if (m_network && m_network->client)
 				{
-					// verify sync
-					if (sync != slave_sync)
+					if (authoritative.valid)
 					{
-						WriteLog("net: desync! calculated: " + std::to_string(sync) + ", received: " + std::to_string(slave_sync), logtype::net);
-
-						Global.desync = slave_sync - sync;
+						if (authoritative.state_hash_version != network::STATE_HASH_VERSION)
+						{
+							// nothing sensible to compare; say so once and stop pretending
+							if (m_statemismatches == 0)
+							{
+								ErrorLog("net: state digest version mismatch, desync detection is off", logtype::net);
+								m_statemismatches = 1;
+							}
+						}
+						else if (statehash != authoritative.state_hash)
+						{
+							++m_statemismatches;
+							// a drift usually persists, so this is reported when it starts
+							// and then only now and then, instead of every single step
+							if (m_statemismatches == 1 || (m_statemismatches % 300) == 0)
+							{
+								WriteLog("net: state mismatch at tick " + std::to_string(authoritative.tick) + " (" + std::to_string(m_statemismatches) +
+								             " steps): local " + std::to_string(statehash) + ", authoritative " + std::to_string(authoritative.state_hash),
+								         logtype::net);
+							}
+							Global.desync = (float)m_statemismatches;
+						}
+						else
+						{
+							if (m_statemismatches != 0)
+								WriteLog("net: state back in step with the authority at tick " + std::to_string(authoritative.tick), logtype::net);
+							m_statemismatches = 0;
+							Global.desync = 0.0f;
+						}
 					}
 
 					// set total delta for rendering code

--- a/application/application.cpp
+++ b/application/application.cpp
@@ -461,6 +461,12 @@ void eu07_application::request_vehicle_leave(network::NetworkEntityId const Enti
 		m_network->request_leave(Entity);
 }
 
+void eu07_application::network_scenario_loaded()
+{
+	if (m_network)
+		m_network->notify_scenario_loaded();
+}
+
 int eu07_application::run()
 {
 	auto frame{0};

--- a/application/application.cpp
+++ b/application/application.cpp
@@ -1105,6 +1105,49 @@ void eu07_application::init_files()
 }
 namespace fs = std::filesystem;
 
+namespace {
+
+// port used when the user did not spell one out in --host / --connect
+uint32_t const EU07_DEFAULT_NETWORK_PORT = 7420;
+
+// completes a user supplied endpoint into the "address:port" form expected by the tcp backend.
+// note: only the plain ipv4/hostname form is split, anything with more colons is passed through
+std::string network_endpoint(std::string const &Argument, std::string const &Defaultaddress)
+{
+	auto address{Argument};
+	std::string port;
+
+	if (std::count(address.begin(), address.end(), ':') == 1)
+	{
+		auto const separator{address.find(':')};
+		port = address.substr(separator + 1);
+		address = address.substr(0, separator);
+	}
+
+	if (address.empty())
+		address = Defaultaddress;
+	if (port.empty())
+		port = std::to_string(EU07_DEFAULT_NETWORK_PORT);
+
+	return address + ":" + port;
+}
+
+void print_usage(std::string const &Executable)
+{
+	std::cout
+	    << "usage: " << Executable << " [options]\n"
+	    << "  -s, --scenario <path>        scenario file to load\n"
+	    << "  -v, --vehicle <name>         vehicle to start in\n"
+	    << "      --host [address:port]    host a multiplayer session (default 0.0.0.0:"
+	    << EU07_DEFAULT_NETWORK_PORT << ")\n"
+	    << "      --connect <address:port> join a multiplayer session (default port "
+	    << EU07_DEFAULT_NETWORK_PORT << ")\n"
+	    << "  -h, --help                   this message"
+	    << std::endl;
+}
+
+} // namespace
+
 int eu07_application::init_settings(int Argc, char *Argv[])
 {
 	Global.asVersion = VERSION_INFO;
@@ -1126,24 +1169,48 @@ int eu07_application::init_settings(int Argc, char *Argv[])
 
 		std::string token{Argv[i]};
 
-		if (token == "-s")
+		if (token == "-s" || token == "--scenario")
 		{
 			if (i + 1 < Argc)
 			{
 				Global.SceneryFile = ToLower(Argv[++i]);
 			}
 		}
-		else if (token == "-v")
+		else if (token == "-v" || token == "--vehicle")
 		{
 			if (i + 1 < Argc)
 			{
 				Global.local_start_vehicle = ToLower(Argv[++i]);
+				Global.local_start_vehicle_override = true;
 			}
+		}
+		else if (token == "--host")
+		{
+			// the address is optional, so that a bare --host just listens on every interface
+			std::string endpoint{std::string("0.0.0.0:") + std::to_string(EU07_DEFAULT_NETWORK_PORT)};
+			if (i + 1 < Argc && Argv[i + 1][0] != '-')
+			{
+				endpoint = network_endpoint(Argv[++i], "0.0.0.0");
+			}
+			Global.network_servers.emplace_back("tcp", endpoint);
+		}
+		else if (token == "--connect")
+		{
+			if (i + 1 >= Argc)
+			{
+				std::cout << "--connect requires a server address" << std::endl;
+				return -1;
+			}
+			Global.network_client.emplace("tcp", network_endpoint(Argv[++i], "127.0.0.1"));
+		}
+		else if (token == "-h" || token == "--help")
+		{
+			print_usage(Argv[0]);
+			return -1;
 		}
 		else
 		{
-			std::cout << "usage: " << std::string(Argv[0]) << " [-s sceneryfilepath]"
-			          << " [-v vehiclename]" << std::endl;
+			print_usage(Argv[0]);
 			return -1;
 		}
 	}
@@ -1423,17 +1490,23 @@ int eu07_application::init_modes()
 {
 	Global.local_random_engine.seed(std::random_device{}());
 
-	if ((!Global.network_servers.empty() || Global.network_client) && Global.SceneryFile.empty())
-	{
-		ErrorLog("launcher mode is currently not supported in network mode");
-		return -1;
-	}
-
 	// activate the default mode
-	if (Global.SceneryFile.empty())
-		push_mode(mode::launcher);
-	else
+	if (Global.network_client)
+	{
+		// a multiplayer client learns the scenario name from the server handshake,
+		// so it goes straight to the loader and waits there for Global.ready_to_load
 		push_mode(mode::scenarioloader);
+	}
+	else if (Global.SceneryFile.empty())
+	{
+		// no scenario given: let the user pick one (a listening server simply
+		// refuses joins until the scenario is up)
+		push_mode(mode::launcher);
+	}
+	else
+	{
+		push_mode(mode::scenarioloader);
+	}
 
 	return 0;
 }
@@ -1449,11 +1522,22 @@ bool eu07_application::init_network()
 	for (auto const &pair : Global.network_servers)
 	{
 		// create all servers
+		WriteLog("net: hosting session on " + pair.second + " (" + pair.first + ")", logtype::net);
 		m_network->create_server(pair.first, pair.second);
 	}
 
 	if (Global.network_client)
 	{
+		if (!Global.local_start_vehicle_override)
+		{
+			// in a multiplayer session the vehicle is assigned by the server;
+			// until the lobby exists the client simply starts out as an observer
+			Global.local_start_vehicle = "ghostview";
+		}
+
+		Global.network_status = "Connecting to " + Global.network_client->second + "...";
+		WriteLog("net: connecting to " + Global.network_client->second + " (" + Global.network_client->first + ")", logtype::net);
+
 		// create client
 		m_network->connect(Global.network_client->first, Global.network_client->second);
 	}

--- a/application/application.cpp
+++ b/application/application.cpp
@@ -594,6 +594,7 @@ int eu07_application::run()
 						if (statehash != authoritative.state_hash)
 						{
 							++m_statemismatches;
+							Global.network_digest_mismatches = m_statemismatches;
 							if (m_statemismatches == 1 || (m_statemismatches % NETWORK_DIGEST_LOG_INTERVAL) == 0)
 							{
 								WriteLog("net: state digest differs at tick " + std::to_string(authoritative.tick) + " (" + std::to_string(m_statemismatches) +
@@ -605,6 +606,7 @@ int eu07_application::run()
 						{
 							WriteLog("net: state digest back in step at tick " + std::to_string(authoritative.tick), logtype::net);
 							m_statemismatches = 0;
+							Global.network_digest_mismatches = 0;
 						}
 					}
 

--- a/application/application.cpp
+++ b/application/application.cpp
@@ -463,10 +463,9 @@ void eu07_application::request_vehicle_leave(network::NetworkEntityId const Enti
 
 namespace {
 
-// how many steps in a row may disagree with the authority before we ask to be corrected,
-// and how long to leave the correction alone before asking again
-uint64_t const NETWORK_RESYNC_THRESHOLD = 120;
-uint64_t const NETWORK_RESYNC_COOLDOWN = 600;
+// the state digest is logged when it starts differing and then only this often, so that
+// a persistent difference does not bury the rest of the log
+uint64_t const NETWORK_DIGEST_LOG_INTERVAL = 1800;
 
 } // namespace
 
@@ -581,46 +580,26 @@ int eu07_application::run()
 				// if we're slave
 				if (m_network && m_network->client)
 				{
-					if (authoritative.valid)
+					// the digest is a diagnostic, not a control input: a client runs its
+					// own physics, so the two will never agree bit for bit and demanding
+					// that they do only produces noise. what actually keeps a client in
+					// line is the authoritative state the server streams to it
+					if (authoritative.valid && authoritative.state_hash_version == network::STATE_HASH_VERSION)
 					{
-						if (authoritative.state_hash_version != network::STATE_HASH_VERSION)
-						{
-							// nothing sensible to compare; say so once and stop pretending
-							if (m_statemismatches == 0)
-							{
-								ErrorLog("net: state digest version mismatch, desync detection is off", logtype::net);
-								m_statemismatches = 1;
-							}
-						}
-						else if (statehash != authoritative.state_hash)
+						if (statehash != authoritative.state_hash)
 						{
 							++m_statemismatches;
-							// a drift usually persists, so this is reported when it starts
-							// and then only now and then, instead of every single step
-							if (m_statemismatches == 1 || (m_statemismatches % 300) == 0)
+							if (m_statemismatches == 1 || (m_statemismatches % NETWORK_DIGEST_LOG_INTERVAL) == 0)
 							{
-								WriteLog("net: state mismatch at tick " + std::to_string(authoritative.tick) + " (" + std::to_string(m_statemismatches) +
+								WriteLog("net: state digest differs at tick " + std::to_string(authoritative.tick) + " (" + std::to_string(m_statemismatches) +
 								             " steps): local " + std::to_string(statehash) + ", authoritative " + std::to_string(authoritative.state_hash),
 								         logtype::net);
 							}
-							Global.desync = (float)m_statemismatches;
-
-							// a short disagreement rides itself out; a lasting one will not,
-							// and calls for the authoritative state rather than a restart
-							if ((m_statemismatches >= NETWORK_RESYNC_THRESHOLD) &&
-							    (m_lastresynctick == 0 || authoritative.tick > m_lastresynctick + NETWORK_RESYNC_COOLDOWN))
-							{
-								m_lastresynctick = authoritative.tick;
-								WriteLog("net: resync requested at tick " + std::to_string(authoritative.tick), logtype::net);
-								m_network->request_resync(authoritative.tick, statehash);
-							}
 						}
-						else
+						else if (m_statemismatches != 0)
 						{
-							if (m_statemismatches != 0)
-								WriteLog("net: state back in step with the authority at tick " + std::to_string(authoritative.tick), logtype::net);
+							WriteLog("net: state digest back in step at tick " + std::to_string(authoritative.tick), logtype::net);
 							m_statemismatches = 0;
-							Global.desync = 0.0f;
 						}
 					}
 

--- a/application/application.cpp
+++ b/application/application.cpp
@@ -894,6 +894,17 @@ eu07_application::get_input_hint( user_command const Command ) const {
 
 void eu07_application::on_key(int const Key, int const Scancode, int const Action, int const Mods)
 {
+	// the session chat opens on the key left of 1, and it is checked before imgui gets a
+	// look at the input: a lobby or any other window that happens to have the keyboard
+	// would otherwise swallow the key and the chat could never be opened at all. the one
+	// case where imgui does get it is when something is already taking typed text - the
+	// chat box itself, most of the time, which closes on escape instead
+	if ((Key == GLFW_KEY_GRAVE_ACCENT) && (Action == GLFW_PRESS) && (Mods == 0) && !m_modestack.empty() && network::is_multiplayer() &&
+	    !ui_layer::wants_keyboard())
+	{
+		if (m_modes[m_modestack.top()]->toggle_chat())
+			return;
+	}
 
 	if (ui_layer::key_callback(Key, Scancode, Action, Mods))
 		return;

--- a/application/application.cpp
+++ b/application/application.cpp
@@ -220,7 +220,7 @@ void eu07_application::DiscordRPCService()
 	discord_rpc.largeImageText = "MaSzyna";
 
 	// run loop
-	while (!glfwWindowShouldClose(m_windows.front()) && !m_modestack.empty() && !Global.applicationQuitOrder)
+	while (!should_close() && !m_modestack.empty() && !Global.applicationQuitOrder)
 	{
 		auto currentMode = m_modestack.top();
 		if (currentMode == mode::launcher)
@@ -363,7 +363,7 @@ int eu07_application::init(int Argc, char *Argv[])
 		return result;
 	}
 
-	if (crashreport_is_pending())
+	if (crashreport_is_pending() && !Global.headless)
 	{ // run crashgui as early as possible
 		if ((result = run_crashgui()) != 0)
 		{
@@ -429,7 +429,10 @@ void eu07_application::queue_quit(bool direct)
 	// down everybody else's session as well
 	if (direct || is_client() || !m_modes[m_modestack.top()]->is_command_processor())
 	{
-		glfwSetWindowShouldClose(m_windows[0], GLFW_TRUE);
+		if (Global.headless)
+			Global.applicationQuitOrder = true;
+		else
+			glfwSetWindowShouldClose(m_windows[0], GLFW_TRUE);
 		return;
 	}
 
@@ -475,14 +478,21 @@ void eu07_application::network_scenario_loaded()
 		m_network->notify_scenario_loaded();
 }
 
+void eu07_application::say(std::string const &Text)
+{
+	if (m_network)
+		m_network->say(Text);
+}
+
 int eu07_application::run()
 {
 	auto frame{0};
 	// main application loop
-	while (!glfwWindowShouldClose(m_windows.front()) && !m_modestack.empty())
+	while (!should_close() && !m_modestack.empty())
 	{
 		Timer::subsystem.mainloop_total.start();
-		glfwPollEvents();
+		if (!Global.headless)
+			glfwPollEvents();
 
 		if (m_headtrack)
 			m_headtrack->update();
@@ -645,7 +655,9 @@ int eu07_application::run()
 		if (m_modestack.empty())
 			break;
 
-		m_modes[m_modestack.top()]->on_event_poll();
+		// there is no keyboard, mouse or gamepad to ask when there is no window
+		if (!Global.headless)
+			m_modes[m_modestack.top()]->on_event_poll();
 
 		if (m_screenshot_queued)
 		{
@@ -718,15 +730,21 @@ void eu07_application::exit()
 	//    SafeDelete( simulation::Train );
 	SafeDelete(simulation::Region);
 
-	ui_layer::shutdown();
-
-	for (auto *window : m_windows)
+	if (!Global.headless)
 	{
-		glfwDestroyWindow(window);
+		ui_layer::shutdown();
+
+		for (auto *window : m_windows)
+		{
+			glfwDestroyWindow(window);
+		}
 	}
 	m_taskqueue.exit();
-	glfwPollEvents(); // TODO: This fixes a segfault on Wayland when closing. Remove after updating glfw to 3.5.
-	glfwTerminate();
+	if (!Global.headless)
+	{
+		glfwPollEvents(); // TODO: This fixes a segfault on Wayland when closing. Remove after updating glfw to 3.5.
+		glfwTerminate();
+	}
 
 	if (!Global.exec_on_exit.empty())
 		system(Global.exec_on_exit.c_str());
@@ -750,6 +768,11 @@ void eu07_application::exit()
 
 void eu07_application::render_ui()
 {
+	if (Global.headless)
+	{
+		return;
+	}
+
 
 	if (m_modestack.empty())
 	{
@@ -761,6 +784,11 @@ void eu07_application::render_ui()
 
 void eu07_application::begin_ui_frame()
 {
+	// there is no imgui context without a window, and nothing would look at its output
+	if (Global.headless)
+	{
+		return;
+	}
 
 	if (m_modestack.empty())
 	{
@@ -811,6 +839,8 @@ bool eu07_application::push_mode(mode const Mode)
 
 void eu07_application::set_title(std::string const &Title)
 {
+	if (m_windows.empty())
+		return;
 
 	glfwSetWindowTitle(m_windows.front(), Title.c_str());
 }
@@ -845,6 +875,8 @@ void eu07_application::set_cursor(int const Mode)
 
 void eu07_application::set_cursor_pos(double const Horizontal, double const Vertical)
 {
+	if (m_windows.empty())
+		return;
 
 	glfwSetCursorPos(m_windows.front(), Horizontal, Vertical);
 }
@@ -1006,7 +1038,17 @@ std::string eu07_application::describe_monitor(GLFWmonitor *monitor) const
 
 bool eu07_application::needs_ogl() const
 {
-	return !Global.NvRenderer;
+	return !Global.NvRenderer && !Global.headless;
+}
+
+// there is no window to be closed when running without one, so the only way out is being
+// asked to leave
+bool eu07_application::should_close() const
+{
+	if (Global.headless)
+		return Global.applicationQuitOrder;
+
+	return m_windows.empty() || glfwWindowShouldClose(m_windows.front());
 }
 
 void eu07_application::init_debug()
@@ -1173,6 +1215,9 @@ void print_usage(std::string const &Executable)
 	    << EU07_DEFAULT_NETWORK_PORT << ")\n"
 	    << "      --connect <address:port> join a multiplayer session (default port "
 	    << EU07_DEFAULT_NETWORK_PORT << ")\n"
+	    << "      --nick <name>            name to be known by in the session\n"
+	    << "      --nogui                  no window, no renderer, no cab: a dedicated\n"
+	    << "                               server that leaves the scenario to the AI\n"
 	    << "  -h, --help                   this message"
 	    << std::endl;
 }
@@ -1234,6 +1279,33 @@ int eu07_application::init_settings(int Argc, char *Argv[])
 			}
 			Global.network_client.emplace("tcp", network_endpoint(Argv[++i], "127.0.0.1"));
 		}
+		else if (token == "--nick")
+		{
+			if (i + 1 >= Argc)
+			{
+				std::cout << "--nick requires a name" << std::endl;
+				return -1;
+			}
+			Global.multiplayer_nickname = Argv[++i];
+		}
+		else if (token == "--nogui")
+		{
+			// no window, no renderer, no player. the log goes to the console it was
+			// started from, because there is nothing else to read it in
+			Global.headless = true;
+			Global.GfxRenderer = "null";
+			// nothing is waiting on a swapchain, so without this the loop would spin a
+			// core flat out for no benefit. fifty steps a second is more than the
+			// authoritative stream needs
+			Global.minframetime = std::chrono::duration<float>(1.0f / 50.0f);
+			Global.iWriteLogEnabled = 2;
+			Global.ShowSystemConsole = true;
+			Global.bSoundEnabled = false;
+			// the scenario is left to its own drivers: this process is a referee, not a
+			// participant, and it never walks into a cab
+			Global.local_start_vehicle = "ghostview";
+			Global.local_start_vehicle_override = true;
+		}
 		else if (token == "-h" || token == "--help")
 		{
 			print_usage(Argv[0]);
@@ -1259,6 +1331,14 @@ int eu07_application::init_locale()
 
 int eu07_application::init_glfw()
 {
+	if (Global.headless)
+	{
+		// no window system at all. everything downstream is guarded on an empty window
+		// list, which is what tells the rest of the application there is nothing to draw on
+		WriteLog("running without a window; this process is a dedicated server");
+		return 0;
+	}
+
 	{
 		int glfw_major, glfw_minor, glfw_rev;
 		glfwGetVersion(&glfw_major, &glfw_minor, &glfw_rev);
@@ -1440,6 +1520,9 @@ int eu07_application::init_ogl()
 
 int eu07_application::init_ui()
 {
+	if (Global.headless)
+		return 0;
+
 	if (false == ui_layer::init(m_windows.front()))
 	{
 		return -1;
@@ -1451,7 +1534,13 @@ int eu07_application::init_ui()
 int eu07_application::init_gfx()
 {
 
-	if (Global.GfxRenderer == "default")
+	if (Global.headless)
+	{
+		// draws nothing, allocates nothing, and lets the rest of the simulation run
+		// exactly as it otherwise would
+		GfxRenderer = gfx_renderer_factory::get_instance()->create("null");
+	}
+	else if (Global.GfxRenderer == "default")
 	{
 		// default render path
 		GfxRenderer = gfx_renderer_factory::get_instance()->create("modern");
@@ -1473,7 +1562,7 @@ int eu07_application::init_gfx()
 		return -1;
 	}
 
-	if (false == GfxRenderer->Init(m_windows.front()))
+	if (false == GfxRenderer->Init(m_windows.empty() ? nullptr : m_windows.front()))
 	{
 		return -1;
 	}
@@ -1555,7 +1644,11 @@ bool eu07_application::init_network()
 		// the host takes part in the session like any other peer, with an identity of its
 		// own, so that crew and permission handling needs no special case for it
 		if (!Global.network_client)
+		{
 			Global.network_peer_id = network::PEER_HOST;
+			auto const name = network::Peers.assign(network::PEER_HOST, network::local_nickname());
+			WriteLog("net: hosting as \"" + name + "\"", logtype::net);
+		}
 	}
 
 	for (auto const &pair : Global.network_servers)

--- a/application/application.cpp
+++ b/application/application.cpp
@@ -1578,6 +1578,9 @@ bool eu07_application::init_network()
 		// create network manager
 		m_network.emplace();
 
+		// settings a session cannot run without, whichever side we are on
+		network::enforce_session_settings();
+
 		// the host takes part in the session like any other peer, with an identity of its
 		// own, so that crew and permission handling needs no special case for it
 		if (!Global.network_client)

--- a/application/application.cpp
+++ b/application/application.cpp
@@ -460,6 +460,18 @@ bool eu07_application::is_client() const
 	return m_network && m_network->client;
 }
 
+void eu07_application::request_vehicle_claim(network::NetworkEntityId const Entity)
+{
+	if (m_network)
+		m_network->request_claim(Entity);
+}
+
+void eu07_application::request_vehicle_leave(network::NetworkEntityId const Entity)
+{
+	if (m_network)
+		m_network->request_leave(Entity);
+}
+
 int eu07_application::run()
 {
 	auto frame{0};

--- a/application/application.cpp
+++ b/application/application.cpp
@@ -498,8 +498,6 @@ int eu07_application::run()
 		//
 		// trivia: being client and server is possible
 
-		double frameStartTime = Timer::GetTime();
-
 		if (m_modes[m_modestack.top()]->is_command_processor())
 		{
 			// active mode is doing real calculations (e.g. drivermode)
@@ -527,22 +525,29 @@ int eu07_application::run()
 				// if we're slave
 				if (m_network && m_network->client)
 				{
-					// fetch frame info from network layer,
-					authoritative = m_network->client->get_next_delta(MAX_NETWORK_PER_FRAME - loop_remaining);
-
-					// use delta and commands received from master
-					Timer::set_delta_override(authoritative.dt);
-					add_to_dequemap(commands_to_exec, authoritative.commands);
+					// take everything the authority has sent since the last frame. the
+					// commands are carried out at once; the world itself runs on our own
+					// clock rather than replaying the server's frame times, which is what
+					// made it run at the wrong speed whenever the two machines drew at
+					// different rates, and put every buffered frame between the player and
+					// their own controls
+					authoritative = m_network->client->take_pending(commands_to_exec);
 
 					// the authority owns the timeline, so we take its step number as ours
 					if (authoritative.valid)
 						Global.simulation_tick = authoritative.tick;
 
+					// what we do to the train we run ourselves happens now, not after a
+					// round trip. it still goes to the server, so that everybody else sees
+					// it; the echo of it is dropped when it comes back
+					command_queue::commands_map predicted;
+					network::collect_predictable(local_commands, predicted);
+					add_to_dequemap(commands_to_exec, predicted);
+
 					// and send our local commands to master
 					m_network->client->send_commands(local_commands);
 
-					if (!authoritative.valid)
-						loop_remaining = -1;
+					loop_remaining = -1;
 				}
 				// if we're master
 				else
@@ -603,25 +608,10 @@ int eu07_application::run()
 						}
 					}
 
-					// set total delta for rendering code
-					double totalDelta = Timer::GetTime() - frameStartTime;
-					Timer::set_delta_override(totalDelta);
 				}
 			}
 
-			if (!loop_remaining)
-			{
-				// loop break forced by counter
-				float received = m_network->client->get_frame_counter();
-				float awaiting = m_network->client->get_awaiting_frames();
-
-				// TODO: don't meddle with mode progresbar
-				m_modes[m_modestack.top()]->set_progress(100.0f * (received - awaiting) / received);
-			}
-			else
-			{
-				m_modes[m_modestack.top()]->set_progress(0.0f, 0.0f);
-			}
+			m_modes[m_modestack.top()]->set_progress(0.0f, 0.0f);
 		}
 		else
 		{

--- a/application/application.h
+++ b/application/application.h
@@ -123,10 +123,9 @@ private:
 // members
 
     bool m_screenshot_queued = false;
-    // consecutive authoritative steps whose state digest did not match ours
+    // consecutive authoritative steps whose state digest did not match ours. purely a
+    // diagnostic: a client runs its own physics, so it is never expected to match exactly
     std::uint64_t m_statemismatches { 0 };
-    // tick at which we last asked the server to put us back in line
-    std::uint64_t m_lastresynctick { 0 };
 
     modeptr_array m_modes { nullptr }; // collection of available application behaviour modes
     mode_stack m_modestack; // current behaviour mode

--- a/application/application.h
+++ b/application/application.h
@@ -93,6 +93,11 @@ public:
         is_server() const;
     bool
         is_client() const;
+    // asks the session authority to put us on the crew of given vehicle, or take us off it
+    void
+        request_vehicle_claim( network::NetworkEntityId const Entity );
+    void
+        request_vehicle_leave( network::NetworkEntityId const Entity );
 
 private:
 // types

--- a/application/application.h
+++ b/application/application.h
@@ -125,6 +125,8 @@ private:
     bool m_screenshot_queued = false;
     // consecutive authoritative steps whose state digest did not match ours
     std::uint64_t m_statemismatches { 0 };
+    // tick at which we last asked the server to put us back in line
+    std::uint64_t m_lastresynctick { 0 };
 
     modeptr_array m_modes { nullptr }; // collection of available application behaviour modes
     mode_stack m_modestack; // current behaviour mode

--- a/application/application.h
+++ b/application/application.h
@@ -98,6 +98,9 @@ public:
     // tells the network layer the scenario finished loading
     void
         network_scenario_loaded();
+    // says something to the rest of the session
+    void
+        say( std::string const &Text );
 
 private:
 // types
@@ -105,6 +108,9 @@ private:
     using mode_stack = std::stack<mode>;
 // methods
 	  bool needs_ogl() const;
+    // true when the run is over: the window was closed, or, with no window, we were asked
+    // to stop
+    bool should_close() const;
     void init_debug();
     void init_console();
     void init_files();

--- a/application/application.h
+++ b/application/application.h
@@ -95,6 +95,9 @@ public:
         request_vehicle_claim( network::NetworkEntityId const Entity );
     void
         request_vehicle_leave( network::NetworkEntityId const Entity );
+    // tells the network layer the scenario finished loading
+    void
+        network_scenario_loaded();
 
 private:
 // types

--- a/application/application.h
+++ b/application/application.h
@@ -84,9 +84,6 @@ public:
         window( int const Windowindex = 0, bool visible = false, int width = 1, int height = 1, GLFWmonitor *monitor = nullptr, bool keep_ownership = true, bool share_ctx = true );
     GLFWmonitor * find_monitor( const std::string &str ) const;
     std::string describe_monitor( GLFWmonitor *monitor ) const;
-	// generate network sync verification number
-	double
-	    generate_sync();
 	void
         queue_quit(bool direct);
     bool
@@ -123,6 +120,8 @@ private:
 // members
 
     bool m_screenshot_queued = false;
+    // consecutive authoritative steps whose state digest did not match ours
+    std::uint64_t m_statemismatches { 0 };
 
     modeptr_array m_modes { nullptr }; // collection of available application behaviour modes
     mode_stack m_modestack; // current behaviour mode

--- a/application/applicationmode.h
+++ b/application/applicationmode.h
@@ -51,6 +51,8 @@ public:
     virtual void on_scroll( double Xoffset, double Yoffset ) = 0;
     virtual void on_window_resize( int w, int h ) = 0;
     virtual void on_event_poll() = 0;
+    // opens or closes the session chat; true when this mode has one to open
+    virtual bool toggle_chat() { return false; }
     virtual bool is_command_processor() const = 0;
 
 protected:

--- a/application/drivermode.cpp
+++ b/application/drivermode.cpp
@@ -30,6 +30,7 @@ http://mozilla.org/MPL/2.0/.
 #include "rendering/renderer.h"
 #include "utilities/Logs.h"
 #include "network/entities.h"
+#include "network/snapshot.h"
 /*
 namespace input {
 
@@ -448,6 +449,11 @@ bool driver_mode::update()
 	simulation::Environment.update_precipitation(); // has to be launched after camera step to work properly
 
 	Timer::subsystem.sim_total.stop();
+
+	// what the other peers' trains are doing is theirs to decide, and the local physics
+	// has spent this frame disagreeing about it. put their readings back before anything
+	// is heard or drawn from them
+	network::hold_remote_state();
 
 	simulation::Region->update_sounds();
 	audio::renderer.update(Global.iPause ? 0.0 : deltarealtime);

--- a/application/drivermode.cpp
+++ b/application/drivermode.cpp
@@ -94,10 +94,8 @@ bool driver_mode::drivermode_input::init()
 	}
 #endif
 #ifdef WITH_HARDWARE_PROTOCOL_V2
-	if (true == Global.hardware_conf.enable)
-	{
-		hardware = std::make_unique<hardware::hardware_manager>(Global.hardware_conf);
-	}
+	// started even with no links configured, so that a controller can be added from the debug panel
+	hardware = std::make_unique<hardware::hardware_manager>(Global.hardware_conf);
 #endif
 #ifdef WITH_ZMQ
 	if (!Global.zmq_address.empty())

--- a/application/drivermode.cpp
+++ b/application/drivermode.cpp
@@ -55,6 +55,13 @@ void driver_mode::drivermode_input::poll()
 		uart->poll();
 	}
 #endif
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+	if (hardware != nullptr)
+	{
+		// exchanges frames already gathered by the hardware worker thread, never touches the port itself
+		hardware->update();
+	}
+#endif
 #ifdef WITH_ZMQ
 	if (zmq != nullptr)
 	{
@@ -84,6 +91,12 @@ bool driver_mode::drivermode_input::init()
 	{
 		uart = std::make_unique<uart_input>();
 		uart->init();
+	}
+#endif
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+	if (true == Global.hardware_conf.enable)
+	{
+		hardware = std::make_unique<hardware::hardware_manager>(Global.hardware_conf);
 	}
 #endif
 #ifdef WITH_ZMQ

--- a/application/drivermode.cpp
+++ b/application/drivermode.cpp
@@ -266,6 +266,14 @@ bool driver_mode::update()
 
 		// variable step simulation time routines
 
+		if (change_train.empty() && !Global.network_pending_vehicle.empty())
+		{
+			// vehicle picked in the multiplayer lobby; the cab itself is built by the
+			// replicated entervehicle command, we only have to move in once it exists
+			change_train = Global.network_pending_vehicle;
+			Global.network_pending_vehicle.clear();
+		}
+
 		if (!change_train.empty())
 		{
 			TTrain *train = simulation::Trains.find(change_train);
@@ -450,6 +458,15 @@ void driver_mode::enter()
 	{
 		Global.local_start_vehicle = "ghostview";
 		Error("Bad scenario: failed to locate player train, \"" + Global.local_start_vehicle + "\"");
+	}
+
+	if (Application.is_server() || Application.is_client())
+	{
+		// in a multiplayer session nobody is dropped into a random vehicle: the roster
+		// published by the server is offered instead, and stays available for later switches
+		auto ui = std::dynamic_pointer_cast<driver_ui>(m_userinterface);
+		if (ui != nullptr)
+			ui->show_multiplayer_lobby(nPlayerTrain == nullptr);
 	}
 
 	// if (!Global.bMultiplayer) //na razie włączone

--- a/application/drivermode.cpp
+++ b/application/drivermode.cpp
@@ -31,6 +31,7 @@ http://mozilla.org/MPL/2.0/.
 #include "utilities/Logs.h"
 #include "network/entities.h"
 #include "network/snapshot.h"
+#include "network/session.h"
 /*
 namespace input {
 
@@ -213,6 +214,17 @@ bool driver_mode::update()
 	if (!change_train.empty())
 	{
 		TTrain *train = simulation::Trains.find(change_train);
+
+		if ((train == nullptr) && network::is_multiplayer())
+		{
+			// a cab belongs to the peer it is on: each player has their own, with their own
+			// camera and their own view of it. waiting for a replicated command to build it
+			// only ever worked for the first person aboard a train - the second finds the
+			// cab already standing on the peer that got there first, so nothing is posted
+			// and the lobby button appears to do nothing at all
+			train = network::ensure_local_cab(simulation::Vehicles.find(change_train));
+		}
+
 		if (train)
 		{
 			Global.local_start_vehicle = change_train;
@@ -540,20 +552,6 @@ void driver_mode::on_key(int const Key, int const Scancode, int const Action, in
 
 	bool anyModifier = Mods & (GLFW_MOD_SHIFT | GLFW_MOD_CONTROL | GLFW_MOD_ALT);
 
-	// the key left of 1 opens and closes the session chat. it is only bound in a session,
-	// so single player keeps it for whatever else may want it later. while the chat has
-	// the keyboard this is never reached: imgui swallows the input before it gets here,
-	// which is exactly what stops typed letters from working the cab
-	if ((Key == GLFW_KEY_GRAVE_ACCENT) && (Action == GLFW_PRESS) && !anyModifier && network::is_multiplayer())
-	{
-		auto ui = std::dynamic_pointer_cast<driver_ui>(m_userinterface);
-		if (ui != nullptr)
-		{
-			ui->toggle_chat();
-			return;
-		}
-	}
-
 	// give the ui first shot at the input processing...
 	if (!anyModifier && true == m_userinterface->on_key(Key, Action))
 	{
@@ -627,6 +625,16 @@ void driver_mode::on_event_poll()
 {
 
 	m_input.poll();
+}
+
+bool driver_mode::toggle_chat()
+{
+	auto ui = std::dynamic_pointer_cast<driver_ui>(m_userinterface);
+	if (ui == nullptr)
+		return false;
+
+	ui->toggle_chat();
+	return true;
 }
 
 bool driver_mode::is_command_processor() const

--- a/application/drivermode.cpp
+++ b/application/drivermode.cpp
@@ -266,6 +266,22 @@ bool driver_mode::update()
 
 		// variable step simulation time routines
 
+		if (Global.network_leave_pending)
+		{
+			// we were taken off the crew (by our own request or by the server), so the
+			// camera goes back to observing. the cab instance itself stays put, it may
+			// still be occupied by somebody else or handed back to the AI
+			Global.network_leave_pending = false;
+			if (simulation::Train != nullptr)
+			{
+				if (!FreeFlyModeFlag)
+					InOutKey();
+				simulation::Train = nullptr;
+				Camera.m_owner = nullptr;
+				Global.local_start_vehicle = "ghostview";
+			}
+		}
+
 		if (change_train.empty() && !Global.network_pending_vehicle.empty())
 		{
 			// vehicle picked in the multiplayer lobby; the cab itself is built by the
@@ -282,8 +298,17 @@ bool driver_mode::update()
 				Global.local_start_vehicle = change_train;
 				simulation::Train = train;
 				InOutKey();
-				m_relay.post(user_command::aidriverdisable, 0.0, 0.0, GLFW_PRESS, 0);
+				if (!Application.is_server() && !Application.is_client())
+				{
+					// in a multiplayer session the AI handover belongs to the server, which
+					// also knows whether the vehicle had an AI driver in the first place
+					m_relay.post(user_command::aidriverdisable, 0.0, 0.0, GLFW_PRESS, 0);
+				}
 				change_train.clear();
+
+				auto ui = std::dynamic_pointer_cast<driver_ui>(m_userinterface);
+				if (ui != nullptr)
+					ui->show_multiplayer_lobby(false);
 			}
 		}
 

--- a/application/drivermode.cpp
+++ b/application/drivermode.cpp
@@ -183,6 +183,54 @@ bool driver_mode::update()
 	simulation::State.update_scripting_interface();
 	simulation::Environment.update();
 
+	// taking a seat has to work whether the world is running or not: a player sitting
+	// in the lobby with the game paused still expects the button to put them in the cab
+	if (Global.network_leave_pending)
+	{
+		// we were taken off the crew (by our own request or by the server), so the
+		// camera goes back to observing. the cab instance itself stays put, it may
+		// still be occupied by somebody else or handed back to the AI
+		Global.network_leave_pending = false;
+		if (simulation::Train != nullptr)
+		{
+			if (!FreeFlyModeFlag)
+				InOutKey();
+			simulation::Train = nullptr;
+			Camera.m_owner = nullptr;
+			Global.local_start_vehicle = "ghostview";
+		}
+	}
+
+	if (change_train.empty() && !Global.network_pending_vehicle.empty())
+	{
+		// vehicle picked in the multiplayer lobby; the cab itself is built by the
+		// replicated entervehicle command, we only have to move in once it exists
+		change_train = Global.network_pending_vehicle;
+		Global.network_pending_vehicle.clear();
+	}
+
+	if (!change_train.empty())
+	{
+		TTrain *train = simulation::Trains.find(change_train);
+		if (train)
+		{
+			Global.local_start_vehicle = change_train;
+			simulation::Train = train;
+			InOutKey();
+			if (!Application.is_server() && !Application.is_client())
+			{
+				// in a multiplayer session the AI handover belongs to the server, which
+				// also knows whether the vehicle had an AI driver in the first place
+				m_relay.post(user_command::aidriverdisable, 0.0, 0.0, GLFW_PRESS, 0);
+			}
+			change_train.clear();
+
+			auto ui = std::dynamic_pointer_cast<driver_ui>(m_userinterface);
+			if (ui != nullptr)
+				ui->show_multiplayer_lobby(false);
+		}
+	}
+
 	if (deltatime != 0.0 || false == simulation::is_ready)
 	{
 		// jak pauza, to nie ma po co tego przeliczać
@@ -266,52 +314,6 @@ bool driver_mode::update()
 		}
 
 		// variable step simulation time routines
-
-		if (Global.network_leave_pending)
-		{
-			// we were taken off the crew (by our own request or by the server), so the
-			// camera goes back to observing. the cab instance itself stays put, it may
-			// still be occupied by somebody else or handed back to the AI
-			Global.network_leave_pending = false;
-			if (simulation::Train != nullptr)
-			{
-				if (!FreeFlyModeFlag)
-					InOutKey();
-				simulation::Train = nullptr;
-				Camera.m_owner = nullptr;
-				Global.local_start_vehicle = "ghostview";
-			}
-		}
-
-		if (change_train.empty() && !Global.network_pending_vehicle.empty())
-		{
-			// vehicle picked in the multiplayer lobby; the cab itself is built by the
-			// replicated entervehicle command, we only have to move in once it exists
-			change_train = Global.network_pending_vehicle;
-			Global.network_pending_vehicle.clear();
-		}
-
-		if (!change_train.empty())
-		{
-			TTrain *train = simulation::Trains.find(change_train);
-			if (train)
-			{
-				Global.local_start_vehicle = change_train;
-				simulation::Train = train;
-				InOutKey();
-				if (!Application.is_server() && !Application.is_client())
-				{
-					// in a multiplayer session the AI handover belongs to the server, which
-					// also knows whether the vehicle had an AI driver in the first place
-					m_relay.post(user_command::aidriverdisable, 0.0, 0.0, GLFW_PRESS, 0);
-				}
-				change_train.clear();
-
-				auto ui = std::dynamic_pointer_cast<driver_ui>(m_userinterface);
-				if (ui != nullptr)
-					ui->show_multiplayer_lobby(false);
-			}
-		}
 
 		if (simulation::Train == nullptr && false == FreeFlyModeFlag)
 		{

--- a/application/drivermode.cpp
+++ b/application/drivermode.cpp
@@ -540,6 +540,20 @@ void driver_mode::on_key(int const Key, int const Scancode, int const Action, in
 
 	bool anyModifier = Mods & (GLFW_MOD_SHIFT | GLFW_MOD_CONTROL | GLFW_MOD_ALT);
 
+	// the key left of 1 opens and closes the session chat. it is only bound in a session,
+	// so single player keeps it for whatever else may want it later. while the chat has
+	// the keyboard this is never reached: imgui swallows the input before it gets here,
+	// which is exactly what stops typed letters from working the cab
+	if ((Key == GLFW_KEY_GRAVE_ACCENT) && (Action == GLFW_PRESS) && !anyModifier && network::is_multiplayer())
+	{
+		auto ui = std::dynamic_pointer_cast<driver_ui>(m_userinterface);
+		if (ui != nullptr)
+		{
+			ui->toggle_chat();
+			return;
+		}
+	}
+
 	// give the ui first shot at the input processing...
 	if (!anyModifier && true == m_userinterface->on_key(Key, Action))
 	{

--- a/application/drivermode.cpp
+++ b/application/drivermode.cpp
@@ -29,6 +29,7 @@ http://mozilla.org/MPL/2.0/.
 #include "utilities/Timer.h"
 #include "rendering/renderer.h"
 #include "utilities/Logs.h"
+#include "network/entities.h"
 /*
 namespace input {
 
@@ -454,7 +455,11 @@ bool driver_mode::update()
 
 	GfxRenderer->Update(deltarealtime);
 
-	simulation::is_ready = simulation::is_ready || (simulation::Train != nullptr && simulation::Train->is_cab_initialized) || Global.local_start_vehicle == "ghostview";
+	simulation::is_ready = simulation::is_ready || (simulation::Train != nullptr && simulation::Train->is_cab_initialized) || Global.local_start_vehicle == "ghostview"
+	                       // in a session a player with no cab is an observer waiting in the
+	                       // lobby, not a game still loading: the world has to be drawn for
+	                       // them, or they are left staring at a black screen
+	                       || (network::is_multiplayer() && simulation::Train == nullptr);
 
 	return true;
 }

--- a/application/drivermode.h
+++ b/application/drivermode.h
@@ -20,6 +20,9 @@ http://mozilla.org/MPL/2.0/.
 #ifdef WITH_UART
 #include "utilities/uart.h"
 #endif
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+#include "hardware/hardware_manager.h"
+#endif
 #ifdef WITH_ZMQ
 #include "input/zmq_input.h"
 #endif
@@ -75,6 +78,9 @@ private:
 #endif
 #ifdef WITH_UART
         std::unique_ptr<uart_input> uart;
+#endif
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+        std::unique_ptr<hardware::hardware_manager> hardware;
 #endif
 #ifdef WITH_ZMQ
         std::unique_ptr<zmq_input> zmq;

--- a/application/drivermode.h
+++ b/application/drivermode.h
@@ -49,6 +49,8 @@ public:
     void on_scroll( double Xoffset, double Yoffset ) override;
 	void on_window_resize( int w, int h ) override { ; }
     void on_event_poll() override;
+    // opens or closes the session chat
+    bool toggle_chat() override;
     bool is_command_processor() const override;
 
 private:

--- a/application/driveruilayer.cpp
+++ b/application/driveruilayer.cpp
@@ -282,7 +282,7 @@ void driver_ui::render_()
 		ImGui::OpenPopup(popupheader);
 	}
 
-	if (Global.network_position_error > 1.0f)
+	if (Global.network_position_error > 0.5f)
 	{
 		ImGui::SetNextWindowSize(ImVec2(-1, -1));
 		if (ImGui::Begin("network", nullptr, ImGuiWindowFlags_NoCollapse))

--- a/application/driveruilayer.cpp
+++ b/application/driveruilayer.cpp
@@ -54,6 +54,10 @@ driver_ui::driver_ui()
 	m_transcriptspanel.size_min = {435, 85};
 	m_transcriptspanel.size_max = {Global.fb_size.x * 0.95, Global.fb_size.y * 0.95};
 
+	m_multiplayerlobby.title = STR("Multiplayer lobby");
+	m_multiplayerlobby.size_min = {560, 320};
+	m_multiplayerlobby.size_max = {Global.fb_size.x * 0.95f, Global.fb_size.y * 0.95f};
+
 	if (Global.gui_defaultwindows)
 	{
 		m_aidpanel.is_open = true;
@@ -278,11 +282,11 @@ void driver_ui::render_()
 		ImGui::OpenPopup(popupheader);
 	}
 
-	if (Global.desync != 0.0f)
+	if (Global.network_position_error > 1.0f)
 	{
 		ImGui::SetNextWindowSize(ImVec2(-1, -1));
 		if (ImGui::Begin("network", nullptr, ImGuiWindowFlags_NoCollapse))
-			ImGui::Text("out of step with the server for %d ticks (at %llu)", (int)Global.desync, (unsigned long long)Global.simulation_tick);
+			ImGui::Text("%.1f m behind the server (tick %llu)", Global.network_position_error, (unsigned long long)Global.simulation_tick);
 		ImGui::End();
 	}
 }

--- a/application/driveruilayer.cpp
+++ b/application/driveruilayer.cpp
@@ -282,11 +282,4 @@ void driver_ui::render_()
 		ImGui::OpenPopup(popupheader);
 	}
 
-	if (Global.network_position_error > 0.5f)
-	{
-		ImGui::SetNextWindowSize(ImVec2(-1, -1));
-		if (ImGui::Begin("network", nullptr, ImGuiWindowFlags_NoCollapse))
-			ImGui::Text("%.1f m behind the server (tick %llu)", Global.network_position_error, (unsigned long long)Global.simulation_tick);
-		ImGui::End();
-	}
 }

--- a/application/driveruilayer.cpp
+++ b/application/driveruilayer.cpp
@@ -282,7 +282,7 @@ void driver_ui::render_()
 	{
 		ImGui::SetNextWindowSize(ImVec2(-1, -1));
 		if (ImGui::Begin("network", nullptr, ImGuiWindowFlags_NoCollapse))
-			ImGui::Text("desync: %0.2f", Global.desync);
+			ImGui::Text("out of step with the server for %d ticks (at %llu)", (int)Global.desync, (unsigned long long)Global.simulation_tick);
 		ImGui::End();
 	}
 }

--- a/application/driveruilayer.cpp
+++ b/application/driveruilayer.cpp
@@ -38,6 +38,7 @@ driver_ui::driver_ui()
 	add_external_panel(&m_perfgraphpanel);
 	add_external_panel(&m_cameraviewpanel);
 	add_external_panel(&m_multiplayerlobby);
+	add_external_panel(&m_chatpanel);
 	m_logpanel.is_open = false;
 
 	m_aidpanel.title = STR("Driving Aid");
@@ -53,6 +54,8 @@ driver_ui::driver_ui()
 	m_transcriptspanel.title = STR("Transcripts");
 	m_transcriptspanel.size_min = {435, 85};
 	m_transcriptspanel.size_max = {Global.fb_size.x * 0.95, Global.fb_size.y * 0.95};
+
+	m_chatpanel.title = STR("Chat");
 
 	m_multiplayerlobby.title = STR("Multiplayer lobby");
 	m_multiplayerlobby.size_min = {560, 320};
@@ -93,7 +96,10 @@ void driver_ui::render_menu_contents()
 			m_timepanel.open();
 
 		if (Application.is_server() || Application.is_client())
+		{
 			ImGui::MenuItem(m_multiplayerlobby.name().c_str(), nullptr, &m_multiplayerlobby.is_open);
+			ImGui::MenuItem(m_chatpanel.name().c_str(), "`", &m_chatpanel.is_open);
+		}
 
 		ImGui::EndMenu();
 	}
@@ -102,6 +108,13 @@ void driver_ui::render_menu_contents()
 void driver_ui::show_multiplayer_lobby(bool const Show)
 {
 	m_multiplayerlobby.is_open = Show;
+}
+
+void driver_ui::toggle_chat()
+{
+	m_chatpanel.is_open = !m_chatpanel.is_open;
+	if (m_chatpanel.is_open)
+		m_chatpanel.focus_input();
 }
 
 void driver_ui::showDebugUI()

--- a/application/driveruilayer.cpp
+++ b/application/driveruilayer.cpp
@@ -37,6 +37,7 @@ driver_ui::driver_ui()
 	add_external_panel(&m_logpanel);
 	add_external_panel(&m_perfgraphpanel);
 	add_external_panel(&m_cameraviewpanel);
+	add_external_panel(&m_multiplayerlobby);
 	m_logpanel.is_open = false;
 
 	m_aidpanel.title = STR("Driving Aid");
@@ -87,8 +88,16 @@ void driver_ui::render_menu_contents()
 		if (ImGui::MenuItem(m_timepanel.name().c_str()))
 			m_timepanel.open();
 
+		if (Application.is_server() || Application.is_client())
+			ImGui::MenuItem(m_multiplayerlobby.name().c_str(), nullptr, &m_multiplayerlobby.is_open);
+
 		ImGui::EndMenu();
 	}
+}
+
+void driver_ui::show_multiplayer_lobby(bool const Show)
+{
+	m_multiplayerlobby.is_open = Show;
 }
 
 void driver_ui::showDebugUI()

--- a/application/driveruilayer.h
+++ b/application/driveruilayer.h
@@ -20,6 +20,7 @@ http://mozilla.org/MPL/2.0/.
 #include "widgets/trainingcard.h"
 #include "widgets/perfgraphs.h"
 #include "widgets/cameraview_extcam.h"
+#include "widgets/multiplayer_lobby.h"
 
 class driver_ui : public ui_layer {
 
@@ -40,6 +41,9 @@ public:
     // updates state of UI elements
     void
         update() override;
+    // opens or closes the multiplayer lobby
+    void
+        show_multiplayer_lobby( bool const Show );
 
 protected:
     void render_menu_contents() override;
@@ -69,4 +73,5 @@ private:
 	ui::map_panel m_mappanel;
 	ui::time_panel m_timepanel;
 	ui::cameraview_panel m_cameraviewpanel;
+	ui::multiplayer_lobby_panel m_multiplayerlobby;
 };

--- a/application/driveruilayer.h
+++ b/application/driveruilayer.h
@@ -21,6 +21,7 @@ http://mozilla.org/MPL/2.0/.
 #include "widgets/perfgraphs.h"
 #include "widgets/cameraview_extcam.h"
 #include "widgets/multiplayer_lobby.h"
+#include "widgets/chat_panel.h"
 
 class driver_ui : public ui_layer {
 
@@ -44,6 +45,9 @@ public:
     // opens or closes the multiplayer lobby
     void
         show_multiplayer_lobby( bool const Show );
+    // opens or closes the session chat, putting the cursor in the box when it opens
+    void
+        toggle_chat();
 
 protected:
     void render_menu_contents() override;
@@ -74,4 +78,5 @@ private:
 	ui::time_panel m_timepanel;
 	ui::cameraview_panel m_cameraviewpanel;
 	ui::multiplayer_lobby_panel m_multiplayerlobby;
+	ui::chat_panel m_chatpanel;
 };

--- a/application/driveruipanels.cpp
+++ b/application/driveruipanels.cpp
@@ -545,6 +545,7 @@ void debug_panel::update()
 	m_powergridlines.clear();
 	m_cameralines.clear();
 	m_rendererlines.clear();
+	m_networklines.clear();
 #ifdef WITH_UART
     m_uartlines.clear();
 #endif
@@ -561,6 +562,11 @@ void debug_panel::update()
 	update_section_powergrid( m_powergridlines );
 	update_section_camera( m_cameralines );
 	update_section_renderer( m_rendererlines );
+	if( Application.is_server() || Application.is_client() ) {
+		update_section_network( m_networklines );
+		net_sent_graph.update( (float)( network::Traffic.sent_rate / 1024.0 ) );
+		net_received_graph.update( (float)( network::Traffic.received_rate / 1024.0 ) );
+	}
 #ifdef WITH_UART
     update_section_uart(m_uartlines);
 #endif
@@ -621,6 +627,13 @@ debug_panel::render() {
         }
         render_section( "Camera", m_cameralines );
         render_section( "Gfx Renderer / Statistics", m_rendererlines );
+        if( ( Application.is_server() || Application.is_client() )
+         && ( true == render_section( "Network", m_networklines ) ) ) {
+            ImGui::TextUnformatted( "sent kB/s" );
+            net_sent_graph.render();
+            ImGui::TextUnformatted( "received kB/s" );
+            net_received_graph.render();
+        }
         render_section_settings();
 		render_section_developer(); // Developer tools
 #ifdef WITH_UART
@@ -1023,6 +1036,70 @@ void debug_panel::graph_data::render() {
 	ImGui::SliderFloat(STR_C("##Range"), &range, 0.5f, 60.0f, "%.1f");
 	ImGui::PlotLines("##plot", data.data(), data.size(), pos, nullptr, 0.0f, range, ImVec2(0, 100));
 	ImGui::PopID();
+}
+
+namespace {
+
+std::string format_bytes( uint64_t const Bytes ) {
+
+    if( Bytes < 1024ull )              { return std::to_string( Bytes ) + " B"; }
+    if( Bytes < 1024ull * 1024ull )    { return to_string( Bytes / 1024.0, 1 ) + " kB"; }
+    if( Bytes < 1024ull * 1024ull * 1024ull ) { return to_string( Bytes / ( 1024.0 * 1024.0 ), 2 ) + " MB"; }
+    return to_string( Bytes / ( 1024.0 * 1024.0 * 1024.0 ), 2 ) + " GB";
+}
+
+} // namespace
+
+void
+debug_panel::update_section_network( std::vector<text_line> &Output ) {
+
+    auto const host { Application.is_server() };
+    auto const client { Application.is_client() };
+
+    Output.emplace_back(
+        "role: " + std::string( host ? ( client ? "host + client" : "host" ) : "client" )
+        + ", peer " + std::to_string( Global.network_peer_id )
+        + ", tick " + std::to_string( Global.simulation_tick ),
+        Global.UITextColor );
+
+    auto const &traffic { network::Traffic };
+
+    Output.emplace_back(
+        "sent: " + format_bytes( traffic.sent_bytes ) + " in " + std::to_string( traffic.sent_messages ) + " messages"
+        + " (" + to_string( traffic.sent_rate / 1024.0, 2 ) + " kB/s)",
+        Global.UITextColor );
+
+    Output.emplace_back(
+        "received: " + format_bytes( traffic.received_bytes ) + " in " + std::to_string( traffic.received_messages ) + " messages"
+        + " (" + to_string( traffic.received_rate / 1024.0, 2 ) + " kB/s)",
+        Global.UITextColor );
+
+    Output.emplace_back(
+        "total: " + format_bytes( traffic.sent_bytes + traffic.received_bytes )
+        + " (" + to_string( ( traffic.sent_rate + traffic.received_rate ) / 1024.0, 2 ) + " kB/s)",
+        Global.UITextColor );
+
+    if( client ) {
+        Output.emplace_back(
+            "worst vehicle out of place: " + to_string( Global.network_position_error, 2 ) + " m",
+            ( Global.network_position_error > 5.0f ?
+                glm::vec4( 1.f, 0.6f, 0.3f, 1.f ) :
+                Global.UITextColor ) );
+
+        Output.emplace_back(
+            "state digest: " + std::string(
+                Global.network_digest_mismatches == 0 ?
+                    "in step with the server" :
+                    "differing for " + std::to_string( Global.network_digest_mismatches ) + " steps" ),
+            Global.UITextColor );
+    }
+
+    if( !Global.network_lobby_message.empty() ) {
+        Output.emplace_back( "lobby: " + Global.network_lobby_message, glm::vec4( 1.f, 0.6f, 0.3f, 1.f ) );
+    }
+    if( !Global.network_reject_reason.empty() ) {
+        Output.emplace_back( "refused: " + Global.network_reject_reason, glm::vec4( 1.f, 0.4f, 0.3f, 1.f ) );
+    }
 }
 
 std::string

--- a/application/driveruipanels.cpp
+++ b/application/driveruipanels.cpp
@@ -571,6 +571,10 @@ void debug_panel::update()
 
 void
 debug_panel::render() {
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+    // a controller waiting for an answer must be visible whether the panel is open or not
+    render_hardware_prompt();
+#endif
     if( false == is_open ) { return; }
 
 	ImGui::PushFont(ui_layer::font_mono);
@@ -632,15 +636,8 @@ debug_panel::render() {
         }
 #endif
 #ifdef WITH_HARDWARE_PROTOCOL_V2
-        if( true == render_section( "Hardware Protocol v2", m_hardwarelines ) ) {
-            bool logmessages = hardware::debug_flags.log_messages;
-            if( ImGui::Checkbox( "Log protocol messages", &logmessages ) ) {
-                hardware::debug_flags.log_messages = logmessages;
-            }
-            bool logframes = hardware::debug_flags.log_frames;
-            if( ImGui::Checkbox( "Log every frame", &logframes ) ) {
-                hardware::debug_flags.log_frames = logframes;
-            }
+        if( true == ImGui::CollapsingHeader( "Hardware Protocol v2" ) ) {
+            render_section_hardware();
         }
 #endif
         // toggles
@@ -1334,15 +1331,22 @@ debug_panel::update_section_uart( std::vector<text_line> &Output ) {
 #endif
 
 #ifdef WITH_HARDWARE_PROTOCOL_V2
+
+namespace {
+
+char const *const hardware_baudrates[] = {
+    "9600", "19200", "38400", "57600", "115200", "230400", "250000", "500000", "1000000", "2000000" };
+
+} // anonymous namespace
+
 void
 debug_panel::update_section_hardware( std::vector<text_line> &Output ) {
 
     auto const *manager = hardware::hardware_manager::instance();
-    if( ( manager == nullptr ) || ( false == manager->active() ) ) {
-        Output.emplace_back( "(no links configured, add an \"uart2 <port> <baud>\" entry to eu07.ini)", Global.UITextColor );
-        return;
-    }
+    if( manager == nullptr ) { return; }
 
+    // one entry per link, in the same order as the reports; render_section_hardware()
+    // interleaves them with the controls of each link
     for( auto const &report : manager->reports() ) {
 
         auto const &protocol = report.protocol;
@@ -1355,7 +1359,7 @@ debug_panel::update_section_hardware( std::vector<text_line> &Output ) {
 
         textline +=
             "\n" + report.transport_kind + " " + report.endpoint
-            + "  " + hardware::to_string( report.state )
+            + "  " + ( report.enabled ? hardware::to_string( report.state ) : "OFF" )
             + " / " + hardware::to_string( report.session );
 
         if( report.session_id != 0 ) {
@@ -1420,6 +1424,172 @@ debug_panel::update_section_hardware( std::vector<text_line> &Output ) {
         }
 
         Output.emplace_back( textline, Global.UITextColor );
+    }
+}
+
+void
+debug_panel::render_section_hardware() {
+
+    auto *manager = hardware::hardware_manager::instance();
+    if( manager == nullptr ) {
+        ImGui::TextUnformatted( "(the hardware protocol is not running)" );
+        return;
+    }
+
+    auto const &reports = manager->reports();
+    if( m_hardwarefunction.size() < reports.size() ) {
+        m_hardwarefunction.resize( reports.size(), 0 );
+    }
+
+    for( std::size_t index = 0; index < reports.size(); ++index ) {
+
+        auto const &report = reports[ index ];
+        ImGui::PushID( static_cast<int>( index ) );
+        ImGui::Separator();
+
+        if( index < m_hardwarelines.size() ) {
+            auto const &line = m_hardwarelines[ index ];
+            ImGui::TextColored( ImVec4( line.color.r, line.color.g, line.color.b, line.color.a ), "%s", line.data.c_str() );
+        }
+
+        // switching a link off closes its port, so the controller can be reprogrammed
+        if( ImGui::Button( report.enabled ? "Disconnect" : "Connect" ) ) {
+            manager->set_link_enabled( index, false == report.enabled );
+        }
+        ImGui::SameLine();
+        if( ImGui::Button( "Remove" ) ) {
+            manager->remove_link( index );
+            ImGui::PopID();
+            break;
+        }
+
+        if( false == report.functions.empty() ) {
+
+            auto &selection = m_hardwarefunction[ index ];
+            if( selection >= static_cast<int>( report.functions.size() ) ) { selection = 0; }
+            if( selection < 0 ) { selection = 0; }
+
+            std::vector<char const *> names;
+            names.reserve( report.functions.size() );
+            for( auto const &function : report.functions ) {
+                names.emplace_back( function.name.c_str() );
+            }
+
+            bool const running = ( report.diagnostic.state == hardware::diagnostic_state::running );
+
+            ImGui::SetNextItemWidth( 260 * Global.ui_scale );
+            ImGui::Combo( "###diagnosticfunction", &selection, names.data(), static_cast<int>( names.size() ) );
+            ImGui::SameLine();
+            if( true == running ) {
+                if( ImGui::Button( "Cancel" ) ) {
+                    manager->cancel_diagnostic( index );
+                }
+            }
+            else {
+                if( ImGui::Button( "Run diagnostic" ) ) {
+                    manager->start_diagnostic( index, report.functions[ selection ].id );
+                }
+            }
+        }
+
+        if( report.diagnostic.state != hardware::diagnostic_state::idle ) {
+            ImGui::Text(
+                "diagnostic %u: %s %u%% %s",
+                static_cast<unsigned>( report.diagnostic.function ),
+                hardware::to_string( report.diagnostic.state ),
+                static_cast<unsigned>( report.diagnostic.progress ),
+                report.diagnostic.message.c_str() );
+        }
+
+        if( false == report.log.empty() ) {
+            if( true == ImGui::TreeNode( "Device log" ) ) {
+                ImGui::BeginChild( "###devicelog", ImVec2S( 0, 140 ), true );
+                for( auto const &entry : report.log ) {
+                    ImGui::Text(
+                        "[%8.3f] %-7s %s",
+                        entry.device_uptime_ms / 1000.0,
+                        hardware::to_string( entry.severity ),
+                        entry.text.c_str() );
+                }
+                ImGui::EndChild();
+                ImGui::TreePop();
+            }
+        }
+
+        ImGui::PopID();
+    }
+
+    // adding a controller which appeared after the simulation started
+    ImGui::Separator();
+    m_hardwareportnames = manager->available_ports();
+    m_hardwareports.clear();
+    for( auto const &name : m_hardwareportnames ) {
+        m_hardwareports.emplace_back( name.c_str() );
+    }
+
+    if( true == m_hardwareports.empty() ) {
+        ImGui::TextUnformatted( "(no serial ports detected)" );
+    }
+    else {
+        if( m_hardwareport >= static_cast<int>( m_hardwareports.size() ) ) { m_hardwareport = -1; }
+        ImGui::SetNextItemWidth( 140 * Global.ui_scale );
+        ImGui::Combo( "###hardwareport", &m_hardwareport, m_hardwareports.data(), static_cast<int>( m_hardwareports.size() ) );
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth( 120 * Global.ui_scale );
+        ImGui::Combo( "###hardwarebaud", &m_hardwarebaud, hardware_baudrates, static_cast<int>( sizeof( hardware_baudrates ) / sizeof( hardware_baudrates[ 0 ] ) ) );
+        ImGui::SameLine();
+        if( ImGui::Button( "Add controller" ) ) {
+            if( ( m_hardwareport >= 0 ) && ( m_hardwareport < static_cast<int>( m_hardwareportnames.size() ) ) ) {
+                manager->add_serial_link( m_hardwareportnames[ m_hardwareport ], std::atoi( hardware_baudrates[ m_hardwarebaud ] ) );
+            }
+        }
+    }
+
+    ImGui::Separator();
+    bool logmessages = hardware::debug_flags.log_messages;
+    if( ImGui::Checkbox( "Log protocol messages", &logmessages ) ) {
+        hardware::debug_flags.log_messages = logmessages;
+    }
+    bool logframes = hardware::debug_flags.log_frames;
+    if( ImGui::Checkbox( "Log every frame", &logframes ) ) {
+        hardware::debug_flags.log_frames = logframes;
+    }
+}
+
+void
+debug_panel::render_hardware_prompt() {
+
+    auto *manager = hardware::hardware_manager::instance();
+    if( manager == nullptr ) { return; }
+
+    for( auto const &report : manager->reports() ) {
+
+        if( false == report.prompt.active ) { continue; }
+
+        auto const title =
+            ( report.device_name.empty() ? std::string( "Controller" ) : report.device_name )
+            + "###hardwareprompt" + std::to_string( report.index );
+
+        bool open = true;
+        ImGui::SetNextWindowSize( ImVec2S( 420, 0 ), ImGuiCond_Appearing );
+        if( true == ImGui::Begin( title.c_str(), &open, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_AlwaysAutoResize ) ) {
+            ImGui::TextWrapped( "%s", report.prompt.text.c_str() );
+            ImGui::Separator();
+            for( std::size_t option = 0; option < report.prompt.options.size(); ++option ) {
+                if( option > 0 ) { ImGui::SameLine(); }
+                ImGui::PushID( static_cast<int>( option ) );
+                if( ImGui::Button( report.prompt.options[ option ].c_str() ) ) {
+                    manager->answer_prompt( report.index, static_cast<std::uint8_t>( option ) );
+                }
+                ImGui::PopID();
+            }
+        }
+        ImGui::End();
+
+        if( false == open ) {
+            // closing the window without choosing tells the controller the user walked away
+            manager->answer_prompt( report.index, hardware::prompt_dismissed );
+        }
     }
 }
 #endif

--- a/application/driveruipanels.cpp
+++ b/application/driveruipanels.cpp
@@ -38,6 +38,10 @@ http://mozilla.org/MPL/2.0/.
 #include "utilities/uart.h"
 #endif
 
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+#include "hardware/hardware_manager.h"
+#endif
+
 void
 drivingaid_panel::update() {
 
@@ -544,6 +548,9 @@ void debug_panel::update()
 #ifdef WITH_UART
     m_uartlines.clear();
 #endif
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+    m_hardwarelines.clear();
+#endif
 
 	update_section_vehicle( m_vehiclelines );
 	update_section_engine( m_enginelines );
@@ -556,6 +563,9 @@ void debug_panel::update()
 	update_section_renderer( m_rendererlines );
 #ifdef WITH_UART
     update_section_uart(m_uartlines);
+#endif
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+    update_section_hardware(m_hardwarelines);
 #endif
 }
 
@@ -619,6 +629,18 @@ debug_panel::render() {
             ImGui::Combo("Port", &UartStatus.selected_port_index, avlports, ports_num);
             ImGui::Combo("Baud", &UartStatus.selected_baud_index, uart_baudrates_list, uart_baudrates_list_num);
             ImGui::Checkbox("Enabled", &UartStatus.enabled);
+        }
+#endif
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+        if( true == render_section( "Hardware Protocol v2", m_hardwarelines ) ) {
+            bool logmessages = hardware::debug_flags.log_messages;
+            if( ImGui::Checkbox( "Log protocol messages", &logmessages ) ) {
+                hardware::debug_flags.log_messages = logmessages;
+            }
+            bool logframes = hardware::debug_flags.log_frames;
+            if( ImGui::Checkbox( "Log every frame", &logframes ) ) {
+                hardware::debug_flags.log_frames = logframes;
+            }
         }
 #endif
         // toggles
@@ -1308,6 +1330,97 @@ debug_panel::update_section_uart( std::vector<text_line> &Output ) {
         ).c_str(),
         Global.UITextColor
     );
+}
+#endif
+
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+void
+debug_panel::update_section_hardware( std::vector<text_line> &Output ) {
+
+    auto const *manager = hardware::hardware_manager::instance();
+    if( ( manager == nullptr ) || ( false == manager->active() ) ) {
+        Output.emplace_back( "(no links configured, add an \"uart2 <port> <baud>\" entry to eu07.ini)", Global.UITextColor );
+        return;
+    }
+
+    for( auto const &report : manager->reports() ) {
+
+        auto const &protocol = report.protocol;
+
+        std::string textline =
+            ( report.device_name.empty() ? std::string( "(waiting for device)" ) : report.device_name )
+            + ( report.device_role.empty() ? "" : " [" + report.device_role + "]" )
+            + ( report.device_id.empty() ? "" : " id: " + report.device_id )
+            + ( report.firmware_version.empty() ? "" : " fw: " + report.firmware_version );
+
+        textline +=
+            "\n" + report.transport_kind + " " + report.endpoint
+            + "  " + hardware::to_string( report.state )
+            + " / " + hardware::to_string( report.session );
+
+        if( report.session_id != 0 ) {
+            textline +=
+                "\nprotocol v" + std::to_string( report.protocol_major ) + "." + std::to_string( report.protocol_minor )
+                + "  session " + std::to_string( report.session_id )
+                + "  frame " + std::to_string( report.frame_size ) + " b"
+                + "  handles " + std::to_string( report.handles )
+                + "  subscriptions " + std::to_string( report.subscriptions );
+        }
+
+        textline +=
+            "\nrx " + to_string( protocol.rx_rate, 0 ) + " pkt/s"
+            + "  tx " + to_string( protocol.tx_rate, 0 ) + " pkt/s"
+            + "  rtt " + to_string( protocol.round_trip_time_ms, 1 ) + " ms"
+            + "  last frame " + to_string( protocol.last_rx_age, 2 ) + " s ago";
+
+        textline +=
+            "\nframes rx " + std::to_string( protocol.rx_frames ) + " tx " + std::to_string( protocol.tx_frames )
+            + "  bytes rx " + std::to_string( report.transport.rx_bytes ) + " tx " + std::to_string( report.transport.tx_bytes );
+
+        textline +=
+            "\nprotocol errors: crc " + std::to_string( protocol.crc_errors )
+            + "  frame " + std::to_string( protocol.frame_errors )
+            + "  length " + std::to_string( protocol.length_errors )
+            + "  version " + std::to_string( protocol.version_errors )
+            + "  gaps " + std::to_string( protocol.sequence_gaps );
+
+        textline +=
+            "\nunknown: message " + std::to_string( protocol.unknown_messages )
+            + "  symbol " + std::to_string( protocol.unknown_symbols )
+            + "  handle " + std::to_string( protocol.unknown_handles )
+            + "  duplicates " + std::to_string( protocol.duplicate_commands )
+            + "  rate limited " + std::to_string( protocol.rate_limited );
+
+        textline +=
+            "\nack " + std::to_string( protocol.acks )
+            + "  nack " + std::to_string( protocol.nacks )
+            + "  state updates " + std::to_string( protocol.state_updates )
+            + "  commands " + std::to_string( protocol.commands_executed )
+            + "  controls " + std::to_string( protocol.controls_applied );
+
+        textline +=
+            "\nsession uptime " + to_string( protocol.connection_uptime, 0 ) + " s"
+            + "  transport errors " + std::to_string( report.transport.transport_errors )
+            + "  reconnects " + std::to_string( report.transport.reconnects );
+
+        if( false == report.transport.last_error.empty() ) {
+            textline += "\nlast transport error: " + report.transport.last_error;
+        }
+
+        if( true == report.device.available ) {
+            textline +=
+                "\ndevice: uptime " + std::to_string( report.device.uptime_ms / 1000 ) + " s"
+                + ", supply " + to_string( report.device.supply_voltage, 2 ) + " V"
+                + ", temperature " + to_string( report.device.temperature, 1 ) + " deg C"
+                + ", overflows rx " + std::to_string( report.device.rx_overflows ) + " tx " + std::to_string( report.device.tx_overflows )
+                + ", watchdog resets " + std::to_string( report.device.watchdog_resets );
+            if( false == report.device.firmware_build.empty() ) {
+                textline += ", build " + report.device.firmware_build;
+            }
+        }
+
+        Output.emplace_back( textline, Global.UITextColor );
+    }
 }
 #endif
 

--- a/application/driveruipanels.h
+++ b/application/driveruipanels.h
@@ -89,6 +89,7 @@ private:
     void update_section_powergrid( std::vector<text_line> &Output );
     void update_section_camera( std::vector<text_line> &Output );
     void update_section_renderer( std::vector<text_line> &Output );
+    void update_section_network( std::vector<text_line> &Output );
 #ifdef WITH_UART
     void update_section_uart( std::vector<text_line> &Output );
 #endif
@@ -123,6 +124,7 @@ private:
         m_eventqueuelines,
         m_powergridlines,
         m_rendererlines,
+        m_networklines,
         m_uartlines,
         m_hardwarelines;
 
@@ -149,6 +151,9 @@ private:
 	};
 	graph_data AccN_jerk_graph;
 	graph_data AccN_acc_graph;
+	// kilobytes per second in and out, so the cost of a session can be read off a chart
+	graph_data net_sent_graph;
+	graph_data net_received_graph;
 	float last_AccN;
 
 	std::array<char, 128> queue_event_buf = { 0 };

--- a/application/driveruipanels.h
+++ b/application/driveruipanels.h
@@ -92,6 +92,9 @@ private:
 #ifdef WITH_UART
     void update_section_uart( std::vector<text_line> &Output );
 #endif
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+    void update_section_hardware( std::vector<text_line> &Output );
+#endif
     // section update helpers
     std::string update_vehicle_coupler( int const Side );
     std::string update_vehicle_brake() const;
@@ -116,7 +119,8 @@ private:
         m_eventqueuelines,
         m_powergridlines,
         m_rendererlines,
-        m_uartlines;
+        m_uartlines,
+        m_hardwarelines;
 
 	double last_time = std::numeric_limits<double>::quiet_NaN();
 

--- a/application/driveruipanels.h
+++ b/application/driveruipanels.h
@@ -94,6 +94,10 @@ private:
 #endif
 #ifdef WITH_HARDWARE_PROTOCOL_V2
     void update_section_hardware( std::vector<text_line> &Output );
+    // interactive part of the hardware section: connect, disconnect, diagnostics
+    void render_section_hardware();
+    // message box a controller asked the simulator to show; rendered as its own window
+    void render_hardware_prompt();
 #endif
     // section update helpers
     std::string update_vehicle_coupler( int const Side );
@@ -121,6 +125,15 @@ private:
         m_rendererlines,
         m_uartlines,
         m_hardwarelines;
+
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+    // debug panel state for the hardware protocol section
+    std::vector<int> m_hardwarefunction; // selected diagnostic function, per link
+    std::vector<char const *> m_hardwareports; // port names for the combo, valid for one frame
+    std::vector<std::string> m_hardwareportnames;
+    int m_hardwareport { -1 };
+    int m_hardwarebaud { 4 }; // 115200
+#endif
 
 	double last_time = std::numeric_limits<double>::quiet_NaN();
 

--- a/application/scenarioloadermode.cpp
+++ b/application/scenarioloadermode.cpp
@@ -19,6 +19,7 @@ http://mozilla.org/MPL/2.0/.
 #include "rendering/renderer.h"
 #include "utilities/Logs.h"
 #include "utilities/translation.h"
+#include "network/entities.h"
 
 scenarioloader_mode::scenarioloader_mode() {
     m_userinterface = std::make_shared<scenarioloader_ui>();
@@ -59,6 +60,11 @@ bool scenarioloader_mode::update() {
 	catch (invalid_scenery_exception &e) {
 		ErrorLog( "Bad init: scenario loading failed" );
 		Application.pop_mode();
+	}
+
+	if( Application.is_server() ) {
+		// the server owns the vehicle numbering for the whole session and publishes it
+		network::Entities.build();
 	}
 
 	WriteLog( "Scenario loading time: " + std::to_string( std::chrono::duration_cast<std::chrono::seconds>( std::chrono::system_clock::now() - timestart ).count() ) + " seconds" );

--- a/application/scenarioloadermode.cpp
+++ b/application/scenarioloadermode.cpp
@@ -32,9 +32,14 @@ bool scenarioloader_mode::init() {
 
 // mode-specific update of simulation data. returns: false on error, true otherwise
 bool scenarioloader_mode::update() {
-	if (!Global.ready_to_load)
-		// waiting for network connection
+	if (!Global.ready_to_load) {
+		// waiting for the network handshake to tell us which scenario to load
+		m_userinterface->set_progress(
+		    Global.network_status.empty()
+		        ? STR("Connecting to server")
+		        : Global.network_status);
 		return true;
+	}
 
 	if (!state) {
 		WriteLog("using simulation seed: " + std::to_string(Global.random_seed), logtype::generic);
@@ -76,8 +81,15 @@ void scenarioloader_mode::enter() {
 
     simulation::is_ready = false;
 
-    Application.set_title( Global.AppName + " (" + Global.SceneryFile + ")" );
-	m_userinterface->set_progress(STR("Loading scenery"));
+    if( Global.SceneryFile.empty() ) {
+        // multiplayer client: the scenario is not known until the server answers
+        Application.set_title( Global.AppName );
+        m_userinterface->set_progress( STR( "Connecting to server" ) );
+    }
+    else {
+        Application.set_title( Global.AppName + " (" + Global.SceneryFile + ")" );
+        m_userinterface->set_progress(STR("Loading scenery"));
+    }
 }
 
 // maintenance method, called when the mode is deactivated

--- a/application/scenarioloadermode.cpp
+++ b/application/scenarioloadermode.cpp
@@ -62,6 +62,10 @@ bool scenarioloader_mode::update() {
 		Application.pop_mode();
 	}
 
+	// the world exists from here on. this is what the network housekeeping waits for;
+	// simulation::is_ready means something else, namely that the player has a cab
+	Global.simulation_loaded = true;
+
 	if( Application.is_server() ) {
 		// the server owns the vehicle numbering for the whole session and publishes it
 		network::Entities.build();

--- a/application/scenarioloadermode.cpp
+++ b/application/scenarioloadermode.cpp
@@ -67,6 +67,10 @@ bool scenarioloader_mode::update() {
 		network::Entities.build();
 	}
 
+	// a client can take the state of the world over now; the server answers with a
+	// snapshot instead of making us replay the session from its first frame
+	Application.network_scenario_loaded();
+
 	WriteLog( "Scenario loading time: " + std::to_string( std::chrono::duration_cast<std::chrono::seconds>( std::chrono::system_clock::now() - timestart ).count() ) + " seconds" );
 	// TODO: implement and use next mode cue
 

--- a/application/uilayer.cpp
+++ b/application/uilayer.cpp
@@ -473,7 +473,9 @@ void ui_layer::render_hierarchy(){
  
 void ui_layer::set_cursor(int const Mode)
 {
-	glfwSetInputMode(m_window, GLFW_CURSOR, Mode);
+	// no window, no cursor to hide
+	if (m_window != nullptr)
+		glfwSetInputMode(m_window, GLFW_CURSOR, Mode);
 	m_cursorvisible = Mode != GLFW_CURSOR_DISABLED;
 }
 

--- a/application/uilayer.cpp
+++ b/application/uilayer.cpp
@@ -112,6 +112,11 @@ bool ui_layer::key_callback(int key, int scancode, int action, int mods)
 	return m_imguiio->WantCaptureKeyboard;
 }
 
+bool ui_layer::wants_keyboard()
+{
+	return (m_imguiio != nullptr) && m_imguiio->WantCaptureKeyboard;
+}
+
 bool ui_layer::char_callback(unsigned int c)
 {
 	ImGui_ImplGlfw_CharCallback(m_window, c);

--- a/application/uilayer.h
+++ b/application/uilayer.h
@@ -115,6 +115,9 @@ public:
     // callback functions for imgui input
     // returns true if input is consumed
     static bool key_callback(int key, int scancode, int action, int mods);
+    // true when something on screen is taking typed input and the game must keep its
+    // hands off the keyboard
+    static bool wants_keyboard();
     static bool char_callback(unsigned int c);
     static bool scroll_callback(double xoffset, double yoffset);
     static bool mouse_button_callback(int button, int action, int mods);

--- a/hardware/diagnostics/hardware_diagnostics.cpp
+++ b/hardware/diagnostics/hardware_diagnostics.cpp
@@ -1,0 +1,28 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "hardware/diagnostics/hardware_diagnostics.h"
+
+namespace hardware
+{
+
+void rate_counter::update( double const Deltatime )
+{
+	m_window += Deltatime;
+	if( m_window < 1.0 )
+	{
+		return;
+	}
+	m_rate = static_cast<float>( m_accumulator / m_window );
+	m_accumulator = 0;
+	m_window = 0.0;
+}
+
+} // namespace hardware

--- a/hardware/diagnostics/hardware_diagnostics.h
+++ b/hardware/diagnostics/hardware_diagnostics.h
@@ -1,0 +1,114 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "hardware/protocol/protocol_defs.h"
+
+// diagnostics gathered per connection, presented in the simulator debug panel
+// transport and protocol problems are counted separately, as they usually have different causes
+
+namespace hardware
+{
+
+// sliding estimate of events per second
+class rate_counter
+{
+
+public:
+// methods
+	void add( std::uint64_t const Count = 1 ) { m_accumulator += Count; }
+	void update( double const Deltatime );
+	float rate() const { return m_rate; }
+
+private:
+// members
+	std::uint64_t m_accumulator = 0;
+	double m_window = 0.0;
+	float m_rate = 0.0f;
+};
+
+struct transport_diagnostics
+{
+	bool connected = false;
+	std::string endpoint;
+	std::string last_error;
+	std::uint64_t rx_bytes = 0;
+	std::uint64_t tx_bytes = 0;
+	std::uint64_t transport_errors = 0;
+	std::uint64_t reconnects = 0;
+};
+
+struct protocol_diagnostics
+{
+	std::uint64_t rx_frames = 0;
+	std::uint64_t tx_frames = 0;
+	std::uint64_t crc_errors = 0;
+	std::uint64_t frame_errors = 0;
+	std::uint64_t length_errors = 0;
+	std::uint64_t version_errors = 0;
+	std::uint64_t unknown_messages = 0;
+	std::uint64_t unknown_handles = 0;
+	std::uint64_t unknown_symbols = 0;
+	std::uint64_t duplicate_commands = 0;
+	std::uint64_t sequence_gaps = 0;
+	std::uint64_t acks = 0;
+	std::uint64_t nacks = 0;
+	std::uint64_t rate_limited = 0;
+	std::uint64_t state_updates = 0;
+	std::uint64_t commands_executed = 0;
+	std::uint64_t controls_applied = 0;
+	// seconds since the last valid frame arrived
+	double last_rx_age = 0.0;
+	double round_trip_time_ms = 0.0;
+	double connection_uptime = 0.0;
+	float rx_rate = 0.0f;
+	float tx_rate = 0.0f;
+	int missed_heartbeats = 0;
+};
+
+// optional information reported by the device itself
+struct device_diagnostics
+{
+	bool available = false;
+	std::uint32_t uptime_ms = 0;
+	float supply_voltage = 0.0f;
+	float temperature = 0.0f;
+	std::uint32_t rx_overflows = 0;
+	std::uint32_t tx_overflows = 0;
+	std::uint32_t watchdog_resets = 0;
+	std::string firmware_build;
+};
+
+// everything the debug panel needs about one connection, copied out once per frame
+struct link_report
+{
+	std::string transport_kind;
+	std::string endpoint;
+	std::string device_name;
+	std::string device_role;
+	std::string device_id;
+	std::string firmware_version;
+	link_state state = link_state::disconnected;
+	session_state session = session_state::disconnected;
+	std::uint32_t session_id = 0;
+	std::uint8_t protocol_major = 0;
+	std::uint8_t protocol_minor = 0;
+	std::size_t handles = 0;
+	std::size_t subscriptions = 0;
+	std::size_t frame_size = 0;
+	transport_diagnostics transport;
+	protocol_diagnostics protocol;
+	device_diagnostics device;
+};
+
+} // namespace hardware

--- a/hardware/diagnostics/hardware_diagnostics.h
+++ b/hardware/diagnostics/hardware_diagnostics.h
@@ -11,6 +11,7 @@ http://mozilla.org/MPL/2.0/.
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "hardware/protocol/protocol_defs.h"
 
@@ -89,6 +90,39 @@ struct device_diagnostics
 	std::string firmware_build;
 };
 
+// one text line sent by the device
+struct device_log_entry
+{
+	log_severity severity = log_severity::info;
+	std::uint32_t device_uptime_ms = 0;
+	std::string text;
+};
+
+// a diagnostic routine the device offers, listed in the debug panel
+struct diagnostic_function
+{
+	std::uint8_t id = 0;
+	std::string name;
+};
+
+// progress of the routine currently running on the device
+struct diagnostic_report
+{
+	diagnostic_state state = diagnostic_state::idle;
+	std::uint8_t function = 0;
+	std::uint8_t progress = 0;
+	std::string message;
+};
+
+// a message box the device asked the simulator to show
+struct diagnostic_prompt
+{
+	bool active = false;
+	std::uint32_t id = 0;
+	std::string text;
+	std::vector<std::string> options;
+};
+
 // everything the debug panel needs about one connection, copied out once per frame
 struct link_report
 {
@@ -106,9 +140,17 @@ struct link_report
 	std::size_t handles = 0;
 	std::size_t subscriptions = 0;
 	std::size_t frame_size = 0;
+	// false when the link was switched off from the debug panel, which releases the port
+	bool enabled = true;
+	// index of the link, as the manager knows it
+	std::size_t index = 0;
 	transport_diagnostics transport;
 	protocol_diagnostics protocol;
 	device_diagnostics device;
+	std::vector<diagnostic_function> functions;
+	diagnostic_report diagnostic;
+	diagnostic_prompt prompt;
+	std::vector<device_log_entry> log;
 };
 
 } // namespace hardware

--- a/hardware/hardware_config.h
+++ b/hardware/hardware_config.h
@@ -9,6 +9,7 @@ http://mozilla.org/MPL/2.0/.
 
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <vector>
 
@@ -52,5 +53,14 @@ struct config
 	// additionally log every frame; very noisy
 	bool debug_frames = false;
 };
+
+// logging switches which can be flipped at run time from the simulator debug panel
+struct debug_switches
+{
+	std::atomic<bool> log_messages { false };
+	std::atomic<bool> log_frames { false };
+};
+
+extern debug_switches debug_flags;
 
 } // namespace hardware

--- a/hardware/hardware_config.h
+++ b/hardware/hardware_config.h
@@ -1,0 +1,56 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "hardware/protocol/protocol_defs.h"
+
+// configuration of the hardware protocol v2, filled from eu07.ini
+// the header deliberately doesn't pull in any transport library, so that it can be included by Globals
+
+namespace hardware
+{
+
+struct serial_link_config
+{
+	std::string port;
+	int baud = 115200;
+};
+
+struct config
+{
+	// v2 is active when at least one link is configured; uart v1 keeps working independently
+	bool enable = false;
+	std::vector<serial_link_config> serial_links;
+
+	std::size_t frame_size = protocol_frame_size_default;
+	int heartbeat_interval_ms = 500;
+	// link is dropped after this many missed heartbeats
+	int heartbeat_timeout_count = 5;
+
+	// per connection safety limits, see the rate limiting chapter of the specification
+	int max_frames_per_second = 500;
+	int max_payload_bytes_per_second = 262144;
+	int max_commands_per_second = 100;
+
+	// interval of the worker thread polling loop, in milliseconds
+	int poll_interval_ms = 1;
+	// delay between reconnection attempts, in seconds
+	float reconnect_interval = 1.0f;
+
+	// verbose protocol logging
+	bool debug = false;
+	// additionally log every frame; very noisy
+	bool debug_frames = false;
+};
+
+} // namespace hardware

--- a/hardware/hardware_manager.cpp
+++ b/hardware/hardware_manager.cpp
@@ -202,6 +202,9 @@ void hardware_link::update( double const Deltatime, state_snapshot const &Snapsh
 	m_lastframeerrors = counters;
 	m_session.add_frame_errors( delta );
 
+	// the session answers a subscription with an immediate snapshot, so it needs the current state first
+	m_session.set_snapshot( Snapshot );
+
 	for( auto const &packet : packets )
 	{
 		m_session.handle_packet( packet );

--- a/hardware/hardware_manager.cpp
+++ b/hardware/hardware_manager.cpp
@@ -30,6 +30,8 @@ constexpr std::size_t read_chunk_size = 4096;
 
 } // anonymous namespace
 
+debug_switches debug_flags;
+
 hardware_manager *hardware_manager::s_instance = nullptr;
 
 hardware_link::hardware_link( std::unique_ptr<hardware_transport> Transport, config const &Config ) : m_transport( std::move( Transport ) ), m_config( Config ), m_session( *this, Config )
@@ -224,6 +226,9 @@ hardware_manager::hardware_manager( config const &Config ) : m_config( Config )
 	}
 #endif
 
+	debug_flags.log_messages = m_config.debug;
+	debug_flags.log_frames = m_config.debug_frames;
+
 	m_reports.resize( m_links.size() );
 
 	if( false == m_links.empty() )
@@ -259,18 +264,28 @@ void hardware_manager::worker()
 	}
 }
 
-void hardware_manager::update( double const Deltatime )
+void hardware_manager::update()
 {
 	if( true == m_links.empty() )
 	{
 		return;
 	}
 
+	// the input polling code doesn't carry a time step, so the sessions get their own
+	auto const now = std::chrono::steady_clock::now();
+	double deltatime = 0.0;
+	if( true == m_updatestarted )
+	{
+		deltatime = std::clamp( std::chrono::duration<double>( now - m_lastupdate ).count(), 0.0, 0.5 );
+	}
+	m_updatestarted = true;
+	m_lastupdate = now;
+
 	state_registry::capture( m_snapshot );
 
 	for( std::size_t index = 0; index < m_links.size(); ++index )
 	{
-		m_links[ index ]->update( Deltatime, m_snapshot );
+		m_links[ index ]->update( deltatime, m_snapshot );
 		m_reports[ index ] = m_links[ index ]->report();
 	}
 }

--- a/hardware/hardware_manager.cpp
+++ b/hardware/hardware_manager.cpp
@@ -27,6 +27,10 @@ constexpr std::size_t rx_queue_limit = 256;
 // frames waiting to be pushed out by the worker thread
 constexpr std::size_t tx_queue_limit = 512;
 constexpr std::size_t read_chunk_size = 4096;
+// how often the list of serial ports is refreshed for the debug panel
+constexpr float port_scan_interval = 2.0f;
+// the worker has nothing to do when no link is configured
+constexpr int idle_poll_interval_ms = 250;
 
 } // anonymous namespace
 
@@ -40,14 +44,21 @@ hardware_link::hardware_link( std::unique_ptr<hardware_transport> Transport, con
 	m_decoder.set_frame_size_limit( m_config.frame_size );
 	m_lastconnectattempt = std::chrono::steady_clock::now() - std::chrono::seconds( 10 );
 
+	m_endpoint = m_transport->endpoint();
 	m_report.transport_kind = m_transport->kind();
-	m_report.endpoint = m_transport->endpoint();
-	m_transportstatus.endpoint = m_report.endpoint;
+	m_report.endpoint = m_endpoint;
+	m_transportstatus.endpoint = m_endpoint;
 }
 
 hardware_link::~hardware_link()
 {
 	m_transport->disconnect();
+}
+
+void hardware_link::set_enabled( bool const Enabled )
+{
+	m_enabled = Enabled;
+	m_report.enabled = Enabled;
 }
 
 void hardware_link::send_packet( packet_header const &Header, std::vector<std::uint8_t> const &Payload )
@@ -66,6 +77,24 @@ void hardware_link::send_packet( packet_header const &Header, std::vector<std::u
 
 void hardware_link::service()
 {
+	if( false == m_enabled )
+	{
+		// the link was switched off from the debug panel; release the port and stay quiet
+		if( true == m_transport->connected() )
+		{
+			m_transport->disconnect();
+			m_writebuffer.clear();
+			m_decoder.reset();
+			std::lock_guard<std::mutex> lock( m_mutex );
+			m_transportstatus.connected = false;
+			m_transportstatus.last_error.clear();
+			m_transportdropped = true;
+			m_rxqueue.clear();
+			m_txqueue.clear();
+		}
+		return;
+	}
+
 	if( false == m_transport->connected() )
 	{
 		auto const now = std::chrono::steady_clock::now();
@@ -213,7 +242,9 @@ void hardware_link::update( double const Deltatime, state_snapshot const &Snapsh
 	m_session.update( Deltatime, Snapshot );
 
 	m_report.transport = status;
+	m_report.enabled = m_enabled;
 	m_report.state = (
+	    false == m_enabled ? link_state::disconnected :
 	    false == status.connected ? link_state::disconnected :
 	    m_session.link_condition() );
 	m_session.fill_report( m_report );
@@ -221,23 +252,24 @@ void hardware_link::update( double const Deltatime, state_snapshot const &Snapsh
 
 hardware_manager::hardware_manager( config const &Config ) : m_config( Config )
 {
+	debug_flags.log_messages = m_config.debug;
+	debug_flags.log_frames = m_config.debug_frames;
+
+	m_lastportscan = std::chrono::steady_clock::now() - std::chrono::seconds( 10 );
+
 #ifdef WITH_UART
 	for( auto const &link : m_config.serial_links )
 	{
-		m_links.emplace_back( std::make_unique<hardware_link>( std::make_unique<serial_transport>( link.port, link.baud ), m_config ) );
+		m_links.emplace_back( std::make_shared<hardware_link>( std::make_unique<serial_transport>( link.port, link.baud ), m_config ) );
 		WriteLog( "hardware: protocol v2 link on " + link.port + " @ " + std::to_string( link.baud ) );
 	}
 #endif
 
-	debug_flags.log_messages = m_config.debug;
-	debug_flags.log_frames = m_config.debug_frames;
-
 	m_reports.resize( m_links.size() );
 
-	if( false == m_links.empty() )
-	{
-		m_thread = std::thread( &hardware_manager::worker, this );
-	}
+	// the worker also runs with no links at all, so that ports can be scanned and controllers
+	// added from the debug panel while the simulation is running
+	m_thread = std::thread( &hardware_manager::worker, this );
 
 	s_instance = this;
 }
@@ -250,27 +282,146 @@ hardware_manager::~hardware_manager()
 	{
 		m_thread.join();
 	}
+	std::lock_guard<std::mutex> lock( m_linksmutex );
 	m_links.clear();
 }
 
 void hardware_manager::worker()
 {
-	auto const interval = std::chrono::milliseconds( std::max( 1, m_config.poll_interval_ms ) );
-
 	while( false == m_quit )
 	{
-		for( auto &link : m_links )
+		std::vector<std::shared_ptr<hardware_link>> links;
+		{
+			std::lock_guard<std::mutex> lock( m_linksmutex );
+			links = m_links;
+		}
+
+		for( auto &link : links )
 		{
 			link->service();
 		}
+
+#ifdef WITH_UART
+		auto const now = std::chrono::steady_clock::now();
+		if( std::chrono::duration<float>( now - m_lastportscan ).count() > port_scan_interval )
+		{
+			m_lastportscan = now;
+			auto ports = list_serial_ports();
+			std::lock_guard<std::mutex> lock( m_portsmutex );
+			m_ports = std::move( ports );
+		}
+#endif
+
+		auto const interval = std::chrono::milliseconds( links.empty() ? idle_poll_interval_ms : std::max( 1, m_config.poll_interval_ms ) );
 		std::this_thread::sleep_for( interval );
+	}
+}
+
+std::shared_ptr<hardware_link> hardware_manager::link_at( std::size_t const Index ) const
+{
+	std::lock_guard<std::mutex> lock( m_linksmutex );
+	return ( Index < m_links.size() ? m_links[ Index ] : nullptr );
+}
+
+std::vector<std::string> hardware_manager::available_ports() const
+{
+	std::lock_guard<std::mutex> lock( m_portsmutex );
+	return m_ports;
+}
+
+bool hardware_manager::add_serial_link( std::string const &Port, int const Baud )
+{
+#ifdef WITH_UART
+	if( true == Port.empty() )
+	{
+		return false;
+	}
+
+	std::lock_guard<std::mutex> lock( m_linksmutex );
+	for( auto const &link : m_links )
+	{
+		if( link->endpoint().compare( 0, Port.size() + 1, Port + " " ) == 0 )
+		{
+			// the port already has a link, enabled or not
+			return false;
+		}
+	}
+
+	m_links.emplace_back( std::make_shared<hardware_link>( std::make_unique<serial_transport>( Port, Baud ), m_config ) );
+	WriteLog( "hardware: protocol v2 link added on " + Port + " @ " + std::to_string( Baud ) );
+	return true;
+#else
+	( void )Port;
+	( void )Baud;
+	return false;
+#endif
+}
+
+bool hardware_manager::remove_link( std::size_t const Index )
+{
+	std::lock_guard<std::mutex> lock( m_linksmutex );
+	if( Index >= m_links.size() )
+	{
+		return false;
+	}
+	// the worker may still hold a reference for the rest of its pass; the port is released
+	// when that reference goes away
+	m_links[ Index ]->set_enabled( false );
+	WriteLog( "hardware: protocol v2 link on " + m_links[ Index ]->endpoint() + " removed" );
+	m_links.erase( m_links.begin() + Index );
+	return true;
+}
+
+void hardware_manager::set_link_enabled( std::size_t const Index, bool const Enabled )
+{
+	auto const link = link_at( Index );
+	if( link == nullptr )
+	{
+		return;
+	}
+	if( link->enabled() == Enabled )
+	{
+		return;
+	}
+	link->set_enabled( Enabled );
+	WriteLog( "hardware: protocol v2 link on " + link->endpoint() + ( Enabled ? " connected" : " disconnected" ) );
+}
+
+bool hardware_manager::start_diagnostic( std::size_t const Index, std::uint8_t const Function )
+{
+	auto const link = link_at( Index );
+	return ( link != nullptr ? link->session().start_diagnostic( Function ) : false );
+}
+
+void hardware_manager::cancel_diagnostic( std::size_t const Index )
+{
+	auto const link = link_at( Index );
+	if( link != nullptr )
+	{
+		link->session().cancel_diagnostic();
+	}
+}
+
+void hardware_manager::answer_prompt( std::size_t const Index, std::uint8_t const Option )
+{
+	auto const link = link_at( Index );
+	if( link != nullptr )
+	{
+		link->session().answer_prompt( Option );
 	}
 }
 
 void hardware_manager::update()
 {
-	if( true == m_links.empty() )
+	std::vector<std::shared_ptr<hardware_link>> links;
 	{
+		std::lock_guard<std::mutex> lock( m_linksmutex );
+		links = m_links;
+	}
+
+	if( true == links.empty() )
+	{
+		m_reports.clear();
 		return;
 	}
 
@@ -286,10 +437,12 @@ void hardware_manager::update()
 
 	state_registry::capture( m_snapshot );
 
-	for( std::size_t index = 0; index < m_links.size(); ++index )
+	m_reports.resize( links.size() );
+	for( std::size_t index = 0; index < links.size(); ++index )
 	{
-		m_links[ index ]->update( deltatime, m_snapshot );
-		m_reports[ index ] = m_links[ index ]->report();
+		links[ index ]->update( deltatime, m_snapshot );
+		m_reports[ index ] = links[ index ]->report();
+		m_reports[ index ].index = index;
 	}
 }
 

--- a/hardware/hardware_manager.cpp
+++ b/hardware/hardware_manager.cpp
@@ -1,0 +1,278 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "hardware/hardware_manager.h"
+
+#include "utilities/Logs.h"
+
+#ifdef WITH_UART
+#include "hardware/transport/serial_transport.h"
+#endif
+
+namespace hardware
+{
+
+namespace
+{
+
+// received frames waiting to be picked up by the simulation thread
+constexpr std::size_t rx_queue_limit = 256;
+// frames waiting to be pushed out by the worker thread
+constexpr std::size_t tx_queue_limit = 512;
+constexpr std::size_t read_chunk_size = 4096;
+
+} // anonymous namespace
+
+hardware_manager *hardware_manager::s_instance = nullptr;
+
+hardware_link::hardware_link( std::unique_ptr<hardware_transport> Transport, config const &Config ) : m_transport( std::move( Transport ) ), m_config( Config ), m_session( *this, Config )
+{
+	m_readbuffer.resize( read_chunk_size );
+	m_decoder.set_frame_size_limit( m_config.frame_size );
+	m_lastconnectattempt = std::chrono::steady_clock::now() - std::chrono::seconds( 10 );
+
+	m_report.transport_kind = m_transport->kind();
+	m_report.endpoint = m_transport->endpoint();
+	m_transportstatus.endpoint = m_report.endpoint;
+}
+
+hardware_link::~hardware_link()
+{
+	m_transport->disconnect();
+}
+
+void hardware_link::send_packet( packet_header const &Header, std::vector<std::uint8_t> const &Payload )
+{
+	std::vector<std::uint8_t> frame;
+	encode_frame( Header, Payload.data(), Payload.size(), frame );
+
+	std::lock_guard<std::mutex> lock( m_mutex );
+	if( m_txqueue.size() >= tx_queue_limit )
+	{
+		// the device isn't keeping up; the oldest update is the least interesting one
+		m_txqueue.pop_front();
+	}
+	m_txqueue.emplace_back( std::move( frame ) );
+}
+
+void hardware_link::service()
+{
+	if( false == m_transport->connected() )
+	{
+		auto const now = std::chrono::steady_clock::now();
+		if( std::chrono::duration<float>( now - m_lastconnectattempt ).count() < m_config.reconnect_interval )
+		{
+			return;
+		}
+		m_lastconnectattempt = now;
+
+		if( true == m_transport->connect() )
+		{
+			m_decoder.reset();
+			std::lock_guard<std::mutex> lock( m_mutex );
+			m_rxqueue.clear();
+			m_txqueue.clear();
+			m_transportstatus.connected = true;
+			m_transportstatus.last_error.clear();
+			++m_transportstatus.reconnects;
+		}
+		else
+		{
+			std::lock_guard<std::mutex> lock( m_mutex );
+			if( true == m_transportstatus.last_error.empty() )
+			{
+				++m_transportstatus.transport_errors;
+			}
+			m_transportstatus.connected = false;
+			m_transportstatus.last_error = m_transport->last_error();
+		}
+		return;
+	}
+
+	bool failed = false;
+
+	// inbound
+	std::vector<decoded_packet> packets;
+	int const received = m_transport->read( m_readbuffer.data(), m_readbuffer.size() );
+	if( received < 0 )
+	{
+		failed = true;
+	}
+	else if( received > 0 )
+	{
+		m_decoder.feed( m_readbuffer.data(), static_cast<std::size_t>( received ), packets );
+	}
+
+	// outbound; partially written frames are kept until the port accepts the rest
+	if( false == failed )
+	{
+		if( true == m_writebuffer.empty() )
+		{
+			std::lock_guard<std::mutex> lock( m_mutex );
+			while( ( false == m_txqueue.empty() ) && ( m_writebuffer.size() < read_chunk_size ) )
+			{
+				auto const &frame = m_txqueue.front();
+				m_writebuffer.insert( m_writebuffer.end(), frame.begin(), frame.end() );
+				m_txqueue.pop_front();
+			}
+		}
+
+		if( false == m_writebuffer.empty() )
+		{
+			int const written = m_transport->write( m_writebuffer.data(), m_writebuffer.size() );
+			if( written < 0 )
+			{
+				failed = true;
+			}
+			else if( written > 0 )
+			{
+				m_writebuffer.erase( m_writebuffer.begin(), m_writebuffer.begin() + written );
+				std::lock_guard<std::mutex> lock( m_mutex );
+				m_transportstatus.tx_bytes += written;
+			}
+		}
+	}
+
+	if( true == failed )
+	{
+		m_transport->disconnect();
+		m_writebuffer.clear();
+		m_decoder.reset();
+		std::lock_guard<std::mutex> lock( m_mutex );
+		m_transportstatus.connected = false;
+		++m_transportstatus.transport_errors;
+		m_transportstatus.last_error = m_transport->last_error();
+		m_transportdropped = true;
+		m_rxqueue.clear();
+		m_txqueue.clear();
+		return;
+	}
+
+	std::lock_guard<std::mutex> lock( m_mutex );
+	if( received > 0 )
+	{
+		m_transportstatus.rx_bytes += received;
+	}
+	m_framecounters = m_decoder.stats();
+	for( auto &packet : packets )
+	{
+		if( m_rxqueue.size() >= rx_queue_limit )
+		{
+			m_rxqueue.pop_front();
+		}
+		m_rxqueue.emplace_back( std::move( packet ) );
+	}
+}
+
+void hardware_link::update( double const Deltatime, state_snapshot const &Snapshot )
+{
+	std::deque<decoded_packet> packets;
+	transport_diagnostics status;
+	frame_decoder::counters counters;
+	bool dropped = false;
+
+	{
+		std::lock_guard<std::mutex> lock( m_mutex );
+		packets.swap( m_rxqueue );
+		status = m_transportstatus;
+		counters = m_framecounters;
+		dropped = m_transportdropped;
+		m_transportdropped = false;
+	}
+
+	if( true == dropped )
+	{
+		m_session.reset();
+	}
+
+	frame_decoder::counters delta;
+	delta.frames = counters.frames - m_lastframeerrors.frames;
+	delta.crc_errors = counters.crc_errors - m_lastframeerrors.crc_errors;
+	delta.frame_errors = counters.frame_errors - m_lastframeerrors.frame_errors;
+	delta.length_errors = counters.length_errors - m_lastframeerrors.length_errors;
+	m_lastframeerrors = counters;
+	m_session.add_frame_errors( delta );
+
+	for( auto const &packet : packets )
+	{
+		m_session.handle_packet( packet );
+	}
+
+	m_session.update( Deltatime, Snapshot );
+
+	m_report.transport = status;
+	m_report.state = (
+	    false == status.connected ? link_state::disconnected :
+	    m_session.link_condition() );
+	m_session.fill_report( m_report );
+}
+
+hardware_manager::hardware_manager( config const &Config ) : m_config( Config )
+{
+#ifdef WITH_UART
+	for( auto const &link : m_config.serial_links )
+	{
+		m_links.emplace_back( std::make_unique<hardware_link>( std::make_unique<serial_transport>( link.port, link.baud ), m_config ) );
+		WriteLog( "hardware: protocol v2 link on " + link.port + " @ " + std::to_string( link.baud ) );
+	}
+#endif
+
+	m_reports.resize( m_links.size() );
+
+	if( false == m_links.empty() )
+	{
+		m_thread = std::thread( &hardware_manager::worker, this );
+	}
+
+	s_instance = this;
+}
+
+hardware_manager::~hardware_manager()
+{
+	s_instance = nullptr;
+	m_quit = true;
+	if( true == m_thread.joinable() )
+	{
+		m_thread.join();
+	}
+	m_links.clear();
+}
+
+void hardware_manager::worker()
+{
+	auto const interval = std::chrono::milliseconds( std::max( 1, m_config.poll_interval_ms ) );
+
+	while( false == m_quit )
+	{
+		for( auto &link : m_links )
+		{
+			link->service();
+		}
+		std::this_thread::sleep_for( interval );
+	}
+}
+
+void hardware_manager::update( double const Deltatime )
+{
+	if( true == m_links.empty() )
+	{
+		return;
+	}
+
+	state_registry::capture( m_snapshot );
+
+	for( std::size_t index = 0; index < m_links.size(); ++index )
+	{
+		m_links[ index ]->update( Deltatime, m_snapshot );
+		m_reports[ index ] = m_links[ index ]->report();
+	}
+}
+
+} // namespace hardware

--- a/hardware/hardware_manager.h
+++ b/hardware/hardware_manager.h
@@ -82,8 +82,8 @@ public:
 	explicit hardware_manager( config const &Config );
 	~hardware_manager();
 
-	// called once per simulation frame from the input polling code
-	void update( double const Deltatime );
+	// called once per simulation frame from the input polling code; the time step is measured here
+	void update();
 
 	std::vector<link_report> const &reports() const { return m_reports; }
 	bool active() const { return false == m_links.empty(); }
@@ -102,6 +102,8 @@ private:
 	std::vector<std::unique_ptr<hardware_link>> m_links;
 	std::vector<link_report> m_reports;
 	state_snapshot m_snapshot;
+	std::chrono::steady_clock::time_point m_lastupdate;
+	bool m_updatestarted = false;
 	std::thread m_thread;
 	std::atomic<bool> m_quit { false };
 };

--- a/hardware/hardware_manager.h
+++ b/hardware/hardware_manager.h
@@ -1,0 +1,109 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <atomic>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "hardware/diagnostics/hardware_diagnostics.h"
+#include "hardware/hardware_config.h"
+#include "hardware/protocol/protocol_session.h"
+#include "hardware/transport/hardware_transport.h"
+
+// owner of every hardware protocol v2 connection, regardless of the transport behind it
+//
+// threading: a single worker thread does all of the blocking work, that is opening ports, reading
+// and writing bytes and turning them into frames. the simulation thread only exchanges ready made
+// frames with it through small locked queues, and is the only one which ever touches simulation
+// state. a device which stops responding, floods the link or disappears therefore cannot stall the
+// simulation
+
+namespace hardware
+{
+
+class hardware_link : public session_output
+{
+
+public:
+// methods
+	hardware_link( std::unique_ptr<hardware_transport> Transport, config const &Config );
+	~hardware_link() override;
+
+	// worker thread: services the transport
+	void service();
+	// simulation thread: processes received frames and runs the session
+	void update( double const Deltatime, state_snapshot const &Snapshot );
+	// simulation thread: the report gathered during the last update
+	link_report const &report() const { return m_report; }
+
+	void send_packet( packet_header const &Header, std::vector<std::uint8_t> const &Payload ) override;
+
+private:
+// members
+	std::unique_ptr<hardware_transport> m_transport;
+	config m_config;
+	protocol_session m_session;
+	link_report m_report;
+
+	// worker thread only
+	frame_decoder m_decoder;
+	std::vector<std::uint8_t> m_readbuffer;
+	std::vector<std::uint8_t> m_writebuffer;
+	std::chrono::steady_clock::time_point m_lastconnectattempt;
+
+	// simulation thread only
+	frame_decoder::counters m_lastframeerrors;
+
+	// shared
+	std::mutex m_mutex;
+	std::deque<decoded_packet> m_rxqueue;
+	std::deque<std::vector<std::uint8_t>> m_txqueue;
+	transport_diagnostics m_transportstatus;
+	frame_decoder::counters m_framecounters;
+	bool m_transportdropped = false;
+};
+
+class hardware_manager
+{
+
+public:
+// methods
+	explicit hardware_manager( config const &Config );
+	~hardware_manager();
+
+	// called once per simulation frame from the input polling code
+	void update( double const Deltatime );
+
+	std::vector<link_report> const &reports() const { return m_reports; }
+	bool active() const { return false == m_links.empty(); }
+
+	// the running instance, if any; used by the debug panel
+	static hardware_manager *instance() { return s_instance; }
+
+private:
+// methods
+	void worker();
+
+// members
+	static hardware_manager *s_instance;
+
+	config m_config;
+	std::vector<std::unique_ptr<hardware_link>> m_links;
+	std::vector<link_report> m_reports;
+	state_snapshot m_snapshot;
+	std::thread m_thread;
+	std::atomic<bool> m_quit { false };
+};
+
+} // namespace hardware

--- a/hardware/hardware_manager.h
+++ b/hardware/hardware_manager.h
@@ -28,6 +28,9 @@ http://mozilla.org/MPL/2.0/.
 // frames with it through small locked queues, and is the only one which ever touches simulation
 // state. a device which stops responding, floods the link or disappears therefore cannot stall the
 // simulation
+//
+// links may be added, switched off and removed while the simulation runs, which is what lets the
+// debug panel release a port so that a controller can be reprogrammed and then reconnected
 
 namespace hardware
 {
@@ -46,6 +49,13 @@ public:
 	void update( double const Deltatime, state_snapshot const &Snapshot );
 	// simulation thread: the report gathered during the last update
 	link_report const &report() const { return m_report; }
+	// simulation thread: the session, for the debug panel
+	protocol_session &session() { return m_session; }
+
+	// switching a link off closes the port and stops reconnecting, which frees the device
+	void set_enabled( bool const Enabled );
+	bool enabled() const { return m_enabled; }
+	std::string const &endpoint() const { return m_endpoint; }
 
 	void send_packet( packet_header const &Header, std::vector<std::uint8_t> const &Payload ) override;
 
@@ -55,6 +65,8 @@ private:
 	config m_config;
 	protocol_session m_session;
 	link_report m_report;
+	std::string m_endpoint;
+	std::atomic<bool> m_enabled { true };
 
 	// worker thread only
 	frame_decoder m_decoder;
@@ -86,7 +98,23 @@ public:
 	void update();
 
 	std::vector<link_report> const &reports() const { return m_reports; }
-	bool active() const { return false == m_links.empty(); }
+	bool active() const { return false == m_reports.empty(); }
+
+	// ---- operations available from the debug panel, simulation thread only ----
+
+	// adds a serial link while the simulation runs; false if the port is already in use
+	bool add_serial_link( std::string const &Port, int const Baud );
+	// removes a link; its port is released
+	bool remove_link( std::size_t const Index );
+	// switching a link off releases its port without forgetting the link
+	void set_link_enabled( std::size_t const Index, bool const Enabled );
+
+	bool start_diagnostic( std::size_t const Index, std::uint8_t const Function );
+	void cancel_diagnostic( std::size_t const Index );
+	void answer_prompt( std::size_t const Index, std::uint8_t const Option );
+
+	// serial ports present in the system, refreshed by the worker thread
+	std::vector<std::string> available_ports() const;
 
 	// the running instance, if any; used by the debug panel
 	static hardware_manager *instance() { return s_instance; }
@@ -94,14 +122,21 @@ public:
 private:
 // methods
 	void worker();
+	std::shared_ptr<hardware_link> link_at( std::size_t const Index ) const;
 
 // members
 	static hardware_manager *s_instance;
 
 	config m_config;
-	std::vector<std::unique_ptr<hardware_link>> m_links;
+	mutable std::mutex m_linksmutex;
+	std::vector<std::shared_ptr<hardware_link>> m_links;
 	std::vector<link_report> m_reports;
 	state_snapshot m_snapshot;
+
+	mutable std::mutex m_portsmutex;
+	std::vector<std::string> m_ports;
+	std::chrono::steady_clock::time_point m_lastportscan;
+
 	std::chrono::steady_clock::time_point m_lastupdate;
 	bool m_updatestarted = false;
 	std::thread m_thread;

--- a/hardware/protocol/protocol_codec.cpp
+++ b/hardware/protocol/protocol_codec.cpp
@@ -1,0 +1,457 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "hardware/protocol/protocol_codec.h"
+
+#include <cstring>
+
+namespace hardware
+{
+
+namespace
+{
+
+// castagnoli polynomial in reflected form
+constexpr std::uint32_t crc32c_polynomial = 0x82F63B78u;
+
+std::array<std::uint32_t, 256> const &crc32c_table()
+{
+	static std::array<std::uint32_t, 256> const table = []()
+	{
+		std::array<std::uint32_t, 256> result {};
+		for( std::uint32_t index = 0; index < 256; ++index )
+		{
+			std::uint32_t value = index;
+			for( int bit = 0; bit < 8; ++bit )
+			{
+				value = ( value & 1 ? ( value >> 1 ) ^ crc32c_polynomial : value >> 1 );
+			}
+			result[ index ] = value;
+		}
+		return result;
+	}();
+
+	return table;
+}
+
+void append_uint16( std::vector<std::uint8_t> &Buffer, std::uint16_t const Value )
+{
+	Buffer.emplace_back( static_cast<std::uint8_t>( Value ) );
+	Buffer.emplace_back( static_cast<std::uint8_t>( Value >> 8 ) );
+}
+
+void append_uint32( std::vector<std::uint8_t> &Buffer, std::uint32_t const Value )
+{
+	Buffer.emplace_back( static_cast<std::uint8_t>( Value ) );
+	Buffer.emplace_back( static_cast<std::uint8_t>( Value >> 8 ) );
+	Buffer.emplace_back( static_cast<std::uint8_t>( Value >> 16 ) );
+	Buffer.emplace_back( static_cast<std::uint8_t>( Value >> 24 ) );
+}
+
+std::uint16_t extract_uint16( std::uint8_t const *Data )
+{
+	return static_cast<std::uint16_t>( static_cast<std::uint16_t>( Data[ 0 ] ) | static_cast<std::uint16_t>( Data[ 1 ] ) << 8 );
+}
+
+std::uint32_t extract_uint32( std::uint8_t const *Data )
+{
+	return static_cast<std::uint32_t>( Data[ 0 ] ) | static_cast<std::uint32_t>( Data[ 1 ] ) << 8 | static_cast<std::uint32_t>( Data[ 2 ] ) << 16 | static_cast<std::uint32_t>( Data[ 3 ] ) << 24;
+}
+
+} // anonymous namespace
+
+std::uint32_t crc32c( std::uint8_t const *Data, std::size_t const Size, std::uint32_t const Seed )
+{
+	auto const &table = crc32c_table();
+	std::uint32_t crc = ~Seed;
+	for( std::size_t index = 0; index < Size; ++index )
+	{
+		crc = table[ ( crc ^ Data[ index ] ) & 0xFF ] ^ ( crc >> 8 );
+	}
+	return ~crc;
+}
+
+void cobs_encode( std::uint8_t const *Data, std::size_t const Size, std::vector<std::uint8_t> &Output )
+{
+	Output.clear();
+	// the first byte holds the distance to the first zero, it's patched once that distance is known
+	std::size_t codeposition = 0;
+	Output.emplace_back( 0 );
+	std::uint8_t code = 1;
+
+	for( std::size_t index = 0; index < Size; ++index )
+	{
+		if( Data[ index ] != 0 )
+		{
+			Output.emplace_back( Data[ index ] );
+			++code;
+			if( code != 0xFF )
+			{
+				continue;
+			}
+		}
+		Output[ codeposition ] = code;
+		codeposition = Output.size();
+		Output.emplace_back( 0 );
+		code = 1;
+	}
+
+	Output[ codeposition ] = code;
+}
+
+bool cobs_decode( std::uint8_t const *Data, std::size_t const Size, std::vector<std::uint8_t> &Output )
+{
+	Output.clear();
+	std::size_t index = 0;
+
+	while( index < Size )
+	{
+		std::uint8_t const code = Data[ index ];
+		if( code == 0 )
+		{
+			// a zero byte can never appear inside an encoded block
+			return false;
+		}
+		++index;
+		std::size_t const runlength = static_cast<std::size_t>( code ) - 1;
+		if( index + runlength > Size )
+		{
+			return false;
+		}
+		Output.insert( Output.end(), Data + index, Data + index + runlength );
+		index += runlength;
+		if( ( code != 0xFF ) && ( index < Size ) )
+		{
+			Output.emplace_back( 0 );
+		}
+	}
+
+	return true;
+}
+
+void encode_frame( packet_header const &Header, std::uint8_t const *Payload, std::size_t const PayloadSize, std::vector<std::uint8_t> &Output )
+{
+	std::vector<std::uint8_t> packet;
+	packet.reserve( protocol_header_size + PayloadSize + protocol_crc_size );
+
+	append_uint16( packet, protocol_magic );
+	packet.emplace_back( Header.protocol_major );
+	packet.emplace_back( Header.protocol_minor );
+	packet.emplace_back( Header.flags );
+	packet.emplace_back( static_cast<std::uint8_t>( protocol_header_size ) );
+	append_uint16( packet, static_cast<std::uint16_t>( Header.type ) );
+	append_uint32( packet, Header.session_id );
+	append_uint32( packet, Header.sequence );
+	append_uint32( packet, Header.timestamp_ms );
+	append_uint16( packet, static_cast<std::uint16_t>( PayloadSize ) );
+	append_uint16( packet, 0 );
+
+	if( PayloadSize > 0 )
+	{
+		packet.insert( packet.end(), Payload, Payload + PayloadSize );
+	}
+
+	append_uint32( packet, crc32c( packet.data(), packet.size() ) );
+
+	cobs_encode( packet.data(), packet.size(), Output );
+	Output.emplace_back( 0 );
+}
+
+void payload_writer::write_bool( bool const Value )
+{
+	m_data.emplace_back( Value ? 1 : 0 );
+}
+
+void payload_writer::write_uint8( std::uint8_t const Value )
+{
+	m_data.emplace_back( Value );
+}
+
+void payload_writer::write_int8( std::int8_t const Value )
+{
+	m_data.emplace_back( static_cast<std::uint8_t>( Value ) );
+}
+
+void payload_writer::write_uint16( std::uint16_t const Value )
+{
+	append_uint16( m_data, Value );
+}
+
+void payload_writer::write_int16( std::int16_t const Value )
+{
+	append_uint16( m_data, static_cast<std::uint16_t>( Value ) );
+}
+
+void payload_writer::write_uint32( std::uint32_t const Value )
+{
+	append_uint32( m_data, Value );
+}
+
+void payload_writer::write_int32( std::int32_t const Value )
+{
+	append_uint32( m_data, static_cast<std::uint32_t>( Value ) );
+}
+
+void payload_writer::write_uint64( std::uint64_t const Value )
+{
+	append_uint32( m_data, static_cast<std::uint32_t>( Value ) );
+	append_uint32( m_data, static_cast<std::uint32_t>( Value >> 32 ) );
+}
+
+void payload_writer::write_int64( std::int64_t const Value )
+{
+	write_uint64( static_cast<std::uint64_t>( Value ) );
+}
+
+void payload_writer::write_float32( float const Value )
+{
+	std::uint32_t bits = 0;
+	std::memcpy( &bits, &Value, sizeof( bits ) );
+	append_uint32( m_data, bits );
+}
+
+void payload_writer::write_float64( double const Value )
+{
+	std::uint64_t bits = 0;
+	std::memcpy( &bits, &Value, sizeof( bits ) );
+	write_uint64( bits );
+}
+
+void payload_writer::write_string( std::string const &Value )
+{
+	auto const length = std::min( Value.size(), protocol_string_max );
+	m_data.emplace_back( static_cast<std::uint8_t>( length ) );
+	m_data.insert( m_data.end(), Value.begin(), Value.begin() + length );
+}
+
+void payload_writer::write_bytes( std::uint8_t const *Data, std::size_t const Size )
+{
+	m_data.insert( m_data.end(), Data, Data + Size );
+}
+
+void payload_writer::patch_uint16( std::size_t const Offset, std::uint16_t const Value )
+{
+	if( Offset + 1 >= m_data.size() )
+	{
+		return;
+	}
+	m_data[ Offset ] = static_cast<std::uint8_t>( Value );
+	m_data[ Offset + 1 ] = static_cast<std::uint8_t>( Value >> 8 );
+}
+
+bool payload_reader::require( std::size_t const Size )
+{
+	if( m_error )
+	{
+		return false;
+	}
+	if( m_position + Size > m_size )
+	{
+		m_error = true;
+		return false;
+	}
+	return true;
+}
+
+bool payload_reader::read_bool()
+{
+	return read_uint8() != 0;
+}
+
+std::uint8_t payload_reader::read_uint8()
+{
+	if( false == require( 1 ) )
+	{
+		return 0;
+	}
+	return m_data[ m_position++ ];
+}
+
+std::int8_t payload_reader::read_int8()
+{
+	return static_cast<std::int8_t>( read_uint8() );
+}
+
+std::uint16_t payload_reader::read_uint16()
+{
+	if( false == require( 2 ) )
+	{
+		return 0;
+	}
+	auto const value = extract_uint16( m_data + m_position );
+	m_position += 2;
+	return value;
+}
+
+std::int16_t payload_reader::read_int16()
+{
+	return static_cast<std::int16_t>( read_uint16() );
+}
+
+std::uint32_t payload_reader::read_uint32()
+{
+	if( false == require( 4 ) )
+	{
+		return 0;
+	}
+	auto const value = extract_uint32( m_data + m_position );
+	m_position += 4;
+	return value;
+}
+
+std::int32_t payload_reader::read_int32()
+{
+	return static_cast<std::int32_t>( read_uint32() );
+}
+
+std::uint64_t payload_reader::read_uint64()
+{
+	std::uint64_t const low = read_uint32();
+	std::uint64_t const high = read_uint32();
+	return low | high << 32;
+}
+
+std::int64_t payload_reader::read_int64()
+{
+	return static_cast<std::int64_t>( read_uint64() );
+}
+
+float payload_reader::read_float32()
+{
+	std::uint32_t const bits = read_uint32();
+	float value = 0.0f;
+	std::memcpy( &value, &bits, sizeof( value ) );
+	return value;
+}
+
+double payload_reader::read_float64()
+{
+	std::uint64_t const bits = read_uint64();
+	double value = 0.0;
+	std::memcpy( &value, &bits, sizeof( value ) );
+	return value;
+}
+
+std::string payload_reader::read_string( std::size_t const Sizelimit )
+{
+	std::size_t const length = read_uint8();
+	if( length > Sizelimit )
+	{
+		m_error = true;
+		return {};
+	}
+	if( false == require( length ) )
+	{
+		return {};
+	}
+	std::string value( reinterpret_cast<char const *>( m_data + m_position ), length );
+	m_position += length;
+	return value;
+}
+
+void frame_decoder::reset()
+{
+	m_buffer.clear();
+	m_overrun = false;
+}
+
+void frame_decoder::set_frame_size_limit( std::size_t const Limit )
+{
+	m_framesizelimit = std::clamp<std::size_t>( Limit, protocol_frame_size_min, protocol_frame_size_max );
+}
+
+void frame_decoder::feed( std::uint8_t const *Data, std::size_t const Size, std::vector<decoded_packet> &Output )
+{
+	// worst case cobs expansion, plus the code byte
+	std::size_t const encodedlimit = m_framesizelimit + m_framesizelimit / 254 + 2;
+
+	for( std::size_t index = 0; index < Size; ++index )
+	{
+		std::uint8_t const byte = Data[ index ];
+
+		if( byte == 0 )
+		{
+			// frame delimiter; anything gathered so far is either a frame or debris to be dropped
+			if( true == m_overrun )
+			{
+				m_overrun = false;
+			}
+			else if( false == m_buffer.empty() )
+			{
+				if( true == cobs_decode( m_buffer.data(), m_buffer.size(), m_scratch ) )
+				{
+					if( m_scratch.size() < protocol_header_size + protocol_crc_size )
+					{
+						++m_stats.length_errors;
+					}
+					else if( extract_uint16( m_scratch.data() ) != protocol_magic )
+					{
+						++m_stats.frame_errors;
+					}
+					else
+					{
+						std::size_t const headersize = m_scratch[ 5 ];
+						std::size_t const payloadlength = extract_uint16( m_scratch.data() + 20 );
+						if( ( headersize < protocol_header_size ) || ( headersize + payloadlength + protocol_crc_size != m_scratch.size() ) )
+						{
+							++m_stats.length_errors;
+						}
+						else
+						{
+							std::uint32_t const expectedcrc = extract_uint32( m_scratch.data() + m_scratch.size() - protocol_crc_size );
+							if( expectedcrc != crc32c( m_scratch.data(), m_scratch.size() - protocol_crc_size ) )
+							{
+								++m_stats.crc_errors;
+							}
+							else
+							{
+								decoded_packet packet;
+								packet.header.protocol_major = m_scratch[ 2 ];
+								packet.header.protocol_minor = m_scratch[ 3 ];
+								packet.header.flags = m_scratch[ 4 ];
+								packet.header.type = static_cast<message_type>( extract_uint16( m_scratch.data() + 6 ) );
+								packet.header.session_id = extract_uint32( m_scratch.data() + 8 );
+								packet.header.sequence = extract_uint32( m_scratch.data() + 12 );
+								packet.header.timestamp_ms = extract_uint32( m_scratch.data() + 16 );
+								packet.header.payload_length = static_cast<std::uint16_t>( payloadlength );
+								packet.payload.assign( m_scratch.begin() + headersize, m_scratch.begin() + headersize + payloadlength );
+								++m_stats.frames;
+								Output.emplace_back( std::move( packet ) );
+							}
+						}
+					}
+				}
+				else
+				{
+					++m_stats.frame_errors;
+				}
+			}
+			m_buffer.clear();
+			continue;
+		}
+
+		if( true == m_overrun )
+		{
+			// still waiting for the delimiter which ends the oversized frame
+			continue;
+		}
+
+		m_buffer.emplace_back( byte );
+
+		if( m_buffer.size() > encodedlimit )
+		{
+			++m_stats.length_errors;
+			m_overrun = true;
+			m_buffer.clear();
+		}
+	}
+}
+
+} // namespace hardware

--- a/hardware/protocol/protocol_codec.h
+++ b/hardware/protocol/protocol_codec.h
@@ -1,0 +1,156 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "hardware/protocol/protocol_defs.h"
+
+// MaSzyna Hardware Protocol v2, frame layer
+// raw packet := header | payload | crc32c, transmitted as COBS( packet ) followed by a 0x00 delimiter
+
+namespace hardware
+{
+
+struct packet_header
+{
+	std::uint8_t protocol_major = protocol_version_major;
+	std::uint8_t protocol_minor = protocol_version_minor;
+	std::uint8_t flags = packetflag_none;
+	message_type type = message_type::invalid;
+	std::uint32_t session_id = 0;
+	std::uint32_t sequence = 0;
+	std::uint32_t timestamp_ms = 0;
+	std::uint16_t payload_length = 0;
+};
+
+struct decoded_packet
+{
+	packet_header header;
+	std::vector<std::uint8_t> payload;
+};
+
+// crc32c (castagnoli), the checksum protecting header and payload
+std::uint32_t crc32c( std::uint8_t const *Data, std::size_t const Size, std::uint32_t const Seed = 0 );
+
+// consistent overhead byte stuffing; the encoded output never contains a zero byte
+void cobs_encode( std::uint8_t const *Data, std::size_t const Size, std::vector<std::uint8_t> &Output );
+// returns false if the input isn't a valid cobs sequence
+bool cobs_decode( std::uint8_t const *Data, std::size_t const Size, std::vector<std::uint8_t> &Output );
+
+// builds a complete, ready to transmit frame including the trailing delimiter
+void encode_frame( packet_header const &Header, std::uint8_t const *Payload, std::size_t const PayloadSize, std::vector<std::uint8_t> &Output );
+
+// bounds checked payload composer; all integers are little-endian, floats are ieee 754
+class payload_writer
+{
+
+public:
+// methods
+	void write_bool( bool const Value );
+	void write_uint8( std::uint8_t const Value );
+	void write_int8( std::int8_t const Value );
+	void write_uint16( std::uint16_t const Value );
+	void write_int16( std::int16_t const Value );
+	void write_uint32( std::uint32_t const Value );
+	void write_int32( std::int32_t const Value );
+	void write_uint64( std::uint64_t const Value );
+	void write_int64( std::int64_t const Value );
+	void write_float32( float const Value );
+	void write_float64( double const Value );
+	// length prefixed (uint8) utf-8 text, truncated to protocol_string_max
+	void write_string( std::string const &Value );
+	void write_bytes( std::uint8_t const *Data, std::size_t const Size );
+
+	void clear() { m_data.clear(); }
+	std::size_t size() const { return m_data.size(); }
+	std::uint8_t const *data() const { return m_data.data(); }
+	std::vector<std::uint8_t> const &buffer() const { return m_data; }
+	// lets the caller patch a count written before the items were emitted
+	void patch_uint16( std::size_t const Offset, std::uint16_t const Value );
+
+private:
+// members
+	std::vector<std::uint8_t> m_data;
+};
+
+// bounds checked payload parser; every read past the end sets the error flag and yields a zeroed result
+class payload_reader
+{
+
+public:
+// methods
+	payload_reader( std::uint8_t const *Data, std::size_t const Size ) : m_data( Data ), m_size( Size ) {}
+	explicit payload_reader( std::vector<std::uint8_t> const &Data ) : m_data( Data.data() ), m_size( Data.size() ) {}
+
+	bool read_bool();
+	std::uint8_t read_uint8();
+	std::int8_t read_int8();
+	std::uint16_t read_uint16();
+	std::int16_t read_int16();
+	std::uint32_t read_uint32();
+	std::int32_t read_int32();
+	std::uint64_t read_uint64();
+	std::int64_t read_int64();
+	float read_float32();
+	double read_float64();
+	std::string read_string( std::size_t const Sizelimit = protocol_string_max );
+
+	bool ok() const { return !m_error; }
+	bool exhausted() const { return m_position >= m_size; }
+	std::size_t remaining() const { return ( m_position < m_size ? m_size - m_position : 0 ); }
+	void fail() { m_error = true; }
+
+private:
+// methods
+	bool require( std::size_t const Size );
+
+// members
+	std::uint8_t const *m_data = nullptr;
+	std::size_t m_size = 0;
+	std::size_t m_position = 0;
+	bool m_error = false;
+};
+
+// stream decoder; recovers from arbitrary corruption at the next delimiter
+class frame_decoder
+{
+
+public:
+// types
+	struct counters
+	{
+		std::uint64_t frames = 0;
+		std::uint64_t crc_errors = 0;
+		std::uint64_t frame_errors = 0;
+		std::uint64_t length_errors = 0;
+		std::uint64_t version_errors = 0;
+	};
+
+// methods
+	void reset();
+	void set_frame_size_limit( std::size_t const Limit );
+	// consumes raw bytes, appends every complete and valid packet to Output
+	void feed( std::uint8_t const *Data, std::size_t const Size, std::vector<decoded_packet> &Output );
+
+	counters const &stats() const { return m_stats; }
+
+private:
+// members
+	std::vector<std::uint8_t> m_buffer;
+	std::vector<std::uint8_t> m_scratch;
+	std::size_t m_framesizelimit = protocol_frame_size_default;
+	bool m_overrun = false;
+	counters m_stats;
+};
+
+} // namespace hardware

--- a/hardware/protocol/protocol_defs.cpp
+++ b/hardware/protocol/protocol_defs.cpp
@@ -27,6 +27,7 @@ char const *to_string( message_type const Type )
 		case message_type::device_ready: return "DEVICE_READY";
 		case message_type::device_info: return "DEVICE_INFO";
 		case message_type::device_diagnostics: return "DEVICE_DIAGNOSTICS";
+		case message_type::device_log: return "DEVICE_LOG";
 		case message_type::resolve_symbols: return "RESOLVE_SYMBOLS";
 		case message_type::symbols_resolved: return "SYMBOLS_RESOLVED";
 		case message_type::query_symbol: return "QUERY_SYMBOL";
@@ -44,6 +45,12 @@ char const *to_string( message_type const Type )
 		case message_type::property_read: return "PROPERTY_READ";
 		case message_type::property_value: return "PROPERTY_VALUE";
 		case message_type::property_write: return "PROPERTY_WRITE";
+		case message_type::diagnostic_functions: return "DIAGNOSTIC_FUNCTIONS";
+		case message_type::diagnostic_run: return "DIAGNOSTIC_RUN";
+		case message_type::diagnostic_cancel: return "DIAGNOSTIC_CANCEL";
+		case message_type::diagnostic_status: return "DIAGNOSTIC_STATUS";
+		case message_type::diagnostic_prompt: return "DIAGNOSTIC_PROMPT";
+		case message_type::diagnostic_prompt_result: return "DIAGNOSTIC_PROMPT_RESULT";
 		default: return "UNKNOWN";
 	}
 }
@@ -105,6 +112,28 @@ char const *to_string( link_state const State )
 		case link_state::healthy: return "HEALTHY";
 		case link_state::degraded: return "DEGRADED";
 		default: return "ERROR";
+	}
+}
+
+char const *to_string( log_severity const Severity )
+{
+	switch( Severity )
+	{
+		case log_severity::debug: return "debug";
+		case log_severity::info: return "info";
+		case log_severity::warning: return "warning";
+		default: return "error";
+	}
+}
+
+char const *to_string( diagnostic_state const State )
+{
+	switch( State )
+	{
+		case diagnostic_state::idle: return "IDLE";
+		case diagnostic_state::running: return "RUNNING";
+		case diagnostic_state::succeeded: return "SUCCEEDED";
+		default: return "FAILED";
 	}
 }
 

--- a/hardware/protocol/protocol_defs.cpp
+++ b/hardware/protocol/protocol_defs.cpp
@@ -1,0 +1,138 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "hardware/protocol/protocol_defs.h"
+
+namespace hardware
+{
+
+char const *to_string( message_type const Type )
+{
+	switch( Type )
+	{
+		case message_type::hello: return "HELLO";
+		case message_type::welcome: return "WELCOME";
+		case message_type::heartbeat: return "HEARTBEAT";
+		case message_type::ack: return "ACK";
+		case message_type::nack: return "NACK";
+		case message_type::ping: return "PING";
+		case message_type::pong: return "PONG";
+		case message_type::device_ready: return "DEVICE_READY";
+		case message_type::device_info: return "DEVICE_INFO";
+		case message_type::device_diagnostics: return "DEVICE_DIAGNOSTICS";
+		case message_type::resolve_symbols: return "RESOLVE_SYMBOLS";
+		case message_type::symbols_resolved: return "SYMBOLS_RESOLVED";
+		case message_type::query_symbol: return "QUERY_SYMBOL";
+		case message_type::symbol_info: return "SYMBOL_INFO";
+		case message_type::symbol_context_changed: return "SYMBOL_CONTEXT_CHANGED";
+		case message_type::subscribe: return "SUBSCRIBE";
+		case message_type::subscribe_result: return "SUBSCRIBE_RESULT";
+		case message_type::unsubscribe: return "UNSUBSCRIBE";
+		case message_type::state_update: return "STATE_UPDATE";
+		case message_type::command_event: return "COMMAND_EVENT";
+		case message_type::control_set: return "CONTROL_SET";
+		case message_type::control_claim: return "CONTROL_CLAIM";
+		case message_type::control_claim_result: return "CONTROL_CLAIM_RESULT";
+		case message_type::control_release: return "CONTROL_RELEASE";
+		case message_type::property_read: return "PROPERTY_READ";
+		case message_type::property_value: return "PROPERTY_VALUE";
+		case message_type::property_write: return "PROPERTY_WRITE";
+		default: return "UNKNOWN";
+	}
+}
+
+char const *to_string( error_code const Code )
+{
+	switch( Code )
+	{
+		case error_code::none: return "NONE";
+		case error_code::unsupported_version: return "UNSUPPORTED_VERSION";
+		case error_code::invalid_session: return "INVALID_SESSION";
+		case error_code::invalid_frame: return "INVALID_FRAME";
+		case error_code::invalid_length: return "INVALID_LENGTH";
+		case error_code::invalid_field: return "INVALID_FIELD";
+		case error_code::unknown_message: return "UNKNOWN_MESSAGE";
+		case error_code::unknown_symbol: return "UNKNOWN_SYMBOL";
+		case error_code::unknown_handle: return "UNKNOWN_HANDLE";
+		case error_code::access_denied: return "ACCESS_DENIED";
+		case error_code::out_of_range: return "OUT_OF_RANGE";
+		case error_code::wrong_type: return "WRONG_TYPE";
+		case error_code::not_ready: return "NOT_READY";
+		case error_code::busy: return "BUSY";
+		case error_code::control_not_owned: return "CONTROL_NOT_OWNED";
+		case error_code::rate_limited: return "RATE_LIMITED";
+		case error_code::unsupported_operation: return "UNSUPPORTED_OPERATION";
+		default: return "INTERNAL_ERROR";
+	}
+}
+
+char const *to_string( value_quality const Quality )
+{
+	switch( Quality )
+	{
+		case value_quality::valid: return "VALID";
+		case value_quality::stale: return "STALE";
+		case value_quality::unavailable: return "UNAVAILABLE";
+		case value_quality::invalid: return "INVALID";
+		default: return "NOT_APPLICABLE";
+	}
+}
+
+char const *to_string( session_state const State )
+{
+	switch( State )
+	{
+		case session_state::disconnected: return "DISCONNECTED";
+		case session_state::waiting_for_hello: return "WAITING FOR HELLO";
+		case session_state::established: return "ESTABLISHED";
+		default: return "READY";
+	}
+}
+
+char const *to_string( link_state const State )
+{
+	switch( State )
+	{
+		case link_state::disconnected: return "DISCONNECTED";
+		case link_state::connecting: return "CONNECTING";
+		case link_state::healthy: return "HEALTHY";
+		case link_state::degraded: return "DEGRADED";
+		default: return "ERROR";
+	}
+}
+
+std::size_t value_type_size( value_type const Type )
+{
+	switch( Type )
+	{
+		case value_type::boolean:
+		case value_type::uint8:
+		case value_type::int8:
+		case value_type::enumeration:
+			return 1;
+		case value_type::uint16:
+		case value_type::int16:
+			return 2;
+		case value_type::uint32:
+		case value_type::int32:
+		case value_type::float32:
+		case value_type::bitfield:
+			return 4;
+		case value_type::uint64:
+		case value_type::int64:
+		case value_type::float64:
+			return 8;
+		default:
+			// variable length, or nothing at all
+			return 0;
+	}
+}
+
+} // namespace hardware

--- a/hardware/protocol/protocol_defs.h
+++ b/hardware/protocol/protocol_defs.h
@@ -1,0 +1,223 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// MaSzyna Hardware Protocol v2 (MHPv2)
+// transport-independent protocol definitions shared by every transport (serial, TCP, RS-485)
+
+namespace hardware
+{
+
+// protocol version implemented by this build
+constexpr std::uint8_t protocol_version_major = 2;
+constexpr std::uint8_t protocol_version_minor = 0;
+
+// 'M2', stored little-endian in the frame header
+constexpr std::uint16_t protocol_magic = 0x324D;
+
+constexpr std::size_t protocol_header_size = 24;
+constexpr std::size_t protocol_crc_size = 4;
+
+constexpr std::size_t protocol_frame_size_min = 64;
+constexpr std::size_t protocol_frame_size_default = 1024;
+constexpr std::size_t protocol_frame_size_max = 4096;
+
+// safety limits applied to anything arriving from the outside world
+constexpr std::size_t protocol_symbol_name_max = 128;
+constexpr std::size_t protocol_string_max = 128;
+constexpr std::size_t protocol_symbols_per_message_max = 64;
+
+// message identifiers; the numbering is part of the public protocol and must not be reordered
+enum class message_type : std::uint16_t
+{
+	invalid = 0x0000,
+
+	hello = 0x0001,
+	welcome = 0x0002,
+	heartbeat = 0x0003,
+
+	ack = 0x0004,
+	nack = 0x0005,
+
+	ping = 0x0006,
+	pong = 0x0007,
+
+	device_ready = 0x0008,
+
+	device_info = 0x0010,
+	device_diagnostics = 0x0011,
+
+	resolve_symbols = 0x0020,
+	symbols_resolved = 0x0021,
+	query_symbol = 0x0022,
+	symbol_info = 0x0023,
+	symbol_context_changed = 0x0024,
+
+	subscribe = 0x0030,
+	subscribe_result = 0x0031,
+	unsubscribe = 0x0032,
+	state_update = 0x0033,
+
+	command_event = 0x0040,
+	control_set = 0x0041,
+
+	control_claim = 0x0042,
+	control_claim_result = 0x0043,
+	control_release = 0x0044,
+
+	property_read = 0x0050,
+	property_value = 0x0051,
+	property_write = 0x0052
+};
+
+// header flag bits
+enum packet_flag : std::uint8_t
+{
+	packetflag_none = 0x00,
+	packetflag_ack_required = 0x01,
+	packetflag_response = 0x02,
+	packetflag_error = 0x04,
+	packetflag_high_priority = 0x08,
+	packetflag_snapshot = 0x10
+};
+
+// wire data types
+enum class value_type : std::uint8_t
+{
+	none = 0x00,
+	boolean = 0x01,
+	uint8 = 0x02,
+	int8 = 0x03,
+	uint16 = 0x04,
+	int16 = 0x05,
+	uint32 = 0x06,
+	int32 = 0x07,
+	uint64 = 0x08,
+	int64 = 0x09,
+	float32 = 0x0A,
+	float64 = 0x0B,
+	utf8_string = 0x0C,
+	byte_array = 0x0D,
+	enumeration = 0x0E,
+	bitfield = 0x0F
+};
+
+// per-value quality indicator, so a device can tell "zero" from "not measured"
+enum class value_quality : std::uint8_t
+{
+	valid = 0,
+	stale = 1,
+	unavailable = 2,
+	invalid = 3,
+	not_applicable = 4
+};
+
+enum class symbol_kind : std::uint8_t
+{
+	state = 0,
+	command = 1,
+	property = 2,
+	diagnostic = 3
+};
+
+enum access_mode : std::uint8_t
+{
+	access_read = 0x01,
+	access_write = 0x02,
+	access_readwrite = 0x03
+};
+
+enum class subscription_mode : std::uint8_t
+{
+	periodic = 0,
+	on_change = 1,
+	periodic_or_change = 2
+};
+
+enum class command_action : std::uint8_t
+{
+	press = 0,
+	release = 1,
+	repeat = 2
+};
+
+enum class error_code : std::uint16_t
+{
+	none = 0,
+
+	unsupported_version = 1,
+	invalid_session = 2,
+
+	invalid_frame = 3,
+	invalid_length = 4,
+	invalid_field = 5,
+
+	unknown_message = 6,
+	unknown_symbol = 7,
+	unknown_handle = 8,
+
+	access_denied = 9,
+	out_of_range = 10,
+	wrong_type = 11,
+
+	not_ready = 12,
+	busy = 13,
+	control_not_owned = 14,
+
+	rate_limited = 15,
+
+	unsupported_operation = 16,
+	internal_error = 17
+};
+
+// capabilities advertised by the device in HELLO
+enum capability_flag : std::uint32_t
+{
+	capability_none = 0x00000000,
+	capability_receive_state = 0x00000001,
+	capability_send_commands = 0x00000002,
+	capability_send_controls = 0x00000004,
+	capability_diagnostics = 0x00000008,
+	capability_soft_takeover = 0x00000010,
+	capability_control_leases = 0x00000020
+};
+
+// session progress, mirrors the connection lifecycle of the specification
+enum class session_state : std::uint8_t
+{
+	disconnected = 0,
+	waiting_for_hello = 1,
+	established = 2,
+	ready = 3
+};
+
+// aggregated link condition presented in the debug ui
+enum class link_state : std::uint8_t
+{
+	disconnected = 0,
+	connecting = 1,
+	healthy = 2,
+	degraded = 3,
+	error = 4
+};
+
+char const *to_string( message_type const Type );
+char const *to_string( error_code const Code );
+char const *to_string( value_quality const Quality );
+char const *to_string( session_state const State );
+char const *to_string( link_state const State );
+
+// size of a fixed-width type on the wire, 0 for variable-length ones
+std::size_t value_type_size( value_type const Type );
+
+} // namespace hardware

--- a/hardware/protocol/protocol_defs.h
+++ b/hardware/protocol/protocol_defs.h
@@ -20,7 +20,7 @@ namespace hardware
 
 // protocol version implemented by this build
 constexpr std::uint8_t protocol_version_major = 2;
-constexpr std::uint8_t protocol_version_minor = 0;
+constexpr std::uint8_t protocol_version_minor = 1;
 
 // 'M2', stored little-endian in the frame header
 constexpr std::uint16_t protocol_magic = 0x324D;
@@ -36,6 +36,10 @@ constexpr std::size_t protocol_frame_size_max = 4096;
 constexpr std::size_t protocol_symbol_name_max = 128;
 constexpr std::size_t protocol_string_max = 128;
 constexpr std::size_t protocol_symbols_per_message_max = 64;
+constexpr std::size_t protocol_diagnostic_functions_max = 32;
+constexpr std::size_t protocol_prompt_options_max = 4;
+// device log lines kept per connection for the debug panel
+constexpr std::size_t protocol_log_history = 64;
 
 // message identifiers; the numbering is part of the public protocol and must not be reordered
 enum class message_type : std::uint16_t
@@ -56,6 +60,7 @@ enum class message_type : std::uint16_t
 
 	device_info = 0x0010,
 	device_diagnostics = 0x0011,
+	device_log = 0x0012,
 
 	resolve_symbols = 0x0020,
 	symbols_resolved = 0x0021,
@@ -77,7 +82,14 @@ enum class message_type : std::uint16_t
 
 	property_read = 0x0050,
 	property_value = 0x0051,
-	property_write = 0x0052
+	property_write = 0x0052,
+
+	diagnostic_functions = 0x0060,
+	diagnostic_run = 0x0061,
+	diagnostic_cancel = 0x0062,
+	diagnostic_status = 0x0063,
+	diagnostic_prompt = 0x0064,
+	diagnostic_prompt_result = 0x0065
 };
 
 // header flag bits
@@ -189,8 +201,31 @@ enum capability_flag : std::uint32_t
 	capability_send_controls = 0x00000004,
 	capability_diagnostics = 0x00000008,
 	capability_soft_takeover = 0x00000010,
-	capability_control_leases = 0x00000020
+	capability_control_leases = 0x00000020,
+	// the device offers diagnostic routines which can be started from the debug panel
+	capability_diagnostic_functions = 0x00000040
 };
+
+// severity of a text line sent by the device
+enum class log_severity : std::uint8_t
+{
+	debug = 0,
+	info = 1,
+	warning = 2,
+	error = 3
+};
+
+// progress of a diagnostic routine running on the device
+enum class diagnostic_state : std::uint8_t
+{
+	idle = 0,
+	running = 1,
+	succeeded = 2,
+	failed = 3
+};
+
+// answer index reported when the user closes a prompt without choosing
+constexpr std::uint8_t prompt_dismissed = 0xFF;
 
 // session progress, mirrors the connection lifecycle of the specification
 enum class session_state : std::uint8_t
@@ -216,6 +251,8 @@ char const *to_string( error_code const Code );
 char const *to_string( value_quality const Quality );
 char const *to_string( session_state const State );
 char const *to_string( link_state const State );
+char const *to_string( log_severity const Severity );
+char const *to_string( diagnostic_state const State );
 
 // size of a fixed-width type on the wire, 0 for variable-length ones
 std::size_t value_type_size( value_type const Type );

--- a/hardware/protocol/protocol_session.cpp
+++ b/hardware/protocol/protocol_session.cpp
@@ -1,0 +1,1057 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "hardware/protocol/protocol_session.h"
+
+#include "hardware/registry/command_registry.h"
+#include "hardware/registry/hardware_symbol_registry.h"
+#include "simulation/simulation.h"
+#include "utilities/Globals.h"
+#include "utilities/Logs.h"
+#include "vehicle/Train.h"
+
+namespace hardware
+{
+
+namespace
+{
+
+// how many transaction results are remembered for duplicate detection
+constexpr std::size_t transaction_cache_size = 128;
+// upper bound on session handles, one per resolved symbol
+constexpr std::size_t handles_max = 1024;
+// round trip time is measured this often
+constexpr double ping_interval = 5.0;
+
+std::uint32_t generate_session_id()
+{
+	static std::mt19937 generator( static_cast<std::uint32_t>( std::chrono::steady_clock::now().time_since_epoch().count() ) );
+	std::uint32_t const value = generator();
+	// zero is reserved for "no session"
+	return ( value != 0 ? value : 1 );
+}
+
+void write_state_value( payload_writer &Writer, state_value const &Value )
+{
+	switch( Value.type )
+	{
+		case value_type::boolean:
+		case value_type::uint8:
+		case value_type::int8:
+		case value_type::enumeration:
+			Writer.write_uint8( static_cast<std::uint8_t>( Value.numeric ) );
+			break;
+		case value_type::uint16:
+		case value_type::int16:
+			Writer.write_uint16( static_cast<std::uint16_t>( Value.numeric ) );
+			break;
+		case value_type::uint32:
+		case value_type::int32:
+		case value_type::bitfield:
+			Writer.write_uint32( static_cast<std::uint32_t>( Value.numeric ) );
+			break;
+		case value_type::uint64:
+		case value_type::int64:
+			Writer.write_uint64( static_cast<std::uint64_t>( Value.numeric ) );
+			break;
+		case value_type::float64:
+			Writer.write_float64( Value.numeric );
+			break;
+		case value_type::utf8_string:
+			Writer.write_string( Value.text );
+			break;
+		default:
+			Writer.write_float32( static_cast<float>( Value.numeric ) );
+			break;
+	}
+}
+
+std::size_t state_value_size( state_value const &Value )
+{
+	if( Value.type == value_type::utf8_string )
+	{
+		return 1 + std::min( Value.text.size(), protocol_string_max );
+	}
+	auto const size = value_type_size( Value.type );
+	return ( size > 0 ? size : 4 );
+}
+
+int glfw_action( command_action const Action )
+{
+	switch( Action )
+	{
+		case command_action::release: return GLFW_RELEASE;
+		case command_action::repeat: return GLFW_REPEAT;
+		default: return GLFW_PRESS;
+	}
+}
+
+} // anonymous namespace
+
+protocol_session::protocol_session( session_output &Output, config const &Config ) : m_output( Output ), m_config( Config )
+{
+	m_framesize = std::clamp<std::size_t>( m_config.frame_size, protocol_frame_size_min, protocol_frame_size_max );
+	reset();
+}
+
+void protocol_session::reset()
+{
+	m_state = session_state::waiting_for_hello;
+	m_sessionid = 0;
+	m_sequence = 0;
+	m_lastreceivedsequence = 0;
+	m_sequenceseen = false;
+	m_framesize = std::clamp<std::size_t>( m_config.frame_size, protocol_frame_size_min, protocol_frame_size_max );
+	m_capabilities = 0;
+	m_peermajor = 0;
+	m_peerminor = 0;
+
+	m_devicename.clear();
+	m_devicerole.clear();
+	m_deviceid.clear();
+	m_firmwareversion.clear();
+	m_hardwareversion.clear();
+
+	m_handles.clear();
+	m_handlelookup.clear();
+	m_subscriptions.clear();
+	m_controlsequence.clear();
+	m_transactions.clear();
+	m_transactionorder.clear();
+
+	m_uptime = 0.0;
+	m_lastreceived = 0.0;
+	m_heartbeattimer = 0.0;
+	m_pingtimer = 0.0;
+	m_pingpending = false;
+	m_ratewindow = 0.0;
+	m_framebudget = m_config.max_frames_per_second;
+	m_payloadbudget = m_config.max_payload_bytes_per_second;
+	m_commandbudget = m_config.max_commands_per_second;
+
+	m_contextvalid = false;
+	m_context = 0;
+
+	m_diagnostics = protocol_diagnostics {};
+	m_devicediagnostics = device_diagnostics {};
+}
+
+link_state protocol_session::link_condition() const
+{
+	if( m_state == session_state::waiting_for_hello )
+	{
+		return link_state::connecting;
+	}
+	if( m_diagnostics.missed_heartbeats <= 2 )
+	{
+		return link_state::healthy;
+	}
+	if( m_diagnostics.missed_heartbeats <= 4 )
+	{
+		return link_state::degraded;
+	}
+	return link_state::error;
+}
+
+void protocol_session::add_frame_errors( frame_decoder::counters const &Delta )
+{
+	m_diagnostics.crc_errors += Delta.crc_errors;
+	m_diagnostics.frame_errors += Delta.frame_errors;
+	m_diagnostics.length_errors += Delta.length_errors;
+}
+
+void protocol_session::send( message_type const Type, std::uint8_t const Flags, payload_writer const &Payload )
+{
+	packet_header header;
+	header.flags = Flags;
+	header.type = Type;
+	header.session_id = m_sessionid;
+	header.sequence = m_sequence++;
+	header.timestamp_ms = static_cast<std::uint32_t>( m_uptime * 1000.0 );
+	header.payload_length = static_cast<std::uint16_t>( Payload.size() );
+
+	m_output.send_packet( header, Payload.buffer() );
+
+	++m_diagnostics.tx_frames;
+	m_txrate.add();
+
+	if( true == m_config.debug_frames )
+	{
+		WriteLog( "hardware: tx " + std::string( to_string( Type ) ) + ", " + std::to_string( Payload.size() ) + " bytes" );
+	}
+}
+
+void protocol_session::send_ack( std::uint32_t const Transaction, message_type const Type )
+{
+	payload_writer writer;
+	writer.write_uint32( Transaction );
+	writer.write_uint16( static_cast<std::uint16_t>( Type ) );
+	send( message_type::ack, packetflag_response, writer );
+	++m_diagnostics.acks;
+}
+
+void protocol_session::send_nack( std::uint32_t const Transaction, message_type const Type, error_code const Error )
+{
+	payload_writer writer;
+	writer.write_uint32( Transaction );
+	writer.write_uint16( static_cast<std::uint16_t>( Type ) );
+	writer.write_uint16( static_cast<std::uint16_t>( Error ) );
+	send( message_type::nack, packetflag_response | packetflag_error, writer );
+	++m_diagnostics.nacks;
+
+	if( true == m_config.debug )
+	{
+		WriteLog( "hardware: nack " + std::string( to_string( Type ) ) + ", " + std::string( to_string( Error ) ) );
+	}
+}
+
+std::size_t protocol_session::symbol_of_handle( std::uint16_t const Handle ) const
+{
+	if( ( Handle == 0 ) || ( Handle > m_handles.size() ) )
+	{
+		return symbol_registry::npos;
+	}
+	return m_handles[ Handle - 1 ];
+}
+
+std::uint16_t protocol_session::handle_of_symbol( std::size_t const SymbolIndex )
+{
+	auto const lookup = m_handlelookup.find( SymbolIndex );
+	if( lookup != m_handlelookup.end() )
+	{
+		return lookup->second;
+	}
+	if( m_handles.size() >= handles_max )
+	{
+		return 0;
+	}
+	m_handles.emplace_back( SymbolIndex );
+	auto const handle = static_cast<std::uint16_t>( m_handles.size() );
+	m_handlelookup.emplace( SymbolIndex, handle );
+	return handle;
+}
+
+bool protocol_session::consume_frame_budget( std::size_t const PayloadSize )
+{
+	if( ( m_framebudget <= 0 ) || ( m_payloadbudget < static_cast<int>( PayloadSize ) ) )
+	{
+		return false;
+	}
+	--m_framebudget;
+	m_payloadbudget -= static_cast<int>( PayloadSize );
+	return true;
+}
+
+bool protocol_session::consume_command_budget()
+{
+	if( m_commandbudget <= 0 )
+	{
+		return false;
+	}
+	--m_commandbudget;
+	return true;
+}
+
+bool protocol_session::remember_transaction( std::uint32_t const Transaction, transaction_result const &Result )
+{
+	if( Transaction == 0 )
+	{
+		// transaction id zero means the device doesn't care about duplicate protection
+		return false;
+	}
+	m_transactions[ Transaction ] = Result;
+	m_transactionorder.emplace_back( Transaction );
+	while( m_transactionorder.size() > transaction_cache_size )
+	{
+		m_transactions.erase( m_transactionorder.front() );
+		m_transactionorder.pop_front();
+	}
+	return true;
+}
+
+protocol_session::transaction_result const *protocol_session::recall_transaction( std::uint32_t const Transaction ) const
+{
+	if( Transaction == 0 )
+	{
+		return nullptr;
+	}
+	auto const lookup = m_transactions.find( Transaction );
+	return ( lookup != m_transactions.end() ? &lookup->second : nullptr );
+}
+
+void protocol_session::handle_packet( decoded_packet const &Packet )
+{
+	++m_diagnostics.rx_frames;
+	m_rxrate.add();
+	m_lastreceived = m_uptime;
+
+	if( false == consume_frame_budget( Packet.payload.size() ) )
+	{
+		++m_diagnostics.rate_limited;
+		return;
+	}
+
+	if( Packet.header.protocol_major != protocol_version_major )
+	{
+		++m_diagnostics.version_errors;
+		if( Packet.header.type == message_type::hello )
+		{
+			send_nack( 0, message_type::hello, error_code::unsupported_version );
+		}
+		return;
+	}
+
+	if( true == m_sequenceseen )
+	{
+		if( Packet.header.sequence != m_lastreceivedsequence + 1 )
+		{
+			++m_diagnostics.sequence_gaps;
+		}
+	}
+	m_lastreceivedsequence = Packet.header.sequence;
+	m_sequenceseen = true;
+
+	if( true == m_config.debug_frames )
+	{
+		WriteLog( "hardware: rx " + std::string( to_string( Packet.header.type ) ) + ", " + std::to_string( Packet.payload.size() ) + " bytes" );
+	}
+
+	if( Packet.header.type == message_type::hello )
+	{
+		handle_hello( Packet );
+		return;
+	}
+
+	if( Packet.header.type == message_type::ping )
+	{
+		payload_reader reader( Packet.payload );
+		auto const token = reader.read_uint32();
+		payload_writer writer;
+		writer.write_uint32( token );
+		send( message_type::pong, packetflag_response, writer );
+		return;
+	}
+
+	// everything past this point belongs to an established session
+	if( ( m_state == session_state::waiting_for_hello ) || ( Packet.header.session_id != m_sessionid ) )
+	{
+		send_nack( 0, Packet.header.type, error_code::invalid_session );
+		return;
+	}
+
+	switch( Packet.header.type )
+	{
+		case message_type::heartbeat:
+			handle_heartbeat( Packet );
+			break;
+
+		case message_type::pong:
+		{
+			payload_reader reader( Packet.payload );
+			auto const token = reader.read_uint32();
+			if( ( true == m_pingpending ) && ( token == m_pingtoken ) )
+			{
+				m_diagnostics.round_trip_time_ms = ( m_uptime - m_pingsent ) * 1000.0;
+				m_pingpending = false;
+			}
+			break;
+		}
+
+		case message_type::device_ready:
+			m_state = session_state::ready;
+			if( true == m_config.debug )
+			{
+				WriteLog( "hardware: device '" + m_devicename + "' is ready" );
+			}
+			break;
+
+		case message_type::device_diagnostics:
+			handle_device_diagnostics( Packet );
+			break;
+
+		case message_type::resolve_symbols:
+			handle_resolve_symbols( Packet );
+			break;
+
+		case message_type::query_symbol:
+			handle_query_symbol( Packet );
+			break;
+
+		case message_type::subscribe:
+			handle_subscribe( Packet );
+			break;
+
+		case message_type::unsubscribe:
+			handle_unsubscribe( Packet );
+			break;
+
+		case message_type::command_event:
+			handle_command_event( Packet );
+			break;
+
+		case message_type::control_set:
+			handle_control_set( Packet );
+			break;
+
+		case message_type::control_claim:
+		case message_type::control_release:
+		case message_type::property_read:
+		case message_type::property_write:
+			// reserved for a later revision
+			send_nack( 0, Packet.header.type, error_code::unsupported_operation );
+			break;
+
+		default:
+			++m_diagnostics.unknown_messages;
+			if( ( Packet.header.flags & packetflag_ack_required ) != 0 )
+			{
+				send_nack( 0, Packet.header.type, error_code::unknown_message );
+			}
+			break;
+	}
+}
+
+void protocol_session::handle_hello( decoded_packet const &Packet )
+{
+	payload_reader reader( Packet.payload );
+
+	auto const major = reader.read_uint8();
+	auto const minor = reader.read_uint8();
+	auto const framesize = reader.read_uint16();
+	auto const capabilities = reader.read_uint32();
+	auto const name = reader.read_string();
+	auto const role = reader.read_string();
+
+	std::string deviceid;
+	std::string firmware;
+	std::string hardware;
+	// the remaining fields are optional, a minimal controller simply doesn't send them
+	if( ( true == reader.ok() ) && ( false == reader.exhausted() ) ) { deviceid = reader.read_string(); }
+	if( ( true == reader.ok() ) && ( false == reader.exhausted() ) ) { firmware = reader.read_string(); }
+	if( ( true == reader.ok() ) && ( false == reader.exhausted() ) ) { hardware = reader.read_string(); }
+
+	if( false == reader.ok() )
+	{
+		++m_diagnostics.length_errors;
+		send_nack( 0, message_type::hello, error_code::invalid_length );
+		return;
+	}
+
+	if( major != protocol_version_major )
+	{
+		++m_diagnostics.version_errors;
+		send_nack( 0, message_type::hello, error_code::unsupported_version );
+		return;
+	}
+
+	if( true == name.empty() )
+	{
+		send_nack( 0, message_type::hello, error_code::invalid_field );
+		return;
+	}
+
+	// a fresh hello always starts a new session, invalidating whatever the previous one held
+	m_handles.clear();
+	m_handlelookup.clear();
+	m_subscriptions.clear();
+	m_controlsequence.clear();
+	m_transactions.clear();
+	m_transactionorder.clear();
+
+	m_peermajor = major;
+	m_peerminor = minor;
+	m_capabilities = capabilities;
+	m_devicename = name;
+	m_devicerole = role;
+	m_deviceid = deviceid;
+	m_firmwareversion = firmware;
+	m_hardwareversion = hardware;
+
+	auto const requested = ( framesize > 0 ? static_cast<std::size_t>( framesize ) : protocol_frame_size_default );
+	m_framesize = std::clamp<std::size_t>( std::min( requested, m_config.frame_size ), protocol_frame_size_min, protocol_frame_size_max );
+
+	m_sessionid = generate_session_id();
+	m_state = session_state::established;
+	m_heartbeattimer = 0.0;
+	m_pingtimer = 0.0;
+	m_pingpending = false;
+	m_contextvalid = false;
+
+	payload_writer writer;
+	writer.write_uint8( protocol_version_major );
+	writer.write_uint8( protocol_version_minor );
+	writer.write_uint32( m_sessionid );
+	writer.write_uint16( static_cast<std::uint16_t>( m_framesize ) );
+	writer.write_uint16( static_cast<std::uint16_t>( m_config.heartbeat_interval_ms ) );
+	writer.write_string( Global.asVersion );
+	send( message_type::welcome, packetflag_response, writer );
+
+	WriteLog( "hardware: session " + std::to_string( m_sessionid ) + " established with '" + m_devicename + "' (" + m_devicerole + ")" );
+}
+
+void protocol_session::handle_heartbeat( decoded_packet const &Packet )
+{
+	payload_reader reader( Packet.payload );
+	// the fields are informational; a device is free to send an empty heartbeat
+	reader.read_uint32();
+	reader.read_uint32();
+	reader.read_uint16();
+}
+
+void protocol_session::handle_device_diagnostics( decoded_packet const &Packet )
+{
+	payload_reader reader( Packet.payload );
+
+	device_diagnostics diagnostics;
+	diagnostics.available = true;
+	diagnostics.uptime_ms = reader.read_uint32();
+	// every field past the uptime is optional
+	if( ( true == reader.ok() ) && ( false == reader.exhausted() ) ) { diagnostics.supply_voltage = reader.read_float32(); }
+	if( ( true == reader.ok() ) && ( false == reader.exhausted() ) ) { diagnostics.temperature = reader.read_float32(); }
+	if( ( true == reader.ok() ) && ( false == reader.exhausted() ) ) { diagnostics.rx_overflows = reader.read_uint32(); }
+	if( ( true == reader.ok() ) && ( false == reader.exhausted() ) ) { diagnostics.tx_overflows = reader.read_uint32(); }
+	if( ( true == reader.ok() ) && ( false == reader.exhausted() ) ) { diagnostics.watchdog_resets = reader.read_uint32(); }
+	if( ( true == reader.ok() ) && ( false == reader.exhausted() ) ) { diagnostics.firmware_build = reader.read_string(); }
+
+	if( false == reader.ok() )
+	{
+		++m_diagnostics.length_errors;
+		return;
+	}
+
+	m_devicediagnostics = diagnostics;
+}
+
+void protocol_session::handle_resolve_symbols( decoded_packet const &Packet )
+{
+	payload_reader reader( Packet.payload );
+	auto const transaction = reader.read_uint32();
+	auto const count = reader.read_uint8();
+
+	if( ( false == reader.ok() ) || ( count > protocol_symbols_per_message_max ) )
+	{
+		send_nack( transaction, message_type::resolve_symbols, error_code::invalid_field );
+		return;
+	}
+
+	auto const &symbols = symbol_registry::instance().entries();
+
+	payload_writer writer;
+	writer.write_uint32( transaction );
+	writer.write_uint8( count );
+
+	for( std::size_t index = 0; index < count; ++index )
+	{
+		auto const name = reader.read_string( protocol_symbol_name_max );
+		if( false == reader.ok() )
+		{
+			send_nack( transaction, message_type::resolve_symbols, error_code::invalid_length );
+			return;
+		}
+
+		auto const symbolindex = symbol_registry::instance().find( name );
+		if( symbolindex == symbol_registry::npos )
+		{
+			++m_diagnostics.unknown_symbols;
+			// handle zero tells the device the symbol isn't available in this simulator build
+			writer.write_uint16( 0 );
+			writer.write_uint8( 0 );
+			writer.write_uint8( static_cast<std::uint8_t>( value_type::none ) );
+			writer.write_uint8( 0 );
+			continue;
+		}
+
+		auto const &symbol = symbols[ symbolindex ];
+		writer.write_uint16( handle_of_symbol( symbolindex ) );
+		writer.write_uint8( static_cast<std::uint8_t>( symbol.kind ) );
+		writer.write_uint8( static_cast<std::uint8_t>( symbol.type ) );
+		writer.write_uint8( symbol.access );
+	}
+
+	send( message_type::symbols_resolved, packetflag_response, writer );
+}
+
+void protocol_session::handle_query_symbol( decoded_packet const &Packet )
+{
+	payload_reader reader( Packet.payload );
+	auto const transaction = reader.read_uint32();
+	auto const handle = reader.read_uint16();
+
+	if( false == reader.ok() )
+	{
+		send_nack( transaction, message_type::query_symbol, error_code::invalid_length );
+		return;
+	}
+
+	auto const symbolindex = symbol_of_handle( handle );
+	if( symbolindex == symbol_registry::npos )
+	{
+		++m_diagnostics.unknown_handles;
+		send_nack( transaction, message_type::query_symbol, error_code::unknown_handle );
+		return;
+	}
+
+	auto const &symbol = symbol_registry::instance().entries()[ symbolindex ];
+
+	payload_writer writer;
+	writer.write_uint32( transaction );
+	writer.write_uint16( handle );
+	writer.write_uint8( static_cast<std::uint8_t>( symbol.kind ) );
+	writer.write_uint8( static_cast<std::uint8_t>( symbol.type ) );
+	writer.write_uint8( symbol.access );
+	writer.write_uint8( static_cast<std::uint8_t>( ( symbol.minimum ? 0x01 : 0x00 ) | ( symbol.maximum ? 0x02 : 0x00 ) ) );
+	writer.write_float32( static_cast<float>( symbol.minimum.value_or( 0.0 ) ) );
+	writer.write_float32( static_cast<float>( symbol.maximum.value_or( 0.0 ) ) );
+	writer.write_string( symbol.name );
+	writer.write_string( symbol.unit );
+	send( message_type::symbol_info, packetflag_response, writer );
+}
+
+void protocol_session::handle_subscribe( decoded_packet const &Packet )
+{
+	payload_reader reader( Packet.payload );
+	auto const transaction = reader.read_uint32();
+	auto const count = reader.read_uint8();
+
+	if( ( false == reader.ok() ) || ( count > protocol_symbols_per_message_max ) )
+	{
+		send_nack( transaction, message_type::subscribe, error_code::invalid_field );
+		return;
+	}
+
+	auto const &symbols = symbol_registry::instance().entries();
+
+	payload_writer writer;
+	writer.write_uint32( transaction );
+	writer.write_uint8( count );
+
+	for( std::size_t index = 0; index < count; ++index )
+	{
+		auto const handle = reader.read_uint16();
+		auto const mode = static_cast<subscription_mode>( reader.read_uint8() );
+		auto const period = reader.read_uint16();
+		auto const deadband = reader.read_float32();
+
+		if( false == reader.ok() )
+		{
+			send_nack( transaction, message_type::subscribe, error_code::invalid_length );
+			return;
+		}
+
+		auto result = error_code::none;
+		auto const symbolindex = symbol_of_handle( handle );
+		if( symbolindex == symbol_registry::npos )
+		{
+			++m_diagnostics.unknown_handles;
+			result = error_code::unknown_handle;
+		}
+		else if( symbols[ symbolindex ].kind != symbol_kind::state )
+		{
+			result = error_code::access_denied;
+		}
+		else
+		{
+			result = m_subscriptions.subscribe( handle, symbolindex, symbols[ symbolindex ].source_index, mode, period, deadband );
+		}
+
+		writer.write_uint16( handle );
+		writer.write_uint16( static_cast<std::uint16_t>( result ) );
+	}
+
+	send( message_type::subscribe_result, packetflag_response, writer );
+
+	// the device initialises its gauges and indicators from the initial snapshot
+	std::vector<state_item> items;
+	m_subscriptions.collect( 0.0, m_snapshot, true, items );
+	send_state_update( items, true );
+}
+
+void protocol_session::handle_unsubscribe( decoded_packet const &Packet )
+{
+	payload_reader reader( Packet.payload );
+	auto const transaction = reader.read_uint32();
+	auto const count = reader.read_uint8();
+
+	if( ( false == reader.ok() ) || ( count > protocol_symbols_per_message_max ) )
+	{
+		send_nack( transaction, message_type::unsubscribe, error_code::invalid_field );
+		return;
+	}
+
+	for( std::size_t index = 0; index < count; ++index )
+	{
+		auto const handle = reader.read_uint16();
+		if( false == reader.ok() )
+		{
+			send_nack( transaction, message_type::unsubscribe, error_code::invalid_length );
+			return;
+		}
+		m_subscriptions.unsubscribe( handle );
+	}
+
+	send_ack( transaction, message_type::unsubscribe );
+}
+
+void protocol_session::handle_command_event( decoded_packet const &Packet )
+{
+	payload_reader reader( Packet.payload );
+	auto const transaction = reader.read_uint32();
+	auto const handle = reader.read_uint16();
+	auto const action = reader.read_uint8();
+	auto const parameter1 = reader.read_float32();
+	auto const parameter2 = reader.read_float32();
+	auto const entity = reader.read_uint32();
+
+	bool const acknowledge = ( ( Packet.header.flags & packetflag_ack_required ) != 0 );
+
+	if( false == reader.ok() )
+	{
+		++m_diagnostics.length_errors;
+		if( true == acknowledge )
+		{
+			send_nack( transaction, message_type::command_event, error_code::invalid_length );
+		}
+		return;
+	}
+
+	// a retransmission of an already executed command must not execute it a second time
+	if( auto const *previous = recall_transaction( transaction ) )
+	{
+		++m_diagnostics.duplicate_commands;
+		if( true == acknowledge )
+		{
+			if( true == previous->accepted )
+			{
+				send_ack( transaction, message_type::command_event );
+			}
+			else
+			{
+				send_nack( transaction, message_type::command_event, previous->error );
+			}
+		}
+		return;
+	}
+
+	auto result = error_code::none;
+
+	if( m_state != session_state::ready )
+	{
+		result = error_code::not_ready;
+	}
+	else if( false == consume_command_budget() )
+	{
+		++m_diagnostics.rate_limited;
+		result = error_code::rate_limited;
+	}
+	else if( action > static_cast<std::uint8_t>( command_action::repeat ) )
+	{
+		result = error_code::invalid_field;
+	}
+	else if( ( false == std::isfinite( parameter1 ) ) || ( false == std::isfinite( parameter2 ) ) )
+	{
+		result = error_code::invalid_field;
+	}
+	else
+	{
+		auto const symbolindex = symbol_of_handle( handle );
+		if( symbolindex == symbol_registry::npos )
+		{
+			++m_diagnostics.unknown_handles;
+			result = error_code::unknown_handle;
+		}
+		else if( symbol_registry::instance().entries()[ symbolindex ].kind != symbol_kind::command )
+		{
+			result = error_code::access_denied;
+		}
+		else
+		{
+			result = execute_command( symbolindex, static_cast<command_action>( action ), parameter1, parameter2, static_cast<std::uint16_t>( entity ) );
+		}
+	}
+
+	transaction_result const outcome { result == error_code::none, result };
+	remember_transaction( transaction, outcome );
+
+	if( true == acknowledge )
+	{
+		if( true == outcome.accepted )
+		{
+			send_ack( transaction, message_type::command_event );
+		}
+		else
+		{
+			send_nack( transaction, message_type::command_event, result );
+		}
+	}
+}
+
+void protocol_session::handle_control_set( decoded_packet const &Packet )
+{
+	payload_reader reader( Packet.payload );
+	auto const handle = reader.read_uint16();
+	auto const sequence = reader.read_uint32();
+	auto const value = reader.read_float32();
+	auto const entity = reader.read_uint32();
+
+	if( false == reader.ok() )
+	{
+		++m_diagnostics.length_errors;
+		return;
+	}
+
+	if( m_state != session_state::ready )
+	{
+		send_nack( 0, message_type::control_set, error_code::not_ready );
+		return;
+	}
+
+	// updates are idempotent, so a late one is simply dropped
+	auto const previous = m_controlsequence.find( handle );
+	if( previous != m_controlsequence.end() )
+	{
+		if( static_cast<std::int32_t>( sequence - previous->second ) <= 0 )
+		{
+			return;
+		}
+	}
+	m_controlsequence[ handle ] = sequence;
+
+	auto const symbolindex = symbol_of_handle( handle );
+	if( symbolindex == symbol_registry::npos )
+	{
+		++m_diagnostics.unknown_handles;
+		send_nack( 0, message_type::control_set, error_code::unknown_handle );
+		return;
+	}
+
+	auto const &symbol = symbol_registry::instance().entries()[ symbolindex ];
+	if( symbol.kind != symbol_kind::command )
+	{
+		send_nack( 0, message_type::control_set, error_code::access_denied );
+		return;
+	}
+
+	auto const &descriptor = command_registry::instance().entries()[ symbol.source_index ];
+	if( false == descriptor.continuous )
+	{
+		send_nack( 0, message_type::control_set, error_code::wrong_type );
+		return;
+	}
+
+	if( false == std::isfinite( value ) )
+	{
+		send_nack( 0, message_type::control_set, error_code::invalid_field );
+		return;
+	}
+
+	// values outside the declared range are rejected rather than silently clipped
+	if( ( descriptor.minimum && ( value < *descriptor.minimum ) ) || ( descriptor.maximum && ( value > *descriptor.maximum ) ) )
+	{
+		send_nack( 0, message_type::control_set, error_code::out_of_range );
+		return;
+	}
+
+	if( false == consume_command_budget() )
+	{
+		++m_diagnostics.rate_limited;
+		return;
+	}
+
+	auto const result = execute_command( symbolindex, command_action::press, value, 0.0, static_cast<std::uint16_t>( entity ) );
+	if( result == error_code::none )
+	{
+		++m_diagnostics.controls_applied;
+	}
+	else
+	{
+		send_nack( 0, message_type::control_set, result );
+	}
+}
+
+error_code protocol_session::execute_command( std::size_t const SymbolIndex, command_action const Action, double const Parameter1, double const Parameter2, std::uint16_t const Recipient )
+{
+	auto const &symbol = symbol_registry::instance().entries()[ SymbolIndex ];
+	auto const &descriptor = command_registry::instance().entries()[ symbol.source_index ];
+
+	if( descriptor.command == user_command::none )
+	{
+		return error_code::unsupported_operation;
+	}
+
+	double parameter = Parameter1;
+
+	if( descriptor.transform == command_transform::mastercontroller_percent )
+	{
+		auto *train = simulation::Train;
+		if( ( train == nullptr ) || ( train->Occupied() == nullptr ) )
+		{
+			return error_code::not_ready;
+		}
+		auto const percentage = std::clamp( Parameter1, 0.0, 1.0 );
+		auto const positions = train->Occupied()->MainCtrlPosNo;
+		parameter = ( percentage > 0.01 ? 1.0 + ( positions - 1 ) * percentage : 0.0 );
+		train->Occupied()->eimic_analog = percentage;
+	}
+
+	m_relay.post( descriptor.command, parameter, Parameter2, glfw_action( Action ), Recipient );
+	++m_diagnostics.commands_executed;
+
+	return error_code::none;
+}
+
+void protocol_session::send_state_update( std::vector<state_item> const &Items, bool const Snapshot )
+{
+	if( true == Items.empty() )
+	{
+		return;
+	}
+
+	std::size_t const budget = ( m_framesize > protocol_header_size + protocol_crc_size ? m_framesize - protocol_header_size - protocol_crc_size : 64 );
+	std::uint8_t const flags = ( Snapshot ? packetflag_snapshot : packetflag_none );
+
+	payload_writer writer;
+	writer.write_uint16( 0 );
+	std::uint16_t count = 0;
+
+	for( auto const &item : Items )
+	{
+		std::size_t const itemsize = 2 + 1 + 1 + state_value_size( item.value );
+		if( ( count > 0 ) && ( writer.size() + itemsize > budget ) )
+		{
+			writer.patch_uint16( 0, count );
+			send( message_type::state_update, flags, writer );
+			++m_diagnostics.state_updates;
+			writer.clear();
+			writer.write_uint16( 0 );
+			count = 0;
+		}
+
+		writer.write_uint16( item.handle );
+		writer.write_uint8( static_cast<std::uint8_t>( item.value.type ) );
+		writer.write_uint8( static_cast<std::uint8_t>( item.value.quality ) );
+		write_state_value( writer, item.value );
+		++count;
+	}
+
+	if( count > 0 )
+	{
+		writer.patch_uint16( 0, count );
+		send( message_type::state_update, flags, writer );
+		++m_diagnostics.state_updates;
+	}
+}
+
+void protocol_session::send_symbol_context_changed( std::uint32_t const Context )
+{
+	payload_writer writer;
+	writer.write_uint32( Context );
+	send( message_type::symbol_context_changed, packetflag_none, writer );
+}
+
+void protocol_session::update( double const Deltatime, state_snapshot const &Snapshot )
+{
+	m_snapshot = Snapshot;
+	m_uptime += Deltatime;
+
+	m_rxrate.update( Deltatime );
+	m_txrate.update( Deltatime );
+	m_diagnostics.rx_rate = m_rxrate.rate();
+	m_diagnostics.tx_rate = m_txrate.rate();
+	m_diagnostics.connection_uptime = m_uptime;
+	m_diagnostics.last_rx_age = m_uptime - m_lastreceived;
+
+	m_ratewindow += Deltatime;
+	if( m_ratewindow >= 1.0 )
+	{
+		m_ratewindow = 0.0;
+		m_framebudget = m_config.max_frames_per_second;
+		m_payloadbudget = m_config.max_payload_bytes_per_second;
+		m_commandbudget = m_config.max_commands_per_second;
+	}
+
+	if( m_state == session_state::waiting_for_hello )
+	{
+		return;
+	}
+
+	double const heartbeatinterval = std::max( 0.05, m_config.heartbeat_interval_ms * 0.001 );
+	m_diagnostics.missed_heartbeats = static_cast<int>( m_diagnostics.last_rx_age / heartbeatinterval );
+
+	if( m_diagnostics.missed_heartbeats >= m_config.heartbeat_timeout_count )
+	{
+		WriteLog( "hardware: device '" + m_devicename + "' stopped responding, session closed" );
+		reset();
+		return;
+	}
+
+	// the metadata of some symbols depends on the controlled vehicle
+	if( ( true == Snapshot.available ) && ( ( false == m_contextvalid ) || ( Snapshot.context_id != m_context ) ) )
+	{
+		bool const notify = m_contextvalid;
+		m_context = Snapshot.context_id;
+		m_contextvalid = true;
+		if( true == notify )
+		{
+			send_symbol_context_changed( m_context );
+		}
+	}
+
+	m_heartbeattimer += Deltatime;
+	if( m_heartbeattimer >= heartbeatinterval )
+	{
+		m_heartbeattimer = 0.0;
+		payload_writer writer;
+		writer.write_uint32( static_cast<std::uint32_t>( m_uptime * 1000.0 ) );
+		writer.write_uint32( m_lastreceivedsequence );
+		writer.write_uint16( static_cast<std::uint16_t>( m_state ) );
+		send( message_type::heartbeat, packetflag_none, writer );
+	}
+
+	m_pingtimer += Deltatime;
+	if( ( false == m_pingpending ) && ( m_pingtimer >= ping_interval ) )
+	{
+		m_pingtimer = 0.0;
+		m_pingpending = true;
+		m_pingsent = m_uptime;
+		++m_pingtoken;
+		payload_writer writer;
+		writer.write_uint32( m_pingtoken );
+		send( message_type::ping, packetflag_none, writer );
+	}
+	else if( ( true == m_pingpending ) && ( m_uptime - m_pingsent > ping_interval ) )
+	{
+		// the answer never arrived, try again later
+		m_pingpending = false;
+		m_pingtimer = 0.0;
+	}
+
+	std::vector<state_item> items;
+	m_subscriptions.collect( Deltatime, Snapshot, false, items );
+	send_state_update( items, false );
+}
+
+void protocol_session::fill_report( link_report &Report ) const
+{
+	Report.device_name = m_devicename;
+	Report.device_role = m_devicerole;
+	Report.device_id = m_deviceid;
+	Report.firmware_version = m_firmwareversion;
+	Report.session = m_state;
+	Report.session_id = m_sessionid;
+	Report.protocol_major = m_peermajor;
+	Report.protocol_minor = m_peerminor;
+	Report.handles = m_handles.size();
+	Report.subscriptions = m_subscriptions.size();
+	Report.frame_size = m_framesize;
+	Report.protocol = m_diagnostics;
+	Report.device = m_devicediagnostics;
+}
+
+} // namespace hardware

--- a/hardware/protocol/protocol_session.cpp
+++ b/hardware/protocol/protocol_session.cpp
@@ -108,6 +108,7 @@ void protocol_session::reset()
 	m_sequence = 0;
 	m_lastreceivedsequence = 0;
 	m_sequenceseen = false;
+	m_outgoingtransaction = 0;
 	m_framesize = std::clamp<std::size_t>( m_config.frame_size, protocol_frame_size_min, protocol_frame_size_max );
 	m_capabilities = 0;
 	m_peermajor = 0;
@@ -141,6 +142,10 @@ void protocol_session::reset()
 
 	m_diagnostics = protocol_diagnostics {};
 	m_devicediagnostics = device_diagnostics {};
+	m_functions.clear();
+	m_diagnostic = diagnostic_report {};
+	m_prompt = diagnostic_prompt {};
+	m_log.clear();
 }
 
 link_state protocol_session::link_condition() const
@@ -374,6 +379,30 @@ void protocol_session::handle_packet( decoded_packet const &Packet )
 
 		case message_type::device_diagnostics:
 			handle_device_diagnostics( Packet );
+			break;
+
+		case message_type::device_log:
+			handle_device_log( Packet );
+			break;
+
+		case message_type::diagnostic_functions:
+			handle_diagnostic_functions( Packet );
+			break;
+
+		case message_type::diagnostic_status:
+			handle_diagnostic_status( Packet );
+			break;
+
+		case message_type::diagnostic_prompt:
+			handle_diagnostic_prompt( Packet );
+			break;
+
+		case message_type::ack:
+			handle_device_answer( Packet, true );
+			break;
+
+		case message_type::nack:
+			handle_device_answer( Packet, false );
 			break;
 
 		case message_type::resolve_symbols:
@@ -906,6 +935,212 @@ error_code protocol_session::execute_command( std::size_t const SymbolIndex, com
 	return error_code::none;
 }
 
+void protocol_session::handle_device_log( decoded_packet const &Packet )
+{
+	payload_reader reader( Packet.payload );
+	auto const severity = static_cast<log_severity>( reader.read_uint8() );
+	auto const uptime = reader.read_uint32();
+	auto const text = reader.read_string();
+
+	if( ( false == reader.ok() ) || ( true == text.empty() ) )
+	{
+		++m_diagnostics.length_errors;
+		return;
+	}
+
+	device_log_entry entry;
+	entry.severity = ( severity <= log_severity::error ? severity : log_severity::info );
+	entry.device_uptime_ms = uptime;
+	entry.text = text;
+	m_log.emplace_back( std::move( entry ) );
+	while( m_log.size() > protocol_log_history )
+	{
+		m_log.pop_front();
+	}
+
+	// debug chatter stays in the panel, anything the device considers worth reporting
+	// also goes to the simulator log
+	if( ( severity != log_severity::debug ) || ( true == debug_flags.log_messages ) )
+	{
+		auto const line = "hardware: [" + m_devicename + "] " + std::string( to_string( severity ) ) + ": " + text;
+		if( severity == log_severity::error )
+		{
+			ErrorLog( line );
+		}
+		else
+		{
+			WriteLog( line );
+		}
+	}
+}
+
+void protocol_session::handle_diagnostic_functions( decoded_packet const &Packet )
+{
+	payload_reader reader( Packet.payload );
+	auto const count = reader.read_uint8();
+	if( ( false == reader.ok() ) || ( count > protocol_diagnostic_functions_max ) )
+	{
+		send_nack( 0, message_type::diagnostic_functions, error_code::invalid_field );
+		return;
+	}
+
+	std::vector<diagnostic_function> functions;
+	functions.reserve( count );
+	for( std::size_t index = 0; index < count; ++index )
+	{
+		diagnostic_function function;
+		function.id = reader.read_uint8();
+		function.name = reader.read_string();
+		if( false == reader.ok() )
+		{
+			send_nack( 0, message_type::diagnostic_functions, error_code::invalid_length );
+			return;
+		}
+		if( false == function.name.empty() )
+		{
+			functions.emplace_back( std::move( function ) );
+		}
+	}
+
+	m_functions = std::move( functions );
+	if( true == debug_flags.log_messages )
+	{
+		WriteLog( "hardware: device '" + m_devicename + "' offers " + std::to_string( m_functions.size() ) + " diagnostic function(s)" );
+	}
+}
+
+void protocol_session::handle_diagnostic_status( decoded_packet const &Packet )
+{
+	payload_reader reader( Packet.payload );
+	auto const function = reader.read_uint8();
+	auto const state = static_cast<diagnostic_state>( reader.read_uint8() );
+	auto const progress = reader.read_uint8();
+	auto const message = reader.read_string();
+
+	if( ( false == reader.ok() ) || ( state > diagnostic_state::failed ) )
+	{
+		++m_diagnostics.length_errors;
+		return;
+	}
+
+	m_diagnostic.function = function;
+	m_diagnostic.state = state;
+	m_diagnostic.progress = ( progress <= 100 ? progress : 100 );
+	m_diagnostic.message = message;
+
+	if( state != diagnostic_state::running )
+	{
+		// a routine which ended cannot be waiting for an answer any more
+		m_prompt = diagnostic_prompt {};
+		WriteLog( "hardware: device '" + m_devicename + "' diagnostic " + std::to_string( function ) + " " + std::string( to_string( state ) ) + ( message.empty() ? "" : ": " + message ) );
+	}
+}
+
+void protocol_session::handle_diagnostic_prompt( decoded_packet const &Packet )
+{
+	payload_reader reader( Packet.payload );
+	diagnostic_prompt prompt;
+	prompt.id = reader.read_uint32();
+	prompt.text = reader.read_string();
+	auto const options = reader.read_uint8();
+
+	if( ( false == reader.ok() ) || ( options > protocol_prompt_options_max ) )
+	{
+		send_nack( 0, message_type::diagnostic_prompt, error_code::invalid_field );
+		return;
+	}
+
+	for( std::size_t index = 0; index < options; ++index )
+	{
+		auto label = reader.read_string();
+		if( false == reader.ok() )
+		{
+			send_nack( 0, message_type::diagnostic_prompt, error_code::invalid_length );
+			return;
+		}
+		prompt.options.emplace_back( std::move( label ) );
+	}
+
+	if( true == prompt.options.empty() )
+	{
+		prompt.options.emplace_back( "OK" );
+	}
+	prompt.active = true;
+	m_prompt = std::move( prompt );
+}
+
+void protocol_session::handle_device_answer( decoded_packet const &Packet, bool const Positive )
+{
+	payload_reader reader( Packet.payload );
+	reader.read_uint32();
+	auto const message = static_cast<message_type>( reader.read_uint16() );
+	auto const error = ( Positive ? error_code::none : static_cast<error_code>( reader.read_uint16() ) );
+
+	if( false == reader.ok() )
+	{
+		++m_diagnostics.length_errors;
+		return;
+	}
+
+	if( ( message == message_type::diagnostic_run ) && ( false == Positive ) )
+	{
+		m_diagnostic.state = diagnostic_state::failed;
+		m_diagnostic.message = to_string( error );
+		WriteLog( "hardware: device '" + m_devicename + "' refused to start the diagnostic: " + std::string( to_string( error ) ) );
+	}
+}
+
+bool protocol_session::start_diagnostic( std::uint8_t const Function )
+{
+	if( m_state != session_state::ready )
+	{
+		return false;
+	}
+	auto const function = std::find_if( m_functions.begin(), m_functions.end(), [ Function ]( diagnostic_function const &Entry ) { return Entry.id == Function; } );
+	if( function == m_functions.end() )
+	{
+		return false;
+	}
+
+	payload_writer writer;
+	writer.write_uint32( ++m_outgoingtransaction );
+	writer.write_uint8( Function );
+	send( message_type::diagnostic_run, packetflag_ack_required, writer );
+
+	m_prompt = diagnostic_prompt {};
+	m_diagnostic.function = Function;
+	m_diagnostic.state = diagnostic_state::running;
+	m_diagnostic.progress = 0;
+	m_diagnostic.message = "requested";
+	WriteLog( "hardware: device '" + m_devicename + "' asked to run diagnostic '" + function->name + "'" );
+	return true;
+}
+
+void protocol_session::cancel_diagnostic()
+{
+	if( m_state != session_state::ready )
+	{
+		return;
+	}
+	payload_writer writer;
+	writer.write_uint8( m_diagnostic.function );
+	send( message_type::diagnostic_cancel, packetflag_none, writer );
+	m_prompt = diagnostic_prompt {};
+}
+
+void protocol_session::answer_prompt( std::uint8_t const Option )
+{
+	if( false == m_prompt.active )
+	{
+		return;
+	}
+	payload_writer writer;
+	writer.write_uint32( m_prompt.id );
+	writer.write_uint8( Option );
+	send( message_type::diagnostic_prompt_result, packetflag_response, writer );
+	m_prompt = diagnostic_prompt {};
+}
+
 void protocol_session::send_state_update( std::vector<state_item> const &Items, bool const Snapshot )
 {
 	if( true == Items.empty() )
@@ -1052,6 +1287,10 @@ void protocol_session::fill_report( link_report &Report ) const
 	Report.frame_size = m_framesize;
 	Report.protocol = m_diagnostics;
 	Report.device = m_devicediagnostics;
+	Report.functions = m_functions;
+	Report.diagnostic = m_diagnostic;
+	Report.prompt = m_prompt;
+	Report.log.assign( m_log.begin(), m_log.end() );
 }
 
 } // namespace hardware

--- a/hardware/protocol/protocol_session.cpp
+++ b/hardware/protocol/protocol_session.cpp
@@ -182,7 +182,7 @@ void protocol_session::send( message_type const Type, std::uint8_t const Flags, 
 	++m_diagnostics.tx_frames;
 	m_txrate.add();
 
-	if( true == m_config.debug_frames )
+	if( true == debug_flags.log_frames )
 	{
 		WriteLog( "hardware: tx " + std::string( to_string( Type ) ) + ", " + std::to_string( Payload.size() ) + " bytes" );
 	}
@@ -206,7 +206,7 @@ void protocol_session::send_nack( std::uint32_t const Transaction, message_type 
 	send( message_type::nack, packetflag_response | packetflag_error, writer );
 	++m_diagnostics.nacks;
 
-	if( true == m_config.debug )
+	if( true == debug_flags.log_messages )
 	{
 		WriteLog( "hardware: nack " + std::string( to_string( Type ) ) + ", " + std::string( to_string( Error ) ) );
 	}
@@ -318,7 +318,7 @@ void protocol_session::handle_packet( decoded_packet const &Packet )
 	m_lastreceivedsequence = Packet.header.sequence;
 	m_sequenceseen = true;
 
-	if( true == m_config.debug_frames )
+	if( true == debug_flags.log_frames )
 	{
 		WriteLog( "hardware: rx " + std::string( to_string( Packet.header.type ) ) + ", " + std::to_string( Packet.payload.size() ) + " bytes" );
 	}
@@ -366,7 +366,7 @@ void protocol_session::handle_packet( decoded_packet const &Packet )
 
 		case message_type::device_ready:
 			m_state = session_state::ready;
-			if( true == m_config.debug )
+			if( true == debug_flags.log_messages )
 			{
 				WriteLog( "hardware: device '" + m_devicename + "' is ready" );
 			}

--- a/hardware/protocol/protocol_session.h
+++ b/hardware/protocol/protocol_session.h
@@ -49,6 +49,8 @@ public:
 	void reset();
 	// consumes one decoded frame
 	void handle_packet( decoded_packet const &Packet );
+	// publishes the state of the current simulation frame, before the received frames are processed
+	void set_snapshot( state_snapshot const &Snapshot ) { m_snapshot = Snapshot; }
 	// periodic work: heartbeats, subscription updates, timeouts
 	void update( double const Deltatime, state_snapshot const &Snapshot );
 	// copies the current condition into the debug report

--- a/hardware/protocol/protocol_session.h
+++ b/hardware/protocol/protocol_session.h
@@ -56,6 +56,16 @@ public:
 	// copies the current condition into the debug report
 	void fill_report( link_report &Report ) const;
 
+	// ---- diagnostics offered by the device, driven from the debug panel ----
+	// starts one of the routines the device advertised; false when it isn't available
+	bool start_diagnostic( std::uint8_t const Function );
+	void cancel_diagnostic();
+	// answers the message box the device asked the simulator to show
+	void answer_prompt( std::uint8_t const Option );
+	bool has_prompt() const { return m_prompt.active; }
+	diagnostic_prompt const &prompt() const { return m_prompt; }
+	std::vector<diagnostic_function> const &functions() const { return m_functions; }
+
 	session_state state() const { return m_state; }
 	link_state link_condition() const;
 	protocol_diagnostics const &diagnostics() const { return m_diagnostics; }
@@ -84,6 +94,11 @@ private:
 	void handle_control_set( decoded_packet const &Packet );
 	void handle_device_diagnostics( decoded_packet const &Packet );
 	void handle_heartbeat( decoded_packet const &Packet );
+	void handle_device_log( decoded_packet const &Packet );
+	void handle_diagnostic_functions( decoded_packet const &Packet );
+	void handle_diagnostic_status( decoded_packet const &Packet );
+	void handle_diagnostic_prompt( decoded_packet const &Packet );
+	void handle_device_answer( decoded_packet const &Packet, bool const Positive );
 
 	void send_state_update( std::vector<state_item> const &Items, bool const Snapshot );
 	void send_symbol_context_changed( std::uint32_t const Context );
@@ -109,6 +124,8 @@ private:
 	std::uint32_t m_sessionid = 0;
 	std::uint32_t m_sequence = 0;
 	std::uint32_t m_lastreceivedsequence = 0;
+	// transaction numbering for the few requests the simulator itself makes
+	std::uint32_t m_outgoingtransaction = 0;
 	bool m_sequenceseen = false;
 	std::size_t m_framesize = protocol_frame_size_default;
 	std::uint32_t m_capabilities = 0;
@@ -150,6 +167,10 @@ private:
 
 	protocol_diagnostics m_diagnostics;
 	device_diagnostics m_devicediagnostics;
+	std::vector<diagnostic_function> m_functions;
+	diagnostic_report m_diagnostic;
+	diagnostic_prompt m_prompt;
+	std::deque<device_log_entry> m_log;
 	rate_counter m_rxrate;
 	rate_counter m_txrate;
 };

--- a/hardware/protocol/protocol_session.h
+++ b/hardware/protocol/protocol_session.h
@@ -1,0 +1,155 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <deque>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "hardware/diagnostics/hardware_diagnostics.h"
+#include "hardware/hardware_config.h"
+#include "hardware/protocol/protocol_codec.h"
+#include "hardware/registry/state_registry.h"
+#include "hardware/subscriptions/subscription_manager.h"
+#include "input/command.h"
+
+// logical protocol layer of one connection
+// runs on the simulation thread; the transport worker only hands over decoded frames, so nothing
+// here ever blocks on hardware, and nothing outside here touches simulation state
+
+namespace hardware
+{
+
+// sink for packets produced by the session
+class session_output
+{
+
+public:
+// methods
+	virtual ~session_output() = default;
+	virtual void send_packet( packet_header const &Header, std::vector<std::uint8_t> const &Payload ) = 0;
+};
+
+class protocol_session
+{
+
+public:
+// methods
+	protocol_session( session_output &Output, config const &Config );
+
+	// drops the session, called when the transport connection is lost
+	void reset();
+	// consumes one decoded frame
+	void handle_packet( decoded_packet const &Packet );
+	// periodic work: heartbeats, subscription updates, timeouts
+	void update( double const Deltatime, state_snapshot const &Snapshot );
+	// copies the current condition into the debug report
+	void fill_report( link_report &Report ) const;
+
+	session_state state() const { return m_state; }
+	link_state link_condition() const;
+	protocol_diagnostics const &diagnostics() const { return m_diagnostics; }
+	// adds the frame level error counts gathered by the transport worker since the last call
+	void add_frame_errors( frame_decoder::counters const &Delta );
+
+private:
+// types
+	struct transaction_result
+	{
+		bool accepted = false;
+		error_code error = error_code::none;
+	};
+
+// methods
+	void send( message_type const Type, std::uint8_t const Flags, payload_writer const &Payload );
+	void send_ack( std::uint32_t const Transaction, message_type const Type );
+	void send_nack( std::uint32_t const Transaction, message_type const Type, error_code const Error );
+
+	void handle_hello( decoded_packet const &Packet );
+	void handle_resolve_symbols( decoded_packet const &Packet );
+	void handle_query_symbol( decoded_packet const &Packet );
+	void handle_subscribe( decoded_packet const &Packet );
+	void handle_unsubscribe( decoded_packet const &Packet );
+	void handle_command_event( decoded_packet const &Packet );
+	void handle_control_set( decoded_packet const &Packet );
+	void handle_device_diagnostics( decoded_packet const &Packet );
+	void handle_heartbeat( decoded_packet const &Packet );
+
+	void send_state_update( std::vector<state_item> const &Items, bool const Snapshot );
+	void send_symbol_context_changed( std::uint32_t const Context );
+
+	// returns the registry index for a session handle, or symbol_registry::npos
+	std::size_t symbol_of_handle( std::uint16_t const Handle ) const;
+	std::uint16_t handle_of_symbol( std::size_t const SymbolIndex );
+
+	bool consume_frame_budget( std::size_t const PayloadSize );
+	bool consume_command_budget();
+	bool remember_transaction( std::uint32_t const Transaction, transaction_result const &Result );
+	transaction_result const *recall_transaction( std::uint32_t const Transaction ) const;
+
+	// executes a command, returns the error which should be reported to the device
+	error_code execute_command( std::size_t const SymbolIndex, command_action const Action, double const Parameter1, double const Parameter2, std::uint16_t const Recipient );
+
+// members
+	session_output &m_output;
+	config m_config;
+	command_relay m_relay;
+
+	session_state m_state = session_state::waiting_for_hello;
+	std::uint32_t m_sessionid = 0;
+	std::uint32_t m_sequence = 0;
+	std::uint32_t m_lastreceivedsequence = 0;
+	bool m_sequenceseen = false;
+	std::size_t m_framesize = protocol_frame_size_default;
+	std::uint32_t m_capabilities = 0;
+	std::uint8_t m_peermajor = 0;
+	std::uint8_t m_peerminor = 0;
+
+	std::string m_devicename;
+	std::string m_devicerole;
+	std::string m_deviceid;
+	std::string m_firmwareversion;
+	std::string m_hardwareversion;
+
+	std::vector<std::size_t> m_handles;
+	std::unordered_map<std::size_t, std::uint16_t> m_handlelookup;
+	subscription_manager m_subscriptions;
+	// per control sequence counters, used to drop stale continuous updates
+	std::unordered_map<std::uint16_t, std::uint32_t> m_controlsequence;
+
+	std::unordered_map<std::uint32_t, transaction_result> m_transactions;
+	std::deque<std::uint32_t> m_transactionorder;
+
+	double m_uptime = 0.0;
+	double m_lastreceived = 0.0;
+	double m_heartbeattimer = 0.0;
+	double m_pingtimer = 0.0;
+	std::uint32_t m_pingtoken = 0;
+	double m_pingsent = 0.0;
+	bool m_pingpending = false;
+
+	double m_ratewindow = 0.0;
+	int m_framebudget = 0;
+	int m_payloadbudget = 0;
+	int m_commandbudget = 0;
+
+	std::uint32_t m_context = 0;
+	bool m_contextvalid = false;
+	// most recent simulator state, kept so that a subscription can be answered right away
+	state_snapshot m_snapshot;
+
+	protocol_diagnostics m_diagnostics;
+	device_diagnostics m_devicediagnostics;
+	rate_counter m_rxrate;
+	rate_counter m_txrate;
+};
+
+} // namespace hardware

--- a/hardware/registry/command_registry.cpp
+++ b/hardware/registry/command_registry.cpp
@@ -1,0 +1,96 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "hardware/registry/command_registry.h"
+
+namespace hardware
+{
+
+namespace
+{
+
+struct command_metadata
+{
+	char const *name;
+	bool continuous;
+	std::optional<double> minimum;
+	std::optional<double> maximum;
+};
+
+// hardware metadata for the commands which carry an analogue value; everything else is an event command
+command_metadata const continuous_commands[] = {
+    { "mastercontrollerset", true, 0.0, std::nullopt },
+    { "secondcontrollerset", true, 0.0, std::nullopt },
+    { "jointcontrollerset", true, 0.0, std::nullopt },
+    { "trainbrakeset", true, 0.0, 1.0 },
+    { "independentbrakeset", true, 0.0, 1.0 },
+    { "dynamicbrakecontrollerset", true, 0.0, 1.0 },
+    { "radiovolumeset", true, 0.0, 1.0 },
+    { "radiochannelset", true, 1.0, 15.0 }
+};
+
+} // anonymous namespace
+
+command_registry const &command_registry::instance()
+{
+	static command_registry const registry;
+	return registry;
+}
+
+command_descriptor const *command_registry::find( std::string const &Name ) const
+{
+	auto const lookup = m_index.find( Name );
+	return ( lookup != m_index.end() ? &m_entries[ lookup->second ] : nullptr );
+}
+
+command_registry::command_registry()
+{
+	std::size_t commandid = 0;
+	for( auto const &description : simulation::Commands_descriptions )
+	{
+		command_descriptor descriptor;
+		descriptor.name = description.name;
+		descriptor.command = static_cast<user_command>( commandid );
+		m_index.emplace( descriptor.name, m_entries.size() );
+		m_entries.emplace_back( std::move( descriptor ) );
+		++commandid;
+	}
+
+	for( auto const &metadata : continuous_commands )
+	{
+		auto const lookup = m_index.find( metadata.name );
+		if( lookup == m_index.end() )
+		{
+			continue;
+		}
+		auto &descriptor = m_entries[ lookup->second ];
+		descriptor.continuous = metadata.continuous;
+		descriptor.minimum = metadata.minimum;
+		descriptor.maximum = metadata.maximum;
+	}
+
+	// protocol level alias: master controller driven with a 0...1 fraction of its range, the way
+	// uart v1 does it in percentage mode. it maps onto the regular mastercontrollerset command
+	auto const mastercontroller = m_index.find( "mastercontrollerset" );
+	if( mastercontroller != m_index.end() )
+	{
+		command_descriptor descriptor;
+		descriptor.name = "mastercontrollersetpercent";
+		descriptor.command = m_entries[ mastercontroller->second ].command;
+		descriptor.continuous = true;
+		descriptor.minimum = 0.0;
+		descriptor.maximum = 1.0;
+		descriptor.transform = command_transform::mastercontroller_percent;
+		m_index.emplace( descriptor.name, m_entries.size() );
+		m_entries.emplace_back( std::move( descriptor ) );
+	}
+}
+
+} // namespace hardware

--- a/hardware/registry/command_registry.h
+++ b/hardware/registry/command_registry.h
@@ -1,0 +1,67 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "hardware/protocol/protocol_defs.h"
+#include "input/command.h"
+
+// command namespace of the hardware api
+// the list is generated from simulation::Commands_descriptions, with hardware metadata added on top,
+// so that external devices never depend on the numeric values of the user_command enumeration
+
+namespace hardware
+{
+
+// optional conversion applied to the value received from the device before the command is posted
+enum class command_transform : std::uint8_t
+{
+	none = 0,
+	// 0...1 fraction of the master controller range of the occupied vehicle
+	mastercontroller_percent = 1
+};
+
+struct command_descriptor
+{
+	// registry name without namespace prefix, i.e. "trainbrakeset" rather than "command.trainbrakeset"
+	std::string name;
+	user_command command = user_command::none;
+	// true for controls which may be driven with CONTROL_SET, false for event-only commands
+	bool continuous = false;
+	value_type parameter_type = value_type::float32;
+	std::optional<double> minimum;
+	std::optional<double> maximum;
+	command_transform transform = command_transform::none;
+};
+
+class command_registry
+{
+
+public:
+// methods
+	static command_registry const &instance();
+
+	std::vector<command_descriptor> const &entries() const { return m_entries; }
+	command_descriptor const *find( std::string const &Name ) const;
+
+private:
+// methods
+	command_registry();
+
+// members
+	std::vector<command_descriptor> m_entries;
+	std::unordered_map<std::string, std::size_t> m_index;
+};
+
+} // namespace hardware

--- a/hardware/registry/hardware_symbol_registry.cpp
+++ b/hardware/registry/hardware_symbol_registry.cpp
@@ -1,0 +1,69 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "hardware/registry/hardware_symbol_registry.h"
+
+#include "hardware/registry/command_registry.h"
+#include "hardware/registry/state_registry.h"
+
+namespace hardware
+{
+
+symbol_registry const &symbol_registry::instance()
+{
+	static symbol_registry const registry;
+	return registry;
+}
+
+std::size_t symbol_registry::find( std::string const &Name ) const
+{
+	auto const lookup = m_index.find( Name );
+	return ( lookup != m_index.end() ? lookup->second : npos );
+}
+
+symbol_registry::symbol_registry()
+{
+	auto const &states = state_registry::instance().entries();
+	m_entries.reserve( states.size() + command_registry::instance().entries().size() );
+
+	for( std::size_t index = 0; index < states.size(); ++index )
+	{
+		auto const &state = states[ index ];
+		symbol_descriptor descriptor;
+		descriptor.name = "state." + state.name;
+		descriptor.kind = symbol_kind::state;
+		descriptor.type = state.type;
+		descriptor.access = access_read;
+		descriptor.unit = state.unit;
+		descriptor.minimum = state.minimum;
+		descriptor.maximum = state.maximum;
+		descriptor.source_index = index;
+		m_index.emplace( descriptor.name, m_entries.size() );
+		m_entries.emplace_back( std::move( descriptor ) );
+	}
+
+	auto const &commands = command_registry::instance().entries();
+	for( std::size_t index = 0; index < commands.size(); ++index )
+	{
+		auto const &command = commands[ index ];
+		symbol_descriptor descriptor;
+		descriptor.name = "command." + command.name;
+		descriptor.kind = symbol_kind::command;
+		descriptor.type = command.parameter_type;
+		descriptor.access = access_write;
+		descriptor.minimum = command.minimum;
+		descriptor.maximum = command.maximum;
+		descriptor.source_index = index;
+		m_index.emplace( descriptor.name, m_entries.size() );
+		m_entries.emplace_back( std::move( descriptor ) );
+	}
+}
+
+} // namespace hardware

--- a/hardware/registry/hardware_symbol_registry.h
+++ b/hardware/registry/hardware_symbol_registry.h
@@ -1,0 +1,64 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <limits>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "hardware/protocol/protocol_defs.h"
+
+// public symbol table of the hardware api
+// merges the state and command registries into one namespace-prefixed list; devices refer to symbols
+// by these names and receive short, session scoped handles in return
+
+namespace hardware
+{
+
+struct symbol_descriptor
+{
+	// full public name, i.e. "state.velocity" or "command.trainbrakeset"
+	std::string name;
+	symbol_kind kind = symbol_kind::state;
+	value_type type = value_type::float32;
+	std::uint8_t access = access_read;
+	std::string unit;
+	std::optional<double> minimum;
+	std::optional<double> maximum;
+	// index into the registry the symbol originates from
+	std::size_t source_index = 0;
+};
+
+class symbol_registry
+{
+
+public:
+// types
+	static constexpr std::size_t npos = std::numeric_limits<std::size_t>::max();
+
+// methods
+	static symbol_registry const &instance();
+
+	std::vector<symbol_descriptor> const &entries() const { return m_entries; }
+	// returns index of the symbol, or npos if the name isn't known
+	std::size_t find( std::string const &Name ) const;
+
+private:
+// methods
+	symbol_registry();
+
+// members
+	std::vector<symbol_descriptor> m_entries;
+	std::unordered_map<std::string, std::size_t> m_index;
+};
+
+} // namespace hardware

--- a/hardware/registry/state_registry.cpp
+++ b/hardware/registry/state_registry.cpp
@@ -1,0 +1,170 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "hardware/registry/state_registry.h"
+
+#include "simulation/simulation.h"
+#include "simulation/simulationtime.h"
+#include "utilities/Globals.h"
+
+namespace hardware
+{
+
+namespace
+{
+
+state_value make_value( state_snapshot const &Snapshot, value_type const Type, double const Value, bool const Applicable = true )
+{
+	state_value result;
+	result.type = Type;
+	result.numeric = Value;
+	result.quality = (
+	    false == Snapshot.available ? value_quality::unavailable :
+	    false == Applicable ? value_quality::not_applicable :
+	    value_quality::valid );
+	if( result.quality != value_quality::valid )
+	{
+		result.numeric = 0.0;
+	}
+	return result;
+}
+
+// values which don't depend on the vehicle are always valid
+state_value make_global_value( value_type const Type, double const Value )
+{
+	state_value result;
+	result.type = Type;
+	result.numeric = Value;
+	result.quality = value_quality::valid;
+	return result;
+}
+
+} // anonymous namespace
+
+state_registry const &state_registry::instance()
+{
+	static state_registry const registry;
+	return registry;
+}
+
+state_descriptor const *state_registry::find( std::string const &Name ) const
+{
+	auto const lookup = m_index.find( Name );
+	return ( lookup != m_index.end() ? &m_entries[ lookup->second ] : nullptr );
+}
+
+void state_registry::add( std::string Name, value_type const Type, std::string Unit, std::optional<double> const Minimum, std::optional<double> const Maximum, std::function<state_value( state_snapshot const & )> Getter )
+{
+	m_index.emplace( Name, m_entries.size() );
+	state_descriptor descriptor;
+	descriptor.name = std::move( Name );
+	descriptor.type = Type;
+	descriptor.unit = std::move( Unit );
+	descriptor.minimum = Minimum;
+	descriptor.maximum = Maximum;
+	descriptor.getter = std::move( Getter );
+	m_entries.emplace_back( std::move( descriptor ) );
+}
+
+state_registry::state_registry()
+{
+	// indicators and switch states
+	add( "shp", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.shp != 0 ); } );
+	add( "alerter", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.alerter != 0 ); } );
+	add( "alerter_sound", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.alerter_sound != 0 ); } );
+	add( "radio_stop", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.radio_stop != 0 ); } );
+	add( "motor_resistors", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.motor_resistors != 0 ); } );
+	add( "line_breaker", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.line_breaker != 0 ); } );
+	add( "ground_relay", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.ground_relay != 0 ); } );
+	add( "motor_overload", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.motor_overload != 0 ); } );
+	add( "motor_overload_threshold", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.motor_overload_threshold != 0 ); } );
+	add( "motor_connectors", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.motor_connectors != 0 ); } );
+	add( "wheelslip", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.wheelslip != 0 ); } );
+	add( "converter_overload", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.converter_overload != 0 ); } );
+	add( "converter_off", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.converter_off != 0 ); } );
+	add( "compressor_overload", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.compressor_overload != 0 ); } );
+	add( "ventilator_overload", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.ventilator_overload != 0 ); } );
+	add( "train_heating", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.train_heating != 0 ); } );
+	add( "coupled_hv_voltage_relays", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.coupled_hv_voltage_relays != 0 ); } );
+	add( "recorder_braking", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.recorder_braking != 0 ); } );
+	add( "recorder_power", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.recorder_power != 0 ); } );
+	add( "springbrake_active", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.springbrake_active != 0 ); } );
+	add( "epbrake_enabled", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.epbrake_enabled != 0 ); } );
+	add( "emergencybrake", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.emergencybrake != 0 ); } );
+	add( "lockpipe", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.lockpipe != 0 ); } );
+	add( "battery", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.battery != 0 ); } );
+	add( "radiomessageindicator", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.radiomessageindicator ); } );
+	add( "dir_forward", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.dir_forward != 0 ); } );
+	add( "dir_backward", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.dir_backward != 0 ); } );
+	add( "doorleftallowed", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.doorleftallowed != 0 ); } );
+	add( "doorleftopened", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.doorleftopened != 0 ); } );
+	add( "doorrightallowed", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.doorrightallowed != 0 ); } );
+	add( "doorrightopened", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.doorrightopened != 0 ); } );
+	add( "doorstepallowed", value_type::boolean, "", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::boolean, s.train.doorstepallowed != 0 ); } );
+
+	// enumerations and counters
+	add( "cab", value_type::uint8, "", 0.0, 2.0, []( state_snapshot const &s ) { return make_value( s, value_type::uint8, s.train.cab ); } );
+	add( "cab_indicator", value_type::uint8, "", 0.0, 1.0, []( state_snapshot const &s ) { return make_value( s, value_type::uint8, s.cab_indicator ); } );
+	add( "radio_channel", value_type::uint8, "", 0.0, 15.0, []( state_snapshot const &s ) { return make_value( s, value_type::uint8, s.train.radio_channel ); } );
+
+	// measurements, in engineering units
+	add( "velocity", value_type::float32, "km/h", 0.0, 400.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, Global.iPause ? 0.0 : s.train.velocity ); } );
+	add( "reservoir_pressure", value_type::float32, "bar", 0.0, 16.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.reservoir_pressure ); } );
+	add( "pipe_pressure", value_type::float32, "bar", 0.0, 16.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.pipe_pressure ); } );
+	add( "brake_pressure", value_type::float32, "bar", 0.0, 16.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.brake_pressure ); } );
+	add( "pantograph_pressure", value_type::float32, "bar", 0.0, 16.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.pantograph_pressure, s.pantographs ); } );
+	add( "hv_voltage", value_type::float32, "V", 0.0, 40000.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.hv_voltage, s.electric ); } );
+	add( "hv_current_1", value_type::float32, "A", -5000.0, 5000.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.hv_current[ 0 ], s.electric ); } );
+	add( "hv_current_2", value_type::float32, "A", -5000.0, 5000.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.hv_current[ 1 ], s.electric ); } );
+	add( "hv_current_3", value_type::float32, "A", -5000.0, 5000.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.hv_current[ 2 ], s.electric ); } );
+	add( "lv_voltage", value_type::float32, "V", 0.0, 200.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.lv_voltage ); } );
+	add( "distance", value_type::float64, "m", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::float64, s.train.distance ); } );
+
+	// simulation clock, available regardless of the occupied vehicle
+	add( "time_month_of_era", value_type::uint32, "", {}, {}, []( state_snapshot const &s ) { return make_global_value( value_type::uint32, s.time_month_of_era ); } );
+	add( "time_minute_of_month", value_type::uint32, "", {}, {}, []( state_snapshot const &s ) { return make_global_value( value_type::uint32, s.time_minute_of_month ); } );
+	add( "time_millisecond_of_day", value_type::uint32, "", {}, {}, []( state_snapshot const &s ) { return make_global_value( value_type::uint32, s.time_millisecond_of_day ); } );
+}
+
+void state_registry::capture( state_snapshot &Snapshot )
+{
+	SYSTEMTIME const time = simulation::Time.data();
+	Snapshot.time_month_of_era = ( time.wYear - 1 ) * 12 + time.wMonth - 1;
+	Snapshot.time_minute_of_month = ( time.wDay - 1 ) * 1440 + time.wHour * 60 + time.wMinute;
+	Snapshot.time_millisecond_of_day = time.wSecond * 1000 + time.wMilliseconds;
+
+	auto const *train = simulation::Train;
+	if( train == nullptr )
+	{
+		Snapshot.available = false;
+		Snapshot.electric = false;
+		Snapshot.pantographs = false;
+		Snapshot.context_id = 0;
+		return;
+	}
+
+	Snapshot.available = true;
+	Snapshot.train = train->get_state();
+
+	if( Snapshot.train.cab > 0 )
+	{
+		// NOTE: moving from a cab to the engine room doesn't change the cab indicator
+		Snapshot.cab_indicator = Snapshot.train.cab - 1;
+	}
+
+	auto const *controlled = train->Controlled();
+	auto const enginetype = ( controlled != nullptr ? controlled->EngineType : TEngineType::None );
+	Snapshot.electric = ( ( enginetype == TEngineType::ElectricSeriesMotor ) || ( enginetype == TEngineType::ElectricInductionMotor ) );
+	Snapshot.pantographs = Snapshot.electric;
+
+	Snapshot.context_id = static_cast<std::uint32_t>( std::hash<std::string>()( train->name() ) );
+}
+
+} // namespace hardware

--- a/hardware/registry/state_registry.cpp
+++ b/hardware/registry/state_registry.cpp
@@ -125,6 +125,7 @@ state_registry::state_registry()
 	add( "hv_current_1", value_type::float32, "A", -5000.0, 5000.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.hv_current[ 0 ], s.electric ); } );
 	add( "hv_current_2", value_type::float32, "A", -5000.0, 5000.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.hv_current[ 1 ], s.electric ); } );
 	add( "hv_current_3", value_type::float32, "A", -5000.0, 5000.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.hv_current[ 2 ], s.electric ); } );
+	add( "engine_voltage", value_type::float64, "V", 0, 40000.0, []( state_snapshot const &s ) { return make_value( s, value_type::float64, s.train.enginevoltage, s.electric ); } );
 	add( "lv_voltage", value_type::float32, "V", 0.0, 200.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.lv_voltage ); } );
 	add( "distance", value_type::float64, "m", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::float64, s.train.distance ); } );
 

--- a/hardware/registry/state_registry.cpp
+++ b/hardware/registry/state_registry.cpp
@@ -12,7 +12,6 @@ http://mozilla.org/MPL/2.0/.
 
 #include "simulation/simulation.h"
 #include "simulation/simulationtime.h"
-#include "utilities/Globals.h"
 
 namespace hardware
 {
@@ -29,8 +28,10 @@ state_value make_value( state_snapshot const &Snapshot, value_type const Type, d
 	    false == Snapshot.available ? value_quality::unavailable :
 	    false == Applicable ? value_quality::not_applicable :
 	    value_quality::valid );
-	if( result.quality != value_quality::valid )
+	if( result.quality == value_quality::unavailable )
 	{
+		// there's nothing to report; a value which merely doesn't apply keeps whatever the
+		// simulator holds, the quality flag is what tells the device not to trust it
 		result.numeric = 0.0;
 	}
 	return result;
@@ -115,7 +116,7 @@ state_registry::state_registry()
 	add( "radio_channel", value_type::uint8, "", 0.0, 15.0, []( state_snapshot const &s ) { return make_value( s, value_type::uint8, s.train.radio_channel ); } );
 
 	// measurements, in engineering units
-	add( "velocity", value_type::float32, "km/h", 0.0, 400.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, Global.iPause ? 0.0 : s.train.velocity ); } );
+	add( "velocity", value_type::float32, "km/h", 0.0, 400.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.velocity ); } );
 	add( "reservoir_pressure", value_type::float32, "bar", 0.0, 16.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.reservoir_pressure ); } );
 	add( "pipe_pressure", value_type::float32, "bar", 0.0, 16.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.pipe_pressure ); } );
 	add( "brake_pressure", value_type::float32, "bar", 0.0, 16.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.brake_pressure ); } );

--- a/hardware/registry/state_registry.cpp
+++ b/hardware/registry/state_registry.cpp
@@ -125,7 +125,7 @@ state_registry::state_registry()
 	add( "hv_current_1", value_type::float32, "A", -5000.0, 5000.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.hv_current[ 0 ], s.electric ); } );
 	add( "hv_current_2", value_type::float32, "A", -5000.0, 5000.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.hv_current[ 1 ], s.electric ); } );
 	add( "hv_current_3", value_type::float32, "A", -5000.0, 5000.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.hv_current[ 2 ], s.electric ); } );
-	add( "engine_voltage", value_type::float64, "V", 0, 40000.0, []( state_snapshot const &s ) { return make_value( s, value_type::float64, s.train.enginevoltage, s.electric ); } );
+	add( "engine_voltage", value_type::uint32, "V", 0, 40000.0, []( state_snapshot const &s ) { return make_value( s, value_type::uint32, s.train.enginevoltage, s.electric ); } );
 	add( "lv_voltage", value_type::float32, "V", 0.0, 200.0, []( state_snapshot const &s ) { return make_value( s, value_type::float32, s.train.lv_voltage ); } );
 	add( "distance", value_type::float64, "m", {}, {}, []( state_snapshot const &s ) { return make_value( s, value_type::float64, s.train.distance ); } );
 

--- a/hardware/registry/state_registry.h
+++ b/hardware/registry/state_registry.h
@@ -1,0 +1,89 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "hardware/protocol/protocol_defs.h"
+#include "vehicle/Train.h"
+
+// shared TrainState registry
+// one description of the simulator state exposed to the outside world, meant to be used by every
+// external interface (hardware protocol v2, zmq, python) instead of each of them keeping its own list
+
+namespace hardware
+{
+
+// values captured once per simulation frame, so that all consumers see a consistent set
+struct state_snapshot
+{
+	// false when there's no occupied vehicle; state symbols then report UNAVAILABLE
+	bool available = false;
+	// high voltage circuit is meaningful for this vehicle
+	bool electric = false;
+	// vehicle is equipped with pantographs
+	bool pantographs = false;
+	TTrain::state_t train {};
+	// last active cab, 0: front, 1: rear. moving to the engine room doesn't change it
+	std::uint8_t cab_indicator = 0;
+	// changes whenever the controlled vehicle changes, used to notify devices about metadata changes
+	std::uint32_t context_id = 0;
+	double time_month_of_era = 0.0;
+	double time_minute_of_month = 0.0;
+	double time_millisecond_of_day = 0.0;
+};
+
+struct state_value
+{
+	value_type type = value_type::float32;
+	value_quality quality = value_quality::unavailable;
+	double numeric = 0.0;
+	std::string text;
+};
+
+struct state_descriptor
+{
+	// registry name without namespace prefix, i.e. "velocity" rather than "state.velocity"
+	std::string name;
+	value_type type = value_type::float32;
+	std::string unit;
+	std::optional<double> minimum;
+	std::optional<double> maximum;
+	std::function<state_value( state_snapshot const & )> getter;
+};
+
+class state_registry
+{
+
+public:
+// methods
+	static state_registry const &instance();
+
+	std::vector<state_descriptor> const &entries() const { return m_entries; }
+	state_descriptor const *find( std::string const &Name ) const;
+
+	// fills the snapshot from the currently occupied train; simulation thread only
+	static void capture( state_snapshot &Snapshot );
+
+private:
+// methods
+	state_registry();
+	void add( std::string Name, value_type const Type, std::string Unit, std::optional<double> const Minimum, std::optional<double> const Maximum, std::function<state_value( state_snapshot const & )> Getter );
+
+// members
+	std::vector<state_descriptor> m_entries;
+	std::unordered_map<std::string, std::size_t> m_index;
+};
+
+} // namespace hardware

--- a/hardware/subscriptions/subscription_manager.cpp
+++ b/hardware/subscriptions/subscription_manager.cpp
@@ -1,0 +1,110 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "hardware/subscriptions/subscription_manager.h"
+
+namespace hardware
+{
+
+error_code subscription_manager::subscribe( std::uint16_t const Handle, std::size_t const SymbolIndex, std::size_t const StateIndex, subscription_mode const Mode, std::uint16_t const PeriodMilliseconds, float const Deadband )
+{
+	if( ( Mode != subscription_mode::periodic ) && ( Mode != subscription_mode::on_change ) && ( Mode != subscription_mode::periodic_or_change ) )
+	{
+		return error_code::invalid_field;
+	}
+	if( ( false == std::isfinite( Deadband ) ) || ( Deadband < 0.0f ) )
+	{
+		return error_code::invalid_field;
+	}
+
+	auto const period = std::clamp<std::uint16_t>( ( PeriodMilliseconds > 0 ? PeriodMilliseconds : subscription_period_min_ms ), subscription_period_min_ms, subscription_period_max_ms ) * 0.001;
+
+	auto entry = std::find_if( m_entries.begin(), m_entries.end(), [ Handle ]( subscription_entry const &Entry ) { return Entry.handle == Handle; } );
+	if( entry == m_entries.end() )
+	{
+		if( m_entries.size() >= subscriptions_max )
+		{
+			return error_code::busy;
+		}
+		m_entries.emplace_back();
+		entry = std::prev( m_entries.end() );
+	}
+
+	entry->handle = Handle;
+	entry->symbol_index = SymbolIndex;
+	entry->state_index = StateIndex;
+	entry->mode = Mode;
+	entry->period = period;
+	entry->deadband = Deadband;
+	entry->timer = period;
+	entry->sampled = false;
+
+	return error_code::none;
+}
+
+bool subscription_manager::unsubscribe( std::uint16_t const Handle )
+{
+	auto const entry = std::find_if( m_entries.begin(), m_entries.end(), [ Handle ]( subscription_entry const &Entry ) { return Entry.handle == Handle; } );
+	if( entry == m_entries.end() )
+	{
+		return false;
+	}
+	m_entries.erase( entry );
+	return true;
+}
+
+void subscription_manager::clear()
+{
+	m_entries.clear();
+}
+
+void subscription_manager::collect( double const Deltatime, state_snapshot const &Snapshot, bool const Everything, std::vector<state_item> &Output )
+{
+	auto const &states = state_registry::instance().entries();
+
+	for( auto &entry : m_entries )
+	{
+		if( entry.state_index >= states.size() )
+		{
+			continue;
+		}
+
+		entry.timer += Deltatime;
+
+		auto const value = states[ entry.state_index ].getter( Snapshot );
+
+		bool const periodic = ( ( entry.mode != subscription_mode::on_change ) && ( entry.timer >= entry.period ) );
+		bool changed = false;
+		if( entry.mode != subscription_mode::periodic )
+		{
+			changed = (
+			    ( false == entry.sampled )
+			 || ( value.quality != entry.last_quality )
+			 || ( std::abs( value.numeric - entry.last_numeric ) > entry.deadband ) );
+		}
+
+		if( ( false == Everything ) && ( false == periodic ) && ( false == changed ) )
+		{
+			continue;
+		}
+
+		entry.timer = 0.0;
+		entry.sampled = true;
+		entry.last_numeric = value.numeric;
+		entry.last_quality = value.quality;
+
+		state_item item;
+		item.handle = entry.handle;
+		item.value = value;
+		Output.emplace_back( std::move( item ) );
+	}
+}
+
+} // namespace hardware

--- a/hardware/subscriptions/subscription_manager.h
+++ b/hardware/subscriptions/subscription_manager.h
@@ -1,0 +1,71 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "hardware/protocol/protocol_defs.h"
+#include "hardware/registry/state_registry.h"
+
+// state subscriptions of a single session
+// a device receives only the values it asked for, at the rate it asked for; unchanged values within
+// the configured deadband generate no traffic at all
+
+namespace hardware
+{
+
+// upper bound on subscriptions per session, keeps a misbehaving device from exhausting memory
+constexpr std::size_t subscriptions_max = 128;
+constexpr std::uint16_t subscription_period_min_ms = 10;
+constexpr std::uint16_t subscription_period_max_ms = 60000;
+
+struct subscription_entry
+{
+	std::uint16_t handle = 0;
+	std::size_t symbol_index = 0;
+	std::size_t state_index = 0;
+	subscription_mode mode = subscription_mode::periodic;
+	double period = 0.05;
+	double deadband = 0.0;
+	double timer = 0.0;
+	bool sampled = false;
+	double last_numeric = 0.0;
+	value_quality last_quality = value_quality::unavailable;
+};
+
+struct state_item
+{
+	std::uint16_t handle = 0;
+	state_value value;
+};
+
+class subscription_manager
+{
+
+public:
+// methods
+	// registers or updates a subscription, returns the error to be reported back to the device
+	error_code subscribe( std::uint16_t const Handle, std::size_t const SymbolIndex, std::size_t const StateIndex, subscription_mode const Mode, std::uint16_t const PeriodMilliseconds, float const Deadband );
+	bool unsubscribe( std::uint16_t const Handle );
+	void clear();
+
+	std::size_t size() const { return m_entries.size(); }
+	std::vector<subscription_entry> const &entries() const { return m_entries; }
+
+	// advances the timers and collects the values which are due for transmission
+	void collect( double const Deltatime, state_snapshot const &Snapshot, bool const Everything, std::vector<state_item> &Output );
+
+private:
+// members
+	std::vector<subscription_entry> m_entries;
+};
+
+} // namespace hardware

--- a/hardware/transport/hardware_transport.h
+++ b/hardware/transport/hardware_transport.h
@@ -1,0 +1,47 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+// transport abstraction of the hardware protocol
+// the upper layers only ever see a byte stream, which is what lets the same protocol run over
+// serial, tcp or rs-485 without changing message semantics
+// every method is called from the hardware worker thread only
+
+namespace hardware
+{
+
+class hardware_transport
+{
+
+public:
+// methods
+	virtual ~hardware_transport() = default;
+
+	virtual bool connected() const = 0;
+	// tries to establish the link, returns true on success
+	virtual bool connect() = 0;
+	virtual void disconnect() = 0;
+	// non-blocking read, returns the number of bytes placed in the buffer or -1 on error
+	virtual int read( std::uint8_t *Buffer, std::size_t const Size ) = 0;
+	// non-blocking write, returns the number of bytes accepted or -1 on error
+	virtual int write( std::uint8_t const *Data, std::size_t const Size ) = 0;
+
+	// human readable transport type, i.e. "Serial"
+	virtual std::string kind() const = 0;
+	// human readable endpoint, i.e. "COM4 @ 115200"
+	virtual std::string endpoint() const = 0;
+	// last error reported by the underlying device
+	virtual std::string last_error() const = 0;
+};
+
+} // namespace hardware

--- a/hardware/transport/serial_transport.cpp
+++ b/hardware/transport/serial_transport.cpp
@@ -1,0 +1,151 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "hardware/transport/serial_transport.h"
+
+namespace hardware
+{
+
+serial_transport::serial_transport( std::string Port, int const Baud ) : m_portname( std::move( Port ) ), m_baud( Baud )
+{
+}
+
+serial_transport::~serial_transport()
+{
+	disconnect();
+}
+
+std::string serial_transport::endpoint() const
+{
+	return m_portname + " @ " + std::to_string( m_baud );
+}
+
+bool serial_transport::connect()
+{
+	disconnect();
+
+	sp_port *port = nullptr;
+	if( sp_get_port_by_name( m_portname.c_str(), &port ) != SP_OK )
+	{
+		m_lasterror = "port not found";
+		return false;
+	}
+
+	if( sp_open( port, static_cast<sp_mode>( SP_MODE_READ | SP_MODE_WRITE ) ) != SP_OK )
+	{
+		m_lasterror = "cannot open port";
+		sp_free_port( port );
+		return false;
+	}
+
+	sp_port_config *config = nullptr;
+	if( ( sp_new_config( &config ) != SP_OK )
+	 || ( sp_set_config_baudrate( config, m_baud ) != SP_OK )
+	 || ( sp_set_config_flowcontrol( config, SP_FLOWCONTROL_NONE ) != SP_OK )
+	 || ( sp_set_config_bits( config, 8 ) != SP_OK )
+	 || ( sp_set_config_stopbits( config, 1 ) != SP_OK )
+	 || ( sp_set_config_parity( config, SP_PARITY_NONE ) != SP_OK )
+	 || ( sp_set_config( port, config ) != SP_OK ) )
+	{
+		m_lasterror = "cannot configure port";
+		if( config != nullptr )
+		{
+			sp_free_config( config );
+		}
+		sp_close( port );
+		sp_free_port( port );
+		return false;
+	}
+	sp_free_config( config );
+
+	if( sp_flush( port, SP_BUF_BOTH ) != SP_OK )
+	{
+		m_lasterror = "cannot flush port";
+		sp_close( port );
+		sp_free_port( port );
+		return false;
+	}
+
+	m_port = port;
+	m_lasterror.clear();
+	return true;
+}
+
+void serial_transport::disconnect()
+{
+	if( m_port == nullptr )
+	{
+		return;
+	}
+	sp_close( m_port );
+	sp_free_port( m_port );
+	m_port = nullptr;
+}
+
+int serial_transport::read( std::uint8_t *Buffer, std::size_t const Size )
+{
+	if( m_port == nullptr )
+	{
+		return -1;
+	}
+
+	int const waiting = sp_input_waiting( m_port );
+	if( waiting < 0 )
+	{
+		m_lasterror = "read failed";
+		return -1;
+	}
+	if( waiting == 0 )
+	{
+		return 0;
+	}
+
+	int const result = sp_nonblocking_read( m_port, Buffer, std::min( Size, static_cast<std::size_t>( waiting ) ) );
+	if( result < 0 )
+	{
+		m_lasterror = "read failed";
+		return -1;
+	}
+	return result;
+}
+
+int serial_transport::write( std::uint8_t const *Data, std::size_t const Size )
+{
+	if( m_port == nullptr )
+	{
+		return -1;
+	}
+
+	int const result = sp_nonblocking_write( m_port, Data, Size );
+	if( result < 0 )
+	{
+		m_lasterror = "write failed";
+		return -1;
+	}
+	return result;
+}
+
+std::vector<std::string> list_serial_ports()
+{
+	std::vector<std::string> result;
+	sp_port **ports = nullptr;
+	if( sp_list_ports( &ports ) != SP_OK )
+	{
+		return result;
+	}
+	for( int index = 0; ports[ index ] != nullptr; ++index )
+	{
+		result.emplace_back( sp_get_port_name( ports[ index ] ) );
+	}
+	sp_free_port_list( ports );
+	return result;
+}
+
+} // namespace hardware

--- a/hardware/transport/serial_transport.h
+++ b/hardware/transport/serial_transport.h
@@ -1,0 +1,54 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <libserialport.h>
+
+#include <string>
+#include <vector>
+
+#include "hardware/transport/hardware_transport.h"
+
+// serial port transport, one connection per port, as described by the specification
+// the port is opened and serviced exclusively from the hardware worker thread
+
+namespace hardware
+{
+
+class serial_transport : public hardware_transport
+{
+
+public:
+// methods
+	serial_transport( std::string Port, int const Baud );
+	~serial_transport() override;
+
+	bool connected() const override { return m_port != nullptr; }
+	bool connect() override;
+	void disconnect() override;
+	int read( std::uint8_t *Buffer, std::size_t const Size ) override;
+	int write( std::uint8_t const *Data, std::size_t const Size ) override;
+
+	std::string kind() const override { return "Serial"; }
+	std::string endpoint() const override;
+	std::string last_error() const override { return m_lasterror; }
+
+private:
+// members
+	std::string m_portname;
+	int m_baud = 115200;
+	sp_port *m_port = nullptr;
+	std::string m_lasterror;
+};
+
+// list of serial ports currently present in the system
+std::vector<std::string> list_serial_ports();
+
+} // namespace hardware

--- a/input/command.cpp
+++ b/input/command.cpp
@@ -15,6 +15,8 @@ http://mozilla.org/MPL/2.0/.
 #include "utilities/Timer.h"
 #include "simulation/simulation.h"
 #include "vehicle/Train.h"
+#include "vehicle/DynObj.h"
+#include "network/entities.h"
 
 namespace simulation {
 
@@ -793,13 +795,61 @@ std::unordered_map<std::string, user_command> commandMap = {
 
 } // namespace simulation
 
+namespace {
+
+// vehicle commands are addressed with the session wide vehicle id while they are in the
+// hands of the network layer, because TTrain ids are handed out locally and two peers
+// numbering the same vehicles differently would send each other's commands astray.
+// outside of multiplayer the registry is empty and both directions are a no-op.
+
+bool is_vehicle_recipient(uint32_t const Recipient) {
+	return (command_target)(Recipient & ~0xffff) == command_target::vehicle;
+}
+
+uint32_t to_network_recipient(uint32_t const Recipient) {
+	if (!is_vehicle_recipient(Recipient) || network::Entities.empty())
+		return Recipient;
+
+	TTrain *train = simulation::Trains.find_id((uint16_t)(Recipient & 0xffff));
+	if (train == nullptr || train->Dynamic() == nullptr)
+		return Recipient;
+
+	auto const id = network::Entities.id_of(train->Dynamic()->name());
+	if (id == network::ENTITY_NONE || id > 0xffff)
+		return Recipient;
+
+	return (uint32_t)command_target::vehicle | id;
+}
+
+// returns false when the addressed vehicle has no cab on this peer yet
+bool from_network_recipient(uint32_t const Recipient, uint32_t &Local) {
+	Local = Recipient;
+
+	if (!is_vehicle_recipient(Recipient) || network::Entities.empty())
+		return true;
+
+	auto const name = network::Entities.name_of(Recipient & 0xffff);
+	if (name.empty())
+		return true;
+
+	TTrain *train = simulation::Trains.find(name);
+	if (train == nullptr)
+		return false;
+
+	Local = (uint32_t)command_target::vehicle | train->id();
+	return true;
+}
+
+} // namespace
+
 void command_queue::update()
 {
 	double delta = Timer::GetDeltaTime();
-	for (auto c : m_active_continuous)
+	for (auto const &c : m_active_continuous)
 	{
-		command_data data({c.first, GLFW_REPEAT, 0.0, 0.0, delta, false, glm::vec3()}); // todo: improve
-		auto lookup = m_commands.emplace( c.second, commanddata_sequence() );
+		command_data data({c.command, GLFW_REPEAT, 0.0, 0.0, delta, false, glm::vec3()}); // todo: improve
+		data.source = c.source;
+		auto lookup = m_commands.emplace( c.recipient, commanddata_sequence() );
 		// recipient stack was either located or created, so we can add to it quite safely
 		lookup.first->second.emplace_back( data );
 	}
@@ -809,7 +859,7 @@ void command_queue::update()
 void
 command_queue::push( command_data const &Command, uint32_t const Recipient ) {
 	if (is_network_target(Recipient)) {
-		auto lookup = m_intercept_queue.emplace(Recipient, commanddata_sequence());
+		auto lookup = m_intercept_queue.emplace(to_network_recipient(Recipient), commanddata_sequence());
 		lookup.first->second.emplace_back(Command);
 	} else {
 		push_direct(Command, Recipient);
@@ -820,10 +870,12 @@ void command_queue::push_direct(const command_data &Command, const uint32_t Reci
 	auto const &desc = simulation::Commands_descriptions[ static_cast<std::size_t>( Command.command ) ];
 	if (desc.mode == command_mode::continuous)
 	{
+		continuous_key const key { Command.source, Recipient, Command.command };
+
 		if (Command.action == GLFW_PRESS)
-			m_active_continuous.emplace(std::make_pair(Command.command, Recipient));
+			m_active_continuous.emplace(key);
 		else if (Command.action == GLFW_RELEASE)
-			m_active_continuous.erase(std::make_pair(Command.command, Recipient));
+			m_active_continuous.erase(key);
 		else if (Command.action == GLFW_REPEAT)
 			return;
 	}
@@ -870,9 +922,16 @@ command_queue::commands_map command_queue::pop_intercept_queue() {
 }
 
 void command_queue::push_commands(const commands_map &commands) {
-	for (auto const &kv : commands)
+	for (auto const &kv : commands) {
+		uint32_t recipient;
+		if (!from_network_recipient(kv.first, recipient)) {
+			// the vehicle has no cab on this peer yet; the command has nowhere to go
+			continue;
+		}
+
 		for (command_data const &data : kv.second)
-			push_direct(data, kv.first);
+			push_direct(data, recipient);
+	}
 }
 
 void
@@ -900,6 +959,7 @@ command_relay::post(user_command const Command, double const Param1, double cons
 
 	uint32_t combined_recipient = static_cast<uint32_t>( command.target ) | Recipient;
 	command_data commanddata({Command, Action, Param1, Param2, Timer::GetDeltaTime(), FreeFlyModeFlag, Position });
+	commanddata.source = Global.network_peer_id;
 	if (Payload)
 		commanddata.payload = *Payload;
 

--- a/input/command.cpp
+++ b/input/command.cpp
@@ -806,17 +806,37 @@ bool is_vehicle_recipient(uint32_t const Recipient) {
 	return (command_target)(Recipient & ~0xffff) == command_target::vehicle;
 }
 
+// says a thing once instead of once per frame; a command that cannot be addressed keeps
+// failing for as long as the player holds the key
+bool report_once(std::string const &Message) {
+	static std::unordered_set<std::string> reported;
+	if (!reported.emplace(Message).second)
+		return false;
+	ErrorLog(Message, logtype::net);
+	return true;
+}
+
 uint32_t to_network_recipient(uint32_t const Recipient) {
-	if (!is_vehicle_recipient(Recipient) || network::Entities.empty())
+	if (!is_vehicle_recipient(Recipient))
 		return Recipient;
+
+	if (network::Entities.empty()) {
+		if (network::is_multiplayer())
+			report_once("net: no vehicle roster yet, vehicle commands cannot be addressed");
+		return Recipient;
+	}
 
 	TTrain *train = simulation::Trains.find_id((uint16_t)(Recipient & 0xffff));
-	if (train == nullptr || train->Dynamic() == nullptr)
+	if (train == nullptr || train->Dynamic() == nullptr) {
+		report_once("net: no cab behind local id " + std::to_string(Recipient & 0xffff) + ", its commands cannot be addressed");
 		return Recipient;
+	}
 
 	auto const id = network::Entities.id_of(train->Dynamic()->name());
-	if (id == network::ENTITY_NONE || id > 0xffff)
+	if (id == network::ENTITY_NONE || id > 0xffff) {
+		report_once("net: \"" + train->Dynamic()->name() + "\" has no network id, its commands cannot leave this peer");
 		return Recipient;
+	}
 
 	return (uint32_t)command_target::vehicle | id;
 }
@@ -833,8 +853,10 @@ bool from_network_recipient(uint32_t const Recipient, uint32_t &Local) {
 		return true;
 
 	TTrain *train = simulation::Trains.find(name);
-	if (train == nullptr)
+	if (train == nullptr) {
+		report_once("net: \"" + name + "\" has no cab here yet, commands for it are dropped");
 		return false;
+	}
 
 	Local = (uint32_t)command_target::vehicle | train->id();
 	return true;

--- a/input/command.h
+++ b/input/command.h
@@ -445,6 +445,12 @@ struct command_data {
 	glm::vec3 location;
 
     std::string payload;
+
+    // network::PeerId of the participant the command came from. kept as a plain integer
+    // so that this header stays independent of the network layer. it matters wherever two
+    // people work the same vehicle: a continuous command held by one of them must not be
+    // cancelled by the other one letting go of the same key
+    uint32_t source { 0 };
 };
 
 // command_queues: collects and holds commands from input sources, for processing by their intended recipients
@@ -487,15 +493,29 @@ private:
 
 	void push_direct( command_data const &Command, uint32_t const Recipient );
 
-	// hash operator for m_active_continuous
-	struct command_set_hash {
-		uint64_t operator() (const std::pair<user_command, uint32_t> &pair) const {
-			return (uint64_t)pair.first << 32 | (uint64_t)pair.second;
-		}
+	// a continuous command is held per source, not just per recipient: with two people in
+	// one cab, the release sent by one of them may only cancel their own hold
+	struct continuous_key {
+		uint32_t source;
+		uint32_t recipient;
+		user_command command;
+
+		bool operator==( continuous_key const &Other ) const {
+			return source == Other.source
+			    && recipient == Other.recipient
+			    && command == Other.command; }
+	};
+
+	struct continuous_key_hash {
+		std::size_t operator() ( continuous_key const &Key ) const {
+			std::size_t hash = (std::size_t)Key.source * 2654435761u;
+			hash ^= (std::size_t)Key.recipient + 0x9e3779b9 + ( hash << 6 ) + ( hash >> 2 );
+			hash ^= (std::size_t)Key.command + 0x9e3779b9 + ( hash << 6 ) + ( hash >> 2 );
+			return hash; }
 	};
 
 	// currently pressed continuous commands
-	std::unordered_set<std::pair<user_command, uint32_t>, command_set_hash> m_active_continuous;
+	std::unordered_set<continuous_key, continuous_key_hash> m_active_continuous;
 };
 
 template<typename A, typename B>

--- a/input/zmq_input.cpp
+++ b/input/zmq_input.cpp
@@ -71,9 +71,9 @@ void zmq_input::poll()
             for (size_t i = 3; i < multipart.size(); i++) {
                 std::string chan_name((char*)multipart[i].data(), multipart[i].size());
 
-                auto chan_it = output_fields_map.find(chan_name);
-                if (chan_it != output_fields_map.end())
-                    peer_it->second.sopi_list.push_back(chan_it->second);
+                auto const *descriptor = hardware::state_registry::instance().find(chan_name);
+                if (descriptor != nullptr)
+                    peer_it->second.sopi_list.push_back(descriptor);
             }
         }
         if (multipart[1] == zmq::message_t("REG_SIPO", 8)) {
@@ -162,6 +162,9 @@ void zmq_input::poll()
         }
     }
 
+    hardware::state_snapshot snapshot;
+    hardware::state_registry::capture(snapshot);
+
     auto now = std::chrono::high_resolution_clock::now();
 
     for (auto peer = peers.begin(); peer != peers.end();) {
@@ -183,130 +186,12 @@ void zmq_input::poll()
         msg.addmem(peerbuf, sizeof(peerbuf));
         msg.addstr("SOPI_DATA");
 
-        for (output_fields field : peer->second.sopi_list)
-            msg.add(pack_field(field));
+        for (auto const *field : peer->second.sopi_list)
+            msg.add(pack_float(static_cast<float>(field->getter(snapshot).numeric)));
 
         if (!msg.send(*sock, ZMQ_DONTWAIT))
             peer = peers.erase(peer);
         else
             ++peer;
     }
-}
-
-std::unordered_map<std::string, zmq_input::output_fields> zmq_input::output_fields_map = {
-    { "shp", output_fields::shp },
-    { "alerter", output_fields::alerter },
-    { "radio_stop", output_fields::radio_stop },
-    { "motor_resistors", output_fields::motor_resistors },
-    { "line_breaker", output_fields::line_breaker },
-    { "motor_overload", output_fields::motor_overload },
-    { "motor_connectors", output_fields::motor_connectors },
-    { "wheelslip", output_fields::wheelslip },
-    { "converter_overload", output_fields::converter_overload },
-    { "converter_off", output_fields::converter_off },
-    { "compressor_overload", output_fields::compressor_overload },
-    { "ventilator_overload", output_fields::ventilator_overload },
-    { "motor_overload_threshold", output_fields::motor_overload_threshold },
-    { "train_heating", output_fields::train_heating },
-    { "cab", output_fields::cab },
-    { "recorder_braking", output_fields::recorder_braking },
-    { "recorder_power", output_fields::recorder_power },
-    { "alerter_sound",output_fields:: alerter_sound },
-    { "coupled_hv_voltage_relays", output_fields::coupled_hv_voltage_relays },
-    { "velocity", output_fields::velocity },
-    { "reservoir_pressure", output_fields::reservoir_pressure },
-    { "pipe_pressure", output_fields::pipe_pressure },
-    { "brake_pressure", output_fields::brake_pressure },
-    { "hv_voltage", output_fields::hv_voltage },
-    { "hv_current_1", output_fields::hv_current_1 },
-    { "hv_current_2", output_fields::hv_current_2 },
-    { "hv_current_3", output_fields::hv_current_3 },
-    { "lv_voltage", output_fields::lv_voltage },
-    { "distance", output_fields::distance },
-    { "radio_channel", output_fields::radio_channel },
-    { "springbrake_active", output_fields::springbrake_active },
-    { "time_month_of_era", output_fields::time_month_of_era },
-    { "time_minute_of_month", output_fields::time_minute_of_month },
-    { "time_millisecond_of_day", output_fields::time_millisecond_of_day }
-};
-
-zmq::message_t zmq_input::pack_field(zmq_input::output_fields f) {
-    const SYSTEMTIME time = simulation::Time.data();
-
-    if (f == output_fields::time_month_of_era)
-        return pack_float((time.wYear - 1) * 12 + time.wMonth - 1);
-    if (f == output_fields::time_minute_of_month)
-        return pack_float((time.wDay - 1) * 1440 + time.wHour * 60 + time.wMinute);
-    if (f == output_fields::time_millisecond_of_day)
-        return pack_float(time.wSecond * 1000 + time.wMilliseconds);
-
-    TTrain *train = simulation::Train;
-    if (!train)
-        return pack_float(0.0f);
-    const TTrain::state_t state = train->get_state();
-
-    if (f == output_fields::shp)
-        return pack_float(state.shp);
-    if (f == output_fields::alerter)
-        return pack_float(state.alerter);
-    if (f == output_fields::radio_stop)
-        return pack_float(state.radio_stop);
-    if (f == output_fields::motor_resistors)
-        return pack_float(state.motor_resistors);
-    if (f == output_fields::line_breaker)
-        return pack_float(state.line_breaker);
-    if (f == output_fields::motor_overload)
-        return pack_float(state.motor_overload);
-    if (f == output_fields::motor_connectors)
-        return pack_float(state.motor_connectors);
-    if (f == output_fields::wheelslip)
-        return pack_float(state.wheelslip);
-    if (f == output_fields::converter_overload)
-        return pack_float(state.converter_overload);
-    if (f == output_fields::converter_off)
-        return pack_float(state.converter_off);
-    if (f == output_fields::compressor_overload)
-        return pack_float(state.compressor_overload);
-    if (f == output_fields::ventilator_overload)
-        return pack_float(state.ventilator_overload);
-    if (f == output_fields::motor_overload_threshold)
-        return pack_float(state.motor_overload_threshold);
-    if (f == output_fields::train_heating)
-        return pack_float(state.train_heating);
-    if (f == output_fields::cab)
-        return pack_float(state.cab);
-    if (f == output_fields::recorder_braking)
-        return pack_float(state.recorder_braking);
-    if (f == output_fields::recorder_power)
-        return pack_float(state.recorder_power);
-    if (f == output_fields::alerter_sound)
-        return pack_float(state.alerter_sound);
-    if (f == output_fields::coupled_hv_voltage_relays)
-        return pack_float(state.coupled_hv_voltage_relays);
-    if (f == output_fields::velocity)
-        return pack_float(state.velocity);
-    if (f == output_fields::reservoir_pressure)
-        return pack_float(state.reservoir_pressure);
-    if (f == output_fields::pipe_pressure)
-        return pack_float(state.pipe_pressure);
-    if (f == output_fields::brake_pressure)
-        return pack_float(state.brake_pressure);
-    if (f == output_fields::hv_voltage)
-        return pack_float(state.hv_voltage);
-    if (f == output_fields::hv_current_1)
-        return pack_float(state.hv_current[0]);
-    if (f == output_fields::hv_current_2)
-        return pack_float(state.hv_current[1]);
-    if (f == output_fields::hv_current_3)
-        return pack_float(state.hv_current[2]);
-    if (f == output_fields::lv_voltage)
-        return pack_float(state.lv_voltage);
-    if (f == output_fields::distance)
-        return pack_float(state.distance);
-    if (f == output_fields::radio_channel)
-        return pack_float(state.radio_channel);
-    if (f == output_fields::springbrake_active)
-        return pack_float(state.springbrake_active);
-
-    return pack_float(0.0f);
 }

--- a/input/zmq_input.h
+++ b/input/zmq_input.h
@@ -2,45 +2,10 @@
 
 #include <zmq_addon.hpp>
 #include "input/command.h"
+#include "hardware/registry/state_registry.h"
 
 class zmq_input
 {
-    enum class output_fields {
-        shp,
-        alerter,
-        radio_stop,
-        motor_resistors,
-        line_breaker,
-        motor_overload,
-        motor_connectors,
-        wheelslip,
-        converter_overload,
-        converter_off,
-        compressor_overload,
-        ventilator_overload,
-        motor_overload_threshold,
-        train_heating,
-        cab,
-        recorder_braking,
-        recorder_power,
-        alerter_sound,
-        coupled_hv_voltage_relays,
-        velocity,
-        reservoir_pressure,
-        pipe_pressure,
-        brake_pressure,
-        hv_voltage,
-        hv_current_1,
-        hv_current_2,
-        hv_current_3,
-        lv_voltage,
-        distance,
-        radio_channel,
-        springbrake_active,
-        time_month_of_era,
-        time_minute_of_month,
-        time_millisecond_of_day
-    };
 
     zmq::context_t ctx;
     std::optional<zmq::socket_t> sock;
@@ -55,7 +20,8 @@ class zmq_input
 
     struct peer_state {
         float update_interval;
-        std::vector<output_fields> sopi_list;
+        // symbols this peer subscribed to, resolved through the shared TrainState registry
+        std::vector<hardware::state_descriptor const *> sopi_list;
         std::vector<std::tuple<input_type, user_command, user_command, bool>> sipo_list;;
         std::chrono::time_point<std::chrono::high_resolution_clock> last_update;
     };
@@ -64,11 +30,9 @@ class zmq_input
 
     float unpack_float(const zmq::message_t &);
     zmq::message_t pack_float(float f);
-    zmq::message_t pack_field(output_fields f);
 
     std::unordered_map<std::string, user_command> nametocommandmap;
 
-    static std::unordered_map<std::string, output_fields> output_fields_map;
     command_relay relay;
 
 public:

--- a/network/backend/asio.cpp
+++ b/network/backend/asio.cpp
@@ -23,6 +23,8 @@ void network::tcp::connection::disconnect()
 
 void network::tcp::connection::send_data(std::shared_ptr<std::string> buffer)
 {
+	Traffic.sent(buffer->size());
+
 	asio::async_write(m_socket, asio::buffer(*buffer.get()), std::bind(&connection::send_complete, this, buffer));
 }
 
@@ -52,6 +54,8 @@ void network::tcp::connection::handle_header(const asio::error_code &err, size_t
 		return;
 	}
 
+	Traffic.received(bytes_transferred);
+
 	uint32_t sig = sn_utils::ld_uint32(header);
 	if (sig != NETWORK_MAGIC) {
 		disconnect();
@@ -80,6 +84,8 @@ void network::tcp::connection::handle_data(const asio::error_code &err, size_t b
 		disconnect();
 		return;
 	}
+
+	Traffic.received(bytes_transferred);
 
 	std::istringstream stream(m_body_buffer);
 	std::shared_ptr<message> msg = deserialize_message(stream);

--- a/network/backend/asio.h
+++ b/network/backend/asio.h
@@ -10,7 +10,8 @@
 namespace network::tcp
 {
     const uint32_t NETWORK_MAGIC = 0x37305545;
-	const uint32_t MAX_MSG_SIZE = 100000;
+	// a snapshot of a busy scenario is comfortably larger than a command frame
+	const uint32_t MAX_MSG_SIZE = 8 * 1024 * 1024;
 
 	class connection : public network::connection
 	{

--- a/network/chat.cpp
+++ b/network/chat.cpp
@@ -1,0 +1,94 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "network/chat.h"
+
+#include "utilities/Globals.h"
+#include "utilities/Logs.h"
+
+namespace
+{
+
+std::deque<network::chat_line> g_log;
+uint64_t g_serial{0};
+
+} // namespace
+
+std::string network::tidy_chat(std::string const &Raw)
+{
+	std::string text;
+	text.reserve(Raw.size());
+
+	bool space{false};
+	for (char const character : Raw)
+	{
+		unsigned char const value = (unsigned char)character;
+		// a newline would let one line pretend to be several, including one that looks
+		// like it came from somebody else
+		if (value < 0x20 || value == 0x7f)
+			continue;
+
+		if (character == ' ')
+		{
+			space = !text.empty();
+			continue;
+		}
+
+		if (space)
+		{
+			text += ' ';
+			space = false;
+		}
+
+		text += character;
+		if (text.size() >= CHAT_LENGTH_LIMIT)
+			break;
+	}
+
+	return text;
+}
+
+void network::note_chat(PeerId const Author, std::string const &Text)
+{
+	auto const text = tidy_chat(Text);
+	if (text.empty())
+		return;
+
+	chat_line line;
+	line.author = Author;
+	line.name = Peers.name_of(Author);
+	line.text = text;
+	line.time = Global.fTimeAngleDeg;
+
+	g_log.emplace_back(line);
+	while (g_log.size() > CHAT_HISTORY)
+		g_log.pop_front();
+
+	++g_serial;
+
+	// on a machine running without a window this is the only place the conversation shows
+	WriteLog("chat: <" + line.name + "> " + line.text, logtype::net);
+}
+
+std::deque<network::chat_line> const &network::chat_log()
+{
+	return g_log;
+}
+
+uint64_t network::chat_serial()
+{
+	return g_serial;
+}
+
+void network::clear_chat()
+{
+	g_log.clear();
+	g_serial = 0;
+}

--- a/network/chat.h
+++ b/network/chat.h
@@ -1,0 +1,51 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <deque>
+#include <string>
+
+#include "network/entities.h"
+
+namespace network
+{
+
+// the longest thing anybody may say at once. a line, not an essay - and a cap the server
+// applies to what it receives rather than trusting the sender to have applied it
+constexpr size_t CHAT_LENGTH_LIMIT = 200;
+// how much of the conversation is kept
+constexpr size_t CHAT_HISTORY = 100;
+
+struct chat_line
+{
+	PeerId author{PEER_NONE};
+	// resolved when the line arrives: a peer may be gone by the time it is read back
+	std::string name;
+	std::string text;
+	// simulation clock, for the timestamp in front of the line
+	double time{0.0};
+};
+
+// puts a line in the log, whoever it came from. also writes it to the ordinary log, which
+// is what a headless server has instead of a chat window
+void note_chat(PeerId Author, std::string const &Text);
+
+std::deque<chat_line> const &chat_log();
+
+// how many lines have arrived since the session started. the panel watches this to know
+// when to scroll, and the rest of the ui to know there is something new
+uint64_t chat_serial();
+
+void clear_chat();
+
+// trims and caps a line, and says whether anything worth sending is left
+std::string tidy_chat(std::string const &Raw);
+
+} // namespace network

--- a/network/entities.cpp
+++ b/network/entities.cpp
@@ -22,6 +22,146 @@ namespace network
 {
 
 entity_registry Entities;
+peer_registry Peers;
+
+namespace
+{
+
+// long enough for a name worth having, short enough not to wreck a lobby column
+constexpr size_t NICKNAME_LIMIT = 24;
+
+std::string tidy_name(std::string const &Raw)
+{
+	std::string name;
+	name.reserve(Raw.size());
+
+	bool space{false};
+	for (char const character : Raw)
+	{
+		// control characters and tabs have no business in a name that goes on somebody
+		// else's screen, and a run of spaces is one space
+		unsigned char const value = (unsigned char)character;
+		if (value < 0x20 || value == 0x7f)
+			continue;
+
+		if (character == ' ')
+		{
+			space = !name.empty();
+			continue;
+		}
+
+		if (space)
+		{
+			name += ' ';
+			space = false;
+		}
+
+		name += character;
+		if (name.size() >= NICKNAME_LIMIT)
+			break;
+	}
+
+	return name;
+}
+
+} // namespace
+
+std::string local_nickname()
+{
+	auto name = tidy_name(Global.multiplayer_nickname);
+	if (!name.empty())
+		return name;
+
+	// nothing configured: whoever is logged in will do, and failing that nothing at all -
+	// the registry has a stand-in for that case
+	for (char const *variable : {"EU07_NICKNAME", "USERNAME", "USER", "LOGNAME"})
+	{
+		char const *value = std::getenv(variable);
+		if (value == nullptr)
+			continue;
+		name = tidy_name(value);
+		if (!name.empty())
+			return name;
+	}
+
+	return std::string();
+}
+
+bool peer_registry::taken(std::string const &Name, PeerId const Except) const
+{
+	for (auto const &entry : m_names)
+	{
+		if (entry.first == Except)
+			continue;
+		if (entry.second == Name)
+			return true;
+	}
+	return false;
+}
+
+std::string peer_registry::assign(PeerId const Peer, std::string const &Requested)
+{
+	std::string name = tidy_name(Requested);
+
+	if (name.empty())
+		name = (Peer == PEER_HOST ? std::string("host") : "player " + std::to_string(Peer));
+
+	// two people called Marcin are two people, and the lobby has to say which is which
+	if (taken(name, Peer))
+	{
+		std::string const base = name;
+		for (int suffix = 2; suffix < 100; ++suffix)
+		{
+			name = base + " (" + std::to_string(suffix) + ")";
+			if (!taken(name, Peer))
+				break;
+		}
+	}
+
+	m_names[Peer] = name;
+
+	return name;
+}
+
+void peer_registry::forget(PeerId const Peer)
+{
+	m_names.erase(Peer);
+}
+
+void peer_registry::adopt(std::vector<peer_entry> const &Roster)
+{
+	m_names.clear();
+	for (auto const &entry : Roster)
+		m_names[entry.id] = entry.name;
+}
+
+std::string peer_registry::name_of(PeerId const Peer) const
+{
+	auto const lookup = m_names.find(Peer);
+	if (lookup != m_names.end())
+		return lookup->second;
+
+	if (Peer == PEER_HOST)
+		return "host";
+	if (Peer == PEER_NONE)
+		return "nobody";
+
+	return "player " + std::to_string(Peer);
+}
+
+std::vector<peer_entry> peer_registry::roster() const
+{
+	std::vector<peer_entry> entries;
+	entries.reserve(m_names.size());
+	for (auto const &entry : m_names)
+		entries.emplace_back(peer_entry{entry.first, entry.second});
+	return entries;
+}
+
+void peer_registry::clear()
+{
+	m_names.clear();
+}
 
 PeerId allocate_peer_id()
 {

--- a/network/entities.cpp
+++ b/network/entities.cpp
@@ -44,10 +44,11 @@ bool is_drivable(TDynamicObject const *Vehicle)
 	if (Vehicle == nullptr || Vehicle->MoverParameters == nullptr)
 		return false;
 
-	// anything with its own drive, plus anything the scenario already put a driver in
-	// (this covers driving trailers of multiple units, which carry no engine of their own)
-	// TODO: a cab count exposed by TMoverParameters would be a more precise test
-	return Vehicle->MoverParameters->EngineType != TEngineType::None || Vehicle->Mechanik != nullptr;
+	auto const &mover = *Vehicle->MoverParameters;
+
+	// a driving position is what counts, not an engine: the driving trailer of a multiple
+	// unit has a full desk and no traction of its own, and the scenario puts nobody in it
+	return mover.EngineType != TEngineType::None || Vehicle->Mechanik != nullptr || mover.MainCtrlPosNo > 0 || mover.BrakeCtrlPosNo > 0;
 }
 
 void entity_registry::clear()
@@ -61,10 +62,12 @@ void entity_registry::build()
 {
 	clear();
 
+	// every vehicle gets an id, not only the ones worth driving. commands are addressed by
+	// it, and a player working a train may walk into any of its cars
 	std::vector<std::string> names;
 	for (TDynamicObject *vehicle : simulation::Vehicles.sequence())
 	{
-		if (!is_drivable(vehicle))
+		if (vehicle == nullptr)
 			continue;
 		names.emplace_back(vehicle->name());
 	}
@@ -88,10 +91,22 @@ void entity_registry::build()
 		m_byname.emplace(name, entry.id);
 	}
 
+	if (m_entries.size() > 0xffff)
+	{
+		// the command channel packs the recipient into sixteen bits
+		ErrorLog("net: scenario holds more vehicles than the command channel can address", logtype::net);
+	}
+
 	reindex();
 	refresh();
 
-	WriteLog("net: assigned network ids to " + std::to_string(m_entries.size()) + " drivable vehicles", logtype::net);
+	uint32_t drivable{0};
+	for (auto const &entry : m_entries)
+		if (entry.drivable)
+			++drivable;
+
+	WriteLog("net: assigned network ids to " + std::to_string(m_entries.size()) + " vehicles, " + std::to_string(drivable) + " of them with a driving position",
+	         logtype::net);
 }
 
 void entity_registry::adopt(std::vector<vehicle_entry> const &Entries)
@@ -112,15 +127,110 @@ void entity_registry::reindex()
 
 void entity_registry::refresh()
 {
+	// only there so that a malformed consist cannot spin us forever
+	int const CONSIST_LIMIT{256};
+
 	for (auto &entry : m_entries)
 	{
 		TDynamicObject const *vehicle = resolve(entry.id);
 
+		entry.consist_id = entry.id;
+		entry.consist_size = 1;
+		entry.consist_lead = false;
+		entry.drivable = is_drivable(vehicle);
 		entry.ai_active = (vehicle != nullptr && vehicle->Mechanik != nullptr && vehicle->Mechanik->AIControllFlag);
-		entry.crew_count = Crews.count(entry.id);
 		entry.crew_capacity = CREW_CAPACITY;
-		entry.claimable = (vehicle != nullptr && entry.crew_count < entry.crew_capacity);
 	}
+
+	// group the vehicles into the trains they are currently coupled into. this is redone
+	// every time, so a train that comes apart turns into two trains here, and the crews
+	// follow whichever half each player happens to be sitting in
+	std::unordered_set<TDynamicObject const *> visited;
+
+	for (auto const &entry : m_entries)
+	{
+		TDynamicObject *vehicle = resolve(entry.id);
+		if (vehicle == nullptr || visited.count(vehicle) > 0)
+			continue;
+
+		TDynamicObject *front = vehicle;
+		for (int step = 0; step < CONSIST_LIMIT; ++step)
+		{
+			TDynamicObject *previous = front->Prev();
+			if (previous == nullptr || previous == vehicle || visited.count(previous) > 0)
+				break;
+			front = previous;
+		}
+
+		std::vector<NetworkEntityId> members;
+		TDynamicObject *member = front;
+		for (int step = 0; step < CONSIST_LIMIT && member != nullptr; ++step, member = member->Next())
+		{
+			if (visited.count(member) > 0)
+				break;
+			visited.emplace(member);
+
+			auto const id = id_of(member->name());
+			if (id != ENTITY_NONE)
+				members.emplace_back(id);
+		}
+
+		if (members.empty())
+			continue;
+
+		// the lowest id in the set names the train, and the lowest one that can actually
+		// be driven stands for it in the lobby
+		NetworkEntityId consist{members.front()};
+		NetworkEntityId lead{ENTITY_NONE};
+		uint8_t crew{0};
+
+		for (auto const id : members)
+		{
+			consist = std::min(consist, id);
+			crew = (uint8_t)std::min<int>(255, crew + Crews.count(id));
+
+			auto const *candidate = find(id);
+			if (candidate != nullptr && candidate->drivable && (lead == ENTITY_NONE || id < lead))
+				lead = id;
+		}
+		if (lead == ENTITY_NONE)
+			lead = consist;
+
+		for (auto const id : members)
+		{
+			auto const lookup = m_byid.find(id);
+			if (lookup == m_byid.end())
+				continue;
+
+			auto &target = m_entries[lookup->second];
+			target.consist_id = consist;
+			target.consist_size = (uint8_t)std::min<size_t>(255, members.size());
+			target.consist_lead = (id == lead);
+			target.crew_count = crew;
+			target.claimable = (crew < target.crew_capacity);
+		}
+	}
+}
+
+NetworkEntityId entity_registry::consist_of(NetworkEntityId Id) const
+{
+	auto const *entry = find(Id);
+	return entry != nullptr ? entry->consist_id : ENTITY_NONE;
+}
+
+std::vector<NetworkEntityId> entity_registry::consist_members(NetworkEntityId Consist) const
+{
+	std::vector<NetworkEntityId> members;
+	if (Consist == ENTITY_NONE)
+		return members;
+
+	for (auto const &entry : m_entries)
+	{
+		if (entry.consist_id == Consist)
+			members.emplace_back(entry.id);
+	}
+
+	return members;
 }
 
 NetworkEntityId entity_registry::id_of(std::string const &Name) const

--- a/network/entities.cpp
+++ b/network/entities.cpp
@@ -9,6 +9,7 @@ http://mozilla.org/MPL/2.0/.
 
 #include "stdafx.h"
 #include "network/entities.h"
+#include "network/session.h"
 
 #include "simulation/simulation.h"
 #include "vehicle/DynObj.h"
@@ -105,9 +106,7 @@ void entity_registry::refresh()
 		TDynamicObject const *vehicle = resolve(entry.id);
 
 		entry.ai_active = (vehicle != nullptr && vehicle->Mechanik != nullptr && vehicle->Mechanik->AIControllFlag);
-		// until the crew model of stage 3 is in place, an existing cab instance is the
-		// only evidence that somebody took the vehicle over
-		entry.crew_count = (simulation::Trains.find(entry.name) != nullptr ? 1 : 0);
+		entry.crew_count = Crews.count(entry.id);
 		entry.crew_capacity = CREW_CAPACITY;
 		entry.claimable = (vehicle != nullptr && entry.crew_count < entry.crew_capacity);
 	}

--- a/network/entities.cpp
+++ b/network/entities.cpp
@@ -16,6 +16,7 @@ http://mozilla.org/MPL/2.0/.
 #include "vehicle/Driver.h"
 #include "vehicle/Train.h"
 #include "utilities/Logs.h"
+#include "utilities/Globals.h"
 
 namespace network
 {
@@ -26,6 +27,16 @@ PeerId allocate_peer_id()
 {
 	static PeerId next = PEER_FIRST_REMOTE;
 	return next++;
+}
+
+bool is_multiplayer()
+{
+	return Global.network_client.has_value() || !Global.network_servers.empty();
+}
+
+bool is_authority()
+{
+	return !Global.network_client.has_value();
 }
 
 bool is_drivable(TDynamicObject const *Vehicle)

--- a/network/entities.cpp
+++ b/network/entities.cpp
@@ -1,0 +1,148 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "network/entities.h"
+
+#include "simulation/simulation.h"
+#include "vehicle/DynObj.h"
+#include "vehicle/Driver.h"
+#include "vehicle/Train.h"
+#include "utilities/Logs.h"
+
+namespace network
+{
+
+entity_registry Entities;
+
+PeerId allocate_peer_id()
+{
+	static PeerId next = PEER_FIRST_REMOTE;
+	return next++;
+}
+
+bool is_drivable(TDynamicObject const *Vehicle)
+{
+	if (Vehicle == nullptr || Vehicle->MoverParameters == nullptr)
+		return false;
+
+	// anything with its own drive, plus anything the scenario already put a driver in
+	// (this covers driving trailers of multiple units, which carry no engine of their own)
+	// TODO: a cab count exposed by TMoverParameters would be a more precise test
+	return Vehicle->MoverParameters->EngineType != TEngineType::None || Vehicle->Mechanik != nullptr;
+}
+
+void entity_registry::clear()
+{
+	m_entries.clear();
+	m_byname.clear();
+	m_byid.clear();
+}
+
+void entity_registry::build()
+{
+	clear();
+
+	std::vector<std::string> names;
+	for (TDynamicObject *vehicle : simulation::Vehicles.sequence())
+	{
+		if (!is_drivable(vehicle))
+			continue;
+		names.emplace_back(vehicle->name());
+	}
+
+	// name order keeps the numbering reproducible regardless of scenario spawn order
+	std::sort(names.begin(), names.end());
+
+	for (auto const &name : names)
+	{
+		if (m_byname.find(name) != m_byname.end())
+		{
+			// a malformed scenario can hold duplicate names; only the first one is addressable
+			ErrorLog("net: duplicate vehicle name \"" + name + "\", not assigning a second network id", logtype::net);
+			continue;
+		}
+
+		vehicle_entry entry;
+		entry.id = static_cast<NetworkEntityId>(m_entries.size() + 1);
+		entry.name = name;
+		m_entries.emplace_back(entry);
+		m_byname.emplace(name, entry.id);
+	}
+
+	reindex();
+	refresh();
+
+	WriteLog("net: assigned network ids to " + std::to_string(m_entries.size()) + " drivable vehicles", logtype::net);
+}
+
+void entity_registry::adopt(std::vector<vehicle_entry> const &Entries)
+{
+	m_entries = Entries;
+	m_byname.clear();
+	for (auto const &entry : m_entries)
+		m_byname.emplace(entry.name, entry.id);
+	reindex();
+}
+
+void entity_registry::reindex()
+{
+	m_byid.clear();
+	for (size_t i = 0; i < m_entries.size(); ++i)
+		m_byid.emplace(m_entries[i].id, i);
+}
+
+void entity_registry::refresh()
+{
+	for (auto &entry : m_entries)
+	{
+		TDynamicObject const *vehicle = resolve(entry.id);
+
+		entry.ai_active = (vehicle != nullptr && vehicle->Mechanik != nullptr && vehicle->Mechanik->AIControllFlag);
+		// until the crew model of stage 3 is in place, an existing cab instance is the
+		// only evidence that somebody took the vehicle over
+		entry.crew_count = (simulation::Trains.find(entry.name) != nullptr ? 1 : 0);
+		entry.crew_capacity = CREW_CAPACITY;
+		entry.claimable = (vehicle != nullptr && entry.crew_count < entry.crew_capacity);
+	}
+}
+
+NetworkEntityId entity_registry::id_of(std::string const &Name) const
+{
+	auto const lookup = m_byname.find(Name);
+	return lookup != m_byname.end() ? lookup->second : ENTITY_NONE;
+}
+
+NetworkEntityId entity_registry::id_of(TDynamicObject const *Vehicle) const
+{
+	return Vehicle != nullptr ? id_of(Vehicle->name()) : ENTITY_NONE;
+}
+
+std::string entity_registry::name_of(NetworkEntityId Id) const
+{
+	auto const *entry = find(Id);
+	return entry != nullptr ? entry->name : std::string();
+}
+
+vehicle_entry const *entity_registry::find(NetworkEntityId Id) const
+{
+	auto const lookup = m_byid.find(Id);
+	return lookup != m_byid.end() ? &m_entries[lookup->second] : nullptr;
+}
+
+TDynamicObject *entity_registry::resolve(NetworkEntityId Id) const
+{
+	auto const *entry = find(Id);
+	if (entry == nullptr)
+		return nullptr;
+
+	return simulation::Vehicles.find(entry->name);
+}
+
+} // namespace network

--- a/network/entities.h
+++ b/network/entities.h
@@ -92,6 +92,12 @@ extern entity_registry Entities;
 // hands out ids for connecting peers; PEER_HOST is reserved for the local participant
 PeerId allocate_peer_id();
 
+// true when this run takes part in a session at all, as host or as client
+bool is_multiplayer();
+// true when this peer decides what happens in the world. a standalone game and the host
+// of a session do; a client does not, it only carries out what the server hands it
+bool is_authority();
+
 // true for vehicles a player can take over
 bool is_drivable(TDynamicObject const *Vehicle);
 

--- a/network/entities.h
+++ b/network/entities.h
@@ -1,0 +1,98 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+class TDynamicObject;
+
+namespace network
+{
+
+// identifies a participant of the session. the host is a participant like any other,
+// so that peer/crew/permission handling does not need a special case for it
+using PeerId = uint32_t;
+constexpr PeerId PEER_NONE = 0;
+constexpr PeerId PEER_HOST = 1;
+// remote peers are numbered from here up
+constexpr PeerId PEER_FIRST_REMOTE = 2;
+
+// identifies a vehicle for the whole session. unlike TTrain::id() this does not depend
+// on the order in which a particular peer happened to create its trains
+using NetworkEntityId = uint32_t;
+constexpr NetworkEntityId ENTITY_NONE = 0;
+
+// how many people may share one vehicle. the crew itself is a plain container,
+// so raising this number does not call for a structural change
+constexpr uint8_t CREW_CAPACITY = 2;
+
+// authoritative description of a single drivable vehicle, as published by the server
+struct vehicle_entry
+{
+	NetworkEntityId id{ENTITY_NONE};
+	std::string name;
+	uint8_t crew_count{0};
+	uint8_t crew_capacity{CREW_CAPACITY};
+	bool ai_active{false};
+	bool claimable{false};
+
+	bool operator==(vehicle_entry const &Other) const
+	{
+		return id == Other.id && name == Other.name && crew_count == Other.crew_count && crew_capacity == Other.crew_capacity && ai_active == Other.ai_active &&
+		       claimable == Other.claimable;
+	}
+	bool operator!=(vehicle_entry const &Other) const { return !(*this == Other); }
+};
+
+// maps stable network ids onto the vehicles of the loaded scenario.
+// the server owns the numbering and publishes it; a client binds the received ids to
+// its own copy of the scenario by vehicle name, which keeps the runtime protocol on ids
+class entity_registry
+{
+public:
+	// server side: builds the numbering from the loaded scenario. vehicles are ordered by
+	// name so that the result does not depend on the order the scenario happened to spawn them
+	void build();
+	// client side: takes over the numbering published by the server
+	void adopt(std::vector<vehicle_entry> const &Entries);
+	// server side: refreshes the volatile part of the published entries
+	void refresh();
+	void clear();
+
+	bool empty() const { return m_entries.empty(); }
+	std::vector<vehicle_entry> const &entries() const { return m_entries; }
+
+	NetworkEntityId id_of(std::string const &Name) const;
+	NetworkEntityId id_of(TDynamicObject const *Vehicle) const;
+	std::string name_of(NetworkEntityId Id) const;
+	TDynamicObject *resolve(NetworkEntityId Id) const;
+	vehicle_entry const *find(NetworkEntityId Id) const;
+
+private:
+	void reindex();
+
+	std::vector<vehicle_entry> m_entries;
+	std::unordered_map<std::string, NetworkEntityId> m_byname;
+	std::unordered_map<NetworkEntityId, size_t> m_byid;
+};
+
+// session wide vehicle registry. stays empty outside of multiplayer
+extern entity_registry Entities;
+
+// hands out ids for connecting peers; PEER_HOST is reserved for the local participant
+PeerId allocate_peer_id();
+
+// true for vehicles a player can take over
+bool is_drivable(TDynamicObject const *Vehicle);
+
+} // namespace network

--- a/network/entities.h
+++ b/network/entities.h
@@ -107,6 +107,40 @@ private:
 // session wide vehicle registry. stays empty outside of multiplayer
 extern entity_registry Entities;
 
+// what a participant is called. a peer id is what the protocol addresses, but "player 4"
+// is no use to anybody reading a lobby or a chat line
+struct peer_entry
+{
+	PeerId id{PEER_NONE};
+	std::string name;
+};
+
+class peer_registry
+{
+  public:
+	// takes a name a peer asked for and makes it fit to show: trimmed, control characters
+	// out, capped in length, and made unique within the session
+	std::string assign(PeerId Peer, std::string const &Requested);
+	void forget(PeerId Peer);
+	// a client replaces its whole idea of who is in the session with what the server sent
+	void adopt(std::vector<peer_entry> const &Roster);
+	// the name, or a readable stand-in for a peer nobody has told us about yet
+	std::string name_of(PeerId Peer) const;
+	std::vector<peer_entry> roster() const;
+	void clear();
+
+  private:
+	bool taken(std::string const &Name, PeerId Except) const;
+
+	std::unordered_map<PeerId, std::string> m_names;
+};
+
+// who is in the session. the host keeps the authoritative copy and hands it to everybody
+extern peer_registry Peers;
+
+// the name this peer would like to be known by, cleaned up but not yet made unique
+std::string local_nickname();
+
 // hands out ids for connecting peers; PEER_HOST is reserved for the local participant
 PeerId allocate_peer_id();
 

--- a/network/entities.h
+++ b/network/entities.h
@@ -36,20 +36,35 @@ constexpr NetworkEntityId ENTITY_NONE = 0;
 // so raising this number does not call for a structural change
 constexpr uint8_t CREW_CAPACITY = 2;
 
-// authoritative description of a single drivable vehicle, as published by the server
+// authoritative description of a single vehicle, as published by the server.
+// every vehicle is listed, not only the ones worth driving: commands are addressed by
+// this id, and a player may walk into any member of the train they are working
 struct vehicle_entry
 {
 	NetworkEntityId id{ENTITY_NONE};
 	std::string name;
+	// the train this vehicle is currently coupled into, named by the lowest id in the set.
+	// a player belongs to a train, not to a single car, so this is what the crew, the
+	// permissions and the lobby all work with. it is recomputed as vehicles couple and
+	// uncouple, which is what splits a crew between the halves of a train that came apart
+	NetworkEntityId consist_id{ENTITY_NONE};
+	// how many vehicles that train has, and whether this entry is the one that stands for
+	// it in the lobby
+	uint8_t consist_size{1};
+	bool consist_lead{false};
+	// crew of the whole train, not of this vehicle alone
 	uint8_t crew_count{0};
 	uint8_t crew_capacity{CREW_CAPACITY};
 	bool ai_active{false};
 	bool claimable{false};
+	// has a driving position of its own
+	bool drivable{false};
 
 	bool operator==(vehicle_entry const &Other) const
 	{
-		return id == Other.id && name == Other.name && crew_count == Other.crew_count && crew_capacity == Other.crew_capacity && ai_active == Other.ai_active &&
-		       claimable == Other.claimable;
+		return id == Other.id && name == Other.name && consist_id == Other.consist_id && consist_size == Other.consist_size && consist_lead == Other.consist_lead &&
+		       crew_count == Other.crew_count && crew_capacity == Other.crew_capacity && ai_active == Other.ai_active && claimable == Other.claimable &&
+		       drivable == Other.drivable;
 	}
 	bool operator!=(vehicle_entry const &Other) const { return !(*this == Other); }
 };
@@ -74,6 +89,9 @@ public:
 
 	NetworkEntityId id_of(std::string const &Name) const;
 	NetworkEntityId id_of(TDynamicObject const *Vehicle) const;
+	// the train a vehicle belongs to, and everything coupled into it
+	NetworkEntityId consist_of(NetworkEntityId Id) const;
+	std::vector<NetworkEntityId> consist_members(NetworkEntityId Consist) const;
 	std::string name_of(NetworkEntityId Id) const;
 	TDynamicObject *resolve(NetworkEntityId Id) const;
 	vehicle_entry const *find(NetworkEntityId Id) const;
@@ -98,7 +116,8 @@ bool is_multiplayer();
 // of a session do; a client does not, it only carries out what the server hands it
 bool is_authority();
 
-// true for vehicles a player can take over
+// true for vehicles that carry a driving position of their own. note that a driving
+// trailer has one without having an engine, and without the scenario putting a driver in
 bool is_drivable(TDynamicObject const *Vehicle);
 
 } // namespace network

--- a/network/manager.cpp
+++ b/network/manager.cpp
@@ -199,6 +199,8 @@ void network::manager::request_resync(uint64_t tick, uint64_t state_hash)
 
 void network::manager::update()
 {
+	Traffic.update();
+
 	for (auto &backend : backend_list())
 		backend.second->update();
 

--- a/network/manager.cpp
+++ b/network/manager.cpp
@@ -11,6 +11,7 @@ http://mozilla.org/MPL/2.0/.
 #include "network/manager.h"
 #include "simulation/simulation.h"
 #include "utilities/Logs.h"
+#include "utilities/Globals.h"
 
 network::server_manager::server_manager()
 {
@@ -82,13 +83,80 @@ void network::server_manager::publish_vehicle_list()
 		srv->push_message(msg);
 }
 
+void network::server_manager::update_crews()
+{
+	Crews.reconcile();
+
+	if (--crew_publish_countdown <= 0) {
+		// peers that joined after somebody took a vehicle over have to learn about it too
+		crew_publish_countdown = PUBLISH_INTERVAL_FRAMES;
+		Crews.mark_all_pending();
+	}
+
+	auto const changed = Crews.take_pending_updates();
+	for (NetworkEntityId const id : changed) {
+		crew_update msg;
+		msg.entity_id = id;
+		msg.crew = Crews.crew_of(id);
+
+		for (auto srv : servers)
+			srv->push_message(msg);
+	}
+}
+
+void network::server_manager::apply_local_claim(NetworkEntityId entity_id)
+{
+	auto const result = Crews.claim(PEER_HOST, entity_id);
+
+	if (result == claim_result::granted || result == claim_result::already_member) {
+		Global.network_lobby_message.clear();
+		Global.network_pending_vehicle = Entities.name_of(entity_id);
+	}
+	else {
+		WriteLog("net: refused local claim of vehicle " + std::to_string(entity_id) + ": " + describe(result), logtype::net);
+		Global.network_lobby_message = describe(result);
+	}
+}
+
+void network::server_manager::apply_local_leave(NetworkEntityId entity_id)
+{
+	if (Crews.leave(PEER_HOST, entity_id))
+		Global.network_leave_pending = true;
+}
+
+void network::manager::request_claim(NetworkEntityId entity_id)
+{
+	if (client) {
+		client->send_claim(entity_id);
+		return;
+	}
+
+	if (servers)
+		servers->apply_local_claim(entity_id);
+}
+
+void network::manager::request_leave(NetworkEntityId entity_id)
+{
+	if (client) {
+		client->send_leave(entity_id);
+		// the server owns the roster, but stepping out of our own cab is a local matter
+		Global.network_leave_pending = true;
+		return;
+	}
+
+	if (servers)
+		servers->apply_local_leave(entity_id);
+}
+
 void network::manager::update()
 {
 	for (auto &backend : backend_list())
 		backend.second->update();
 
-	if (servers && simulation::is_ready)
+	if (servers && simulation::is_ready) {
+		servers->update_crews();
 		servers->publish_vehicle_list();
+	}
 
 	if (client)
 		client->update();

--- a/network/manager.cpp
+++ b/network/manager.cpp
@@ -151,6 +151,12 @@ void network::manager::request_leave(NetworkEntityId entity_id)
 		servers->apply_local_leave(entity_id);
 }
 
+void network::manager::notify_scenario_loaded()
+{
+	if (client)
+		client->send_ready();
+}
+
 void network::manager::update()
 {
 	for (auto &backend : backend_list())

--- a/network/manager.cpp
+++ b/network/manager.cpp
@@ -32,8 +32,16 @@ command_queue::commands_map network::server_manager::pop_commands()
 
 void network::server_manager::push_delta(double render_dt, double dt, uint64_t tick, uint64_t state_hash, const command_queue::commands_map &commands)
 {
-	if (dt == 0.0 && commands.empty())
+	if (dt == 0.0)
 		return;
+
+	// a client no longer replays these frame by frame, so an empty one is only worth
+	// sending now and then, to carry the tick and the digest
+	if (commands.empty() && (--heartbeat_countdown > 0))
+		return;
+
+	if (commands.empty())
+		heartbeat_countdown = HEARTBEAT_INTERVAL_FRAMES;
 
 	frame_info msg;
 	msg.render_dt = render_dt;
@@ -203,8 +211,12 @@ void network::manager::update()
 		servers->publish_state();
 	}
 
-	if (client)
+	if (client) {
 		client->update();
+
+		if (Global.simulation_loaded)
+			client->publish_state();
+	}
 }
 
 void network::manager::create_server(const std::string &backend, const std::string &conf)

--- a/network/manager.cpp
+++ b/network/manager.cpp
@@ -88,6 +88,7 @@ void network::server_manager::publish_vehicle_list()
 
 void network::server_manager::update_crews()
 {
+	Crews.expire_absences();
 	Crews.reconcile();
 
 	if (--crew_publish_countdown <= 0) {
@@ -155,6 +156,12 @@ void network::manager::notify_scenario_loaded()
 {
 	if (client)
 		client->send_ready();
+}
+
+void network::manager::request_resync(uint64_t tick, uint64_t state_hash)
+{
+	if (client)
+		client->send_resync_request(tick, state_hash);
 }
 
 void network::manager::update()

--- a/network/manager.cpp
+++ b/network/manager.cpp
@@ -13,6 +13,7 @@ http://mozilla.org/MPL/2.0/.
 #include "utilities/Logs.h"
 #include "utilities/Globals.h"
 #include "network/statehash.h"
+#include "network/snapshot.h"
 
 network::server_manager::server_manager()
 {
@@ -158,6 +159,30 @@ void network::manager::notify_scenario_loaded()
 		client->send_ready();
 }
 
+void network::server_manager::publish_state()
+{
+	if (--state_countdown > 0)
+		return;
+
+	state_countdown = STATE_INTERVAL_FRAMES;
+
+	// most of the time only what changed goes out; every so often the whole thing does,
+	// so that anything a peer missed heals by itself
+	bool const full = ((state_updates++ % STATE_FULL_EVERY) == 0);
+
+	auto const blob = take_snapshot(full);
+	if (blob.empty())
+		return;
+
+	snapshot msg;
+	msg.tick = Global.simulation_tick;
+	msg.mode = 1; // correction on top of a running simulation
+	msg.blob = blob;
+
+	for (auto srv : servers)
+		srv->push_message(msg);
+}
+
 void network::manager::request_resync(uint64_t tick, uint64_t state_hash)
 {
 	if (client)
@@ -172,6 +197,7 @@ void network::manager::update()
 	if (servers && simulation::is_ready) {
 		servers->update_crews();
 		servers->publish_vehicle_list();
+		servers->publish_state();
 	}
 
 	if (client)

--- a/network/manager.cpp
+++ b/network/manager.cpp
@@ -112,6 +112,7 @@ void network::server_manager::update_crews()
 		crew_update msg;
 		msg.entity_id = id;
 		msg.crew = Crews.crew_of(id);
+		msg.since = Crews.crew_since_of(id);
 
 		for (auto srv : servers)
 			srv->push_message(msg);
@@ -226,6 +227,7 @@ void network::manager::say(const std::string &text)
 	{
 		// a client waits to hear itself back from the server, so that everybody sees the
 		// conversation in the same order
+		WriteLog("net: saying \"" + line + "\"", logtype::net);
 		client->send_chat(line);
 	}
 }

--- a/network/manager.cpp
+++ b/network/manager.cpp
@@ -14,6 +14,7 @@ http://mozilla.org/MPL/2.0/.
 #include "utilities/Globals.h"
 #include "network/statehash.h"
 #include "network/snapshot.h"
+#include "network/chat.h"
 
 network::server_manager::server_manager()
 {
@@ -189,6 +190,44 @@ void network::server_manager::publish_state()
 
 	for (auto srv : servers)
 		srv->push_message(msg);
+}
+
+void network::server_manager::broadcast_chat(PeerId const author, const std::string &text)
+{
+	chat_message msg;
+	msg.peer = author;
+	msg.text = text;
+
+	for (auto srv : servers)
+		srv->push_message(msg);
+}
+
+void network::server_manager::publish_roster()
+{
+	for (auto srv : servers)
+		srv->publish_roster();
+}
+
+void network::manager::say(const std::string &text)
+{
+	auto const line = tidy_chat(text);
+	if (line.empty())
+		return;
+
+	if (servers)
+	{
+		// the host is the one who decides what was said, so it says it and passes it on
+		note_chat(Global.network_peer_id, line);
+		servers->broadcast_chat(Global.network_peer_id, line);
+		return;
+	}
+
+	if (client)
+	{
+		// a client waits to hear itself back from the server, so that everybody sees the
+		// conversation in the same order
+		client->send_chat(line);
+	}
 }
 
 void network::manager::request_resync(uint64_t tick, uint64_t state_hash)

--- a/network/manager.cpp
+++ b/network/manager.cpp
@@ -194,7 +194,10 @@ void network::manager::update()
 	for (auto &backend : backend_list())
 		backend.second->update();
 
-	if (servers && simulation::is_ready) {
+	if (servers && Global.simulation_loaded) {
+		// note: not simulation::is_ready. that one waits for the local player's cab, and
+		// the cab of a claimed vehicle is built by update_crews() - waiting for it here
+		// would leave the two waiting on each other
 		servers->update_crews();
 		servers->publish_vehicle_list();
 		servers->publish_state();

--- a/network/manager.cpp
+++ b/network/manager.cpp
@@ -12,6 +12,7 @@ http://mozilla.org/MPL/2.0/.
 #include "simulation/simulation.h"
 #include "utilities/Logs.h"
 #include "utilities/Globals.h"
+#include "network/statehash.h"
 
 network::server_manager::server_manager()
 {
@@ -28,7 +29,7 @@ command_queue::commands_map network::server_manager::pop_commands()
 	return map;
 }
 
-void network::server_manager::push_delta(double render_dt, double dt, double sync, const command_queue::commands_map &commands)
+void network::server_manager::push_delta(double render_dt, double dt, uint64_t tick, uint64_t state_hash, const command_queue::commands_map &commands)
 {
 	if (dt == 0.0 && commands.empty())
 		return;
@@ -36,7 +37,9 @@ void network::server_manager::push_delta(double render_dt, double dt, double syn
 	frame_info msg;
 	msg.render_dt = render_dt;
 	msg.dt = dt;
-	msg.sync = sync;
+	msg.tick = tick;
+	msg.state_hash = state_hash;
+	msg.state_hash_version = STATE_HASH_VERSION;
 	msg.commands = commands;
 
 	for (auto srv : servers)

--- a/network/manager.cpp
+++ b/network/manager.cpp
@@ -59,10 +59,36 @@ network::manager::manager()
 {
 }
 
+void network::server_manager::publish_vehicle_list()
+{
+	if (Entities.empty())
+		return;
+
+	Entities.refresh();
+
+	// resend on every change, and once in a while regardless, so that a peer which has
+	// just finished catching up does not have to wait for somebody to move
+	bool const changed = (Entities.entries() != last_published_list);
+	if (!changed && --publish_countdown > 0)
+		return;
+
+	last_published_list = Entities.entries();
+	publish_countdown = PUBLISH_INTERVAL_FRAMES;
+
+	vehicle_list msg;
+	msg.vehicles = last_published_list;
+
+	for (auto srv : servers)
+		srv->push_message(msg);
+}
+
 void network::manager::update()
 {
 	for (auto &backend : backend_list())
 		backend.second->update();
+
+	if (servers && simulation::is_ready)
+		servers->publish_vehicle_list();
 
 	if (client)
 		client->update();

--- a/network/manager.h
+++ b/network/manager.h
@@ -42,6 +42,10 @@ namespace network
 		int crew_publish_countdown = 0;
 		int state_countdown = 0;
 		int state_updates = 0;
+		int heartbeat_countdown = 0;
+
+		// how many frames with nothing in them may pass before one is sent anyway
+		static const int HEARTBEAT_INTERVAL_FRAMES = 10;
 	};
 
     class manager

--- a/network/manager.h
+++ b/network/manager.h
@@ -50,5 +50,9 @@ namespace network
 		// registry when we are the server, over the wire when we are a client
 		void request_claim(NetworkEntityId entity_id);
 		void request_leave(NetworkEntityId entity_id);
+
+		// the local scenario is loaded; a client asks the server for a snapshot of the
+		// world as it stands right now
+		void notify_scenario_loaded();
 	};
 }

--- a/network/manager.h
+++ b/network/manager.h
@@ -14,7 +14,7 @@ namespace network
 	public:
 		server_manager();
 
-		void push_delta(double render_dt, double dt, double sync, const command_queue::commands_map &commands);
+		void push_delta(double render_dt, double dt, uint64_t tick, uint64_t state_hash, const command_queue::commands_map &commands);
 		command_queue::commands_map pop_commands();
 		void create_server(const std::string &backend, const std::string &conf);
 		// refreshes the authoritative vehicle roster and publishes it when it changed

--- a/network/manager.h
+++ b/network/manager.h
@@ -27,6 +27,10 @@ namespace network
 		// crew request coming from the local participant, which needs no transport
 		void apply_local_claim(NetworkEntityId entity_id);
 		void apply_local_leave(NetworkEntityId entity_id);
+		// hands a line of chat to every peer
+		void broadcast_chat(PeerId author, const std::string &text);
+		// tells the peers who is taking part
+		void publish_roster();
 
 	private:
 		// how many frames may pass between two unconditional broadcasts of the roster
@@ -73,5 +77,9 @@ namespace network
 
 		// our world drifted away from the authoritative one; ask to be corrected
 		void request_resync(uint64_t tick, uint64_t state_hash);
+
+		// something the local participant said. the host says it to everybody at once, a
+		// client hands it to the host to say on its behalf
+		void say(const std::string &text);
 	};
 }

--- a/network/manager.h
+++ b/network/manager.h
@@ -54,5 +54,8 @@ namespace network
 		// the local scenario is loaded; a client asks the server for a snapshot of the
 		// world as it stands right now
 		void notify_scenario_loaded();
+
+		// our world drifted away from the authoritative one; ask to be corrected
+		void request_resync(uint64_t tick, uint64_t state_hash);
 	};
 }

--- a/network/manager.h
+++ b/network/manager.h
@@ -17,6 +17,15 @@ namespace network
 		void push_delta(double render_dt, double dt, double sync, const command_queue::commands_map &commands);
 		command_queue::commands_map pop_commands();
 		void create_server(const std::string &backend, const std::string &conf);
+		// refreshes the authoritative vehicle roster and publishes it when it changed
+		void publish_vehicle_list();
+
+	private:
+		// how many frames may pass between two unconditional broadcasts of the roster
+		static const int PUBLISH_INTERVAL_FRAMES = 120;
+
+		std::vector<vehicle_entry> last_published_list;
+		int publish_countdown = 0;
 	};
 
     class manager

--- a/network/manager.h
+++ b/network/manager.h
@@ -21,6 +21,9 @@ namespace network
 		void publish_vehicle_list();
 		// brings the world in line with the crew roster and announces every change
 		void update_crews();
+		// sends the peers what the world actually looks like. this is what keeps a client
+		// in line - the command stream alone cannot, because a client runs its own physics
+		void publish_state();
 		// crew request coming from the local participant, which needs no transport
 		void apply_local_claim(NetworkEntityId entity_id);
 		void apply_local_leave(NetworkEntityId entity_id);
@@ -29,9 +32,16 @@ namespace network
 		// how many frames may pass between two unconditional broadcasts of the roster
 		static const int PUBLISH_INTERVAL_FRAMES = 120;
 
+		// how often the authoritative state goes out, and how often it goes out whole
+		// rather than as what changed since the last one
+		static const int STATE_INTERVAL_FRAMES = 10;
+		static const int STATE_FULL_EVERY = 60;
+
 		std::vector<vehicle_entry> last_published_list;
 		int publish_countdown = 0;
 		int crew_publish_countdown = 0;
+		int state_countdown = 0;
+		int state_updates = 0;
 	};
 
     class manager

--- a/network/manager.h
+++ b/network/manager.h
@@ -34,7 +34,9 @@ namespace network
 
 		// how often the authoritative state goes out, and how often it goes out whole
 		// rather than as what changed since the last one
-		static const int STATE_INTERVAL_FRAMES = 10;
+		// a horn can be pressed and let go inside a couple of frames, so the state does not
+		// wait long before it goes out
+		static const int STATE_INTERVAL_FRAMES = 6;
 		static const int STATE_FULL_EVERY = 60;
 
 		std::vector<vehicle_entry> last_published_list;

--- a/network/manager.h
+++ b/network/manager.h
@@ -19,6 +19,11 @@ namespace network
 		void create_server(const std::string &backend, const std::string &conf);
 		// refreshes the authoritative vehicle roster and publishes it when it changed
 		void publish_vehicle_list();
+		// brings the world in line with the crew roster and announces every change
+		void update_crews();
+		// crew request coming from the local participant, which needs no transport
+		void apply_local_claim(NetworkEntityId entity_id);
+		void apply_local_leave(NetworkEntityId entity_id);
 
 	private:
 		// how many frames may pass between two unconditional broadcasts of the roster
@@ -26,6 +31,7 @@ namespace network
 
 		std::vector<vehicle_entry> last_published_list;
 		int publish_countdown = 0;
+		int crew_publish_countdown = 0;
 	};
 
     class manager
@@ -39,5 +45,10 @@ namespace network
 		void create_server(const std::string &backend, const std::string &conf);
 		void connect(const std::string &backend, const std::string &conf);
 		void update();
+
+		// routes a lobby request to whoever holds the authority: straight into the crew
+		// registry when we are the server, over the wire when we are a client
+		void request_claim(NetworkEntityId entity_id);
+		void request_leave(NetworkEntityId entity_id);
 	};
 }

--- a/network/message.cpp
+++ b/network/message.cpp
@@ -80,6 +80,32 @@ void network::vehicle_list::deserialize(std::istream &stream)
 	}
 }
 
+void network::client_ready::serialize(std::ostream &stream) const
+{
+	sn_utils::s_str(stream, scenario);
+}
+
+void network::client_ready::deserialize(std::istream &stream)
+{
+	scenario = sn_utils::d_str(stream);
+}
+
+void network::snapshot::serialize(std::ostream &stream) const
+{
+	sn_utils::ls_uint64(stream, tick);
+	sn_utils::ls_uint32(stream, (uint32_t)blob.size());
+	stream.write(blob.data(), blob.size());
+}
+
+void network::snapshot::deserialize(std::istream &stream)
+{
+	tick = sn_utils::ld_uint64(stream);
+
+	uint32_t const size = sn_utils::ld_uint32(stream);
+	blob.assign(size, '\0');
+	stream.read(blob.data(), size);
+}
+
 void network::claim_vehicle::serialize(std::ostream &stream) const
 {
 	sn_utils::ls_uint32(stream, entity_id);
@@ -247,6 +273,10 @@ std::shared_ptr<network::message> network::deserialize_message(std::istream &str
 		msg = std::make_shared<leave_vehicle>();
 	else if (type == message::CREW_UPDATE)
 		msg = std::make_shared<crew_update>();
+	else if (type == message::CLIENT_READY)
+		msg = std::make_shared<client_ready>();
+	else if (type == message::SNAPSHOT)
+		msg = std::make_shared<snapshot>();
 
 	if (!msg) {
 		// unknown message type; hand back a marker the peer handlers treat as a protocol error

--- a/network/message.cpp
+++ b/network/message.cpp
@@ -80,6 +80,67 @@ void network::vehicle_list::deserialize(std::istream &stream)
 	}
 }
 
+void network::claim_vehicle::serialize(std::ostream &stream) const
+{
+	sn_utils::ls_uint32(stream, entity_id);
+}
+
+void network::claim_vehicle::deserialize(std::istream &stream)
+{
+	entity_id = sn_utils::ld_uint32(stream);
+}
+
+void network::claim_granted::serialize(std::ostream &stream) const
+{
+	sn_utils::ls_uint32(stream, entity_id);
+}
+
+void network::claim_granted::deserialize(std::istream &stream)
+{
+	entity_id = sn_utils::ld_uint32(stream);
+}
+
+void network::claim_denied::serialize(std::ostream &stream) const
+{
+	sn_utils::ls_uint32(stream, entity_id);
+	sn_utils::s_str(stream, reason);
+}
+
+void network::claim_denied::deserialize(std::istream &stream)
+{
+	entity_id = sn_utils::ld_uint32(stream);
+	reason = sn_utils::d_str(stream);
+}
+
+void network::leave_vehicle::serialize(std::ostream &stream) const
+{
+	sn_utils::ls_uint32(stream, entity_id);
+}
+
+void network::leave_vehicle::deserialize(std::istream &stream)
+{
+	entity_id = sn_utils::ld_uint32(stream);
+}
+
+void network::crew_update::serialize(std::ostream &stream) const
+{
+	sn_utils::ls_uint32(stream, entity_id);
+	sn_utils::ls_uint32(stream, (uint32_t)crew.size());
+	for (PeerId const peer : crew)
+		sn_utils::ls_uint32(stream, peer);
+}
+
+void network::crew_update::deserialize(std::istream &stream)
+{
+	entity_id = sn_utils::ld_uint32(stream);
+
+	crew.clear();
+	uint32_t const count = sn_utils::ld_uint32(stream);
+	crew.reserve(count);
+	for (uint32_t i = 0; i < count; i++)
+		crew.emplace_back(sn_utils::ld_uint32(stream));
+}
+
 void ::network::request_command::serialize(std::ostream &stream) const
 {
 	sn_utils::ls_uint32(stream, commands.size());
@@ -169,6 +230,16 @@ std::shared_ptr<network::message> network::deserialize_message(std::istream &str
 		msg = std::make_shared<server_reject>();
 	else if (type == message::VEHICLE_LIST)
 		msg = std::make_shared<vehicle_list>();
+	else if (type == message::CLAIM_VEHICLE)
+		msg = std::make_shared<claim_vehicle>();
+	else if (type == message::CLAIM_GRANTED)
+		msg = std::make_shared<claim_granted>();
+	else if (type == message::CLAIM_DENIED)
+		msg = std::make_shared<claim_denied>();
+	else if (type == message::LEAVE_VEHICLE)
+		msg = std::make_shared<leave_vehicle>();
+	else if (type == message::CREW_UPDATE)
+		msg = std::make_shared<crew_update>();
 
 	if (!msg) {
 		// unknown message type; hand back a marker the peer handlers treat as a protocol error

--- a/network/message.cpp
+++ b/network/message.cpp
@@ -97,6 +97,7 @@ void network::client_ready::deserialize(std::istream &stream)
 void network::snapshot::serialize(std::ostream &stream) const
 {
 	sn_utils::ls_uint64(stream, tick);
+	sn_utils::s_uint8(stream, mode);
 	sn_utils::ls_uint32(stream, (uint32_t)blob.size());
 	stream.write(blob.data(), blob.size());
 }
@@ -104,6 +105,7 @@ void network::snapshot::serialize(std::ostream &stream) const
 void network::snapshot::deserialize(std::istream &stream)
 {
 	tick = sn_utils::ld_uint64(stream);
+	mode = sn_utils::d_uint8(stream);
 
 	uint32_t const size = sn_utils::ld_uint32(stream);
 	blob.assign(size, '\0');

--- a/network/message.cpp
+++ b/network/message.cpp
@@ -8,6 +8,7 @@ void network::client_hello::serialize(std::ostream &stream) const
 	sn_utils::ls_uint32(stream, start_packet);
 	sn_utils::s_str(stream, app_version);
 	sn_utils::ls_uint64(stream, session_token);
+	sn_utils::s_str(stream, nickname);
 }
 
 void network::client_hello::deserialize(std::istream &stream)
@@ -16,6 +17,43 @@ void network::client_hello::deserialize(std::istream &stream)
 	start_packet = sn_utils::ld_uint32(stream);
 	app_version = sn_utils::d_str(stream);
 	session_token = sn_utils::ld_uint64(stream);
+	nickname = sn_utils::d_str(stream);
+}
+
+void network::peer_roster::serialize(std::ostream &stream) const
+{
+	sn_utils::ls_uint32(stream, (uint32_t)peers.size());
+	for (auto const &entry : peers)
+	{
+		sn_utils::ls_uint32(stream, entry.id);
+		sn_utils::s_str(stream, entry.name);
+	}
+}
+
+void network::peer_roster::deserialize(std::istream &stream)
+{
+	auto const count = sn_utils::ld_uint32(stream);
+	peers.clear();
+	peers.reserve(count);
+	for (uint32_t i = 0; i < count; ++i)
+	{
+		peer_entry entry;
+		entry.id = sn_utils::ld_uint32(stream);
+		entry.name = sn_utils::d_str(stream);
+		peers.emplace_back(std::move(entry));
+	}
+}
+
+void network::chat_message::serialize(std::ostream &stream) const
+{
+	sn_utils::ls_uint32(stream, peer);
+	sn_utils::s_str(stream, text);
+}
+
+void network::chat_message::deserialize(std::istream &stream)
+{
+	peer = sn_utils::ld_uint32(stream);
+	text = sn_utils::d_str(stream);
 }
 
 void network::server_reject::serialize(std::ostream &stream) const
@@ -307,6 +345,10 @@ std::shared_ptr<network::message> network::deserialize_message(std::istream &str
 		msg = std::make_shared<snapshot>();
 	else if (type == message::REQUEST_RESYNC)
 		msg = std::make_shared<request_resync>();
+	else if (type == message::PEER_ROSTER)
+		msg = std::make_shared<peer_roster>();
+	else if (type == message::CHAT)
+		msg = std::make_shared<chat_message>();
 
 	if (!msg) {
 		// unknown message type; hand back a marker the peer handlers treat as a protocol error

--- a/network/message.cpp
+++ b/network/message.cpp
@@ -160,6 +160,7 @@ void ::network::request_command::serialize(std::ostream &stream) const
 			sn_utils::s_vec3(stream, data.location);
 
 			sn_utils::s_str(stream, data.payload);
+			sn_utils::ls_uint32(stream, data.source);
 		}
 	}
 }
@@ -186,6 +187,7 @@ void network::request_command::deserialize(std::istream &stream)
 			data.location = sn_utils::d_vec3(stream);
 
 			data.payload = sn_utils::d_str(stream);
+			data.source = sn_utils::ld_uint32(stream);
 
 			sequence.emplace_back(data);
 		}

--- a/network/message.cpp
+++ b/network/message.cpp
@@ -37,6 +37,8 @@ void network::server_hello::serialize(std::ostream &stream) const
 	sn_utils::s_str(stream, app_version);
 	sn_utils::ls_uint32(stream, peer_id);
 	sn_utils::ls_uint64(stream, session_token);
+	sn_utils::ls_float64(stream, sync_running);
+	sn_utils::ls_float64(stream, sync_stop);
 }
 
 void network::server_hello::deserialize(std::istream &stream)
@@ -48,6 +50,8 @@ void network::server_hello::deserialize(std::istream &stream)
 	app_version = sn_utils::d_str(stream);
 	peer_id = sn_utils::ld_uint32(stream);
 	session_token = sn_utils::ld_uint64(stream);
+	sync_running = sn_utils::ld_float64(stream);
+	sync_stop = sn_utils::ld_float64(stream);
 }
 
 void network::vehicle_list::serialize(std::ostream &stream) const

--- a/network/message.cpp
+++ b/network/message.cpp
@@ -143,6 +143,7 @@ void network::crew_update::deserialize(std::istream &stream)
 
 void ::network::request_command::serialize(std::ostream &stream) const
 {
+	sn_utils::ls_uint64(stream, tick);
 	sn_utils::ls_uint32(stream, commands.size());
 	for (auto const &kv : commands)
 	{
@@ -167,6 +168,8 @@ void ::network::request_command::serialize(std::ostream &stream) const
 
 void network::request_command::deserialize(std::istream &stream)
 {
+	tick = sn_utils::ld_uint64(stream);
+
 	uint32_t commands_size = sn_utils::ld_uint32(stream);
 	for (uint32_t i = 0; i < commands_size; i++)
 	{
@@ -200,7 +203,8 @@ void network::frame_info::serialize(std::ostream &stream) const
 {
 	sn_utils::ls_float64(stream, render_dt);
 	sn_utils::ls_float64(stream, dt);
-	sn_utils::ls_float64(stream, sync);
+	sn_utils::ls_uint64(stream, state_hash);
+	sn_utils::ls_uint32(stream, state_hash_version);
 
 	request_command::serialize(stream);
 }
@@ -209,7 +213,8 @@ void network::frame_info::deserialize(std::istream &stream)
 {
 	render_dt = sn_utils::ld_float64(stream);
 	dt = sn_utils::ld_float64(stream);
-	sync = sn_utils::ld_float64(stream);
+	state_hash = sn_utils::ld_uint64(stream);
+	state_hash_version = sn_utils::ld_uint32(stream);
 
 	request_command::deserialize(stream);
 }

--- a/network/message.cpp
+++ b/network/message.cpp
@@ -7,6 +7,7 @@ void network::client_hello::serialize(std::ostream &stream) const
 	sn_utils::ls_int32(stream, version);
 	sn_utils::ls_uint32(stream, start_packet);
 	sn_utils::s_str(stream, app_version);
+	sn_utils::ls_uint64(stream, session_token);
 }
 
 void network::client_hello::deserialize(std::istream &stream)
@@ -14,6 +15,7 @@ void network::client_hello::deserialize(std::istream &stream)
 	version = sn_utils::ld_int32(stream);
 	start_packet = sn_utils::ld_uint32(stream);
 	app_version = sn_utils::d_str(stream);
+	session_token = sn_utils::ld_uint64(stream);
 }
 
 void network::server_reject::serialize(std::ostream &stream) const
@@ -34,6 +36,7 @@ void network::server_hello::serialize(std::ostream &stream) const
     sn_utils::s_str(stream, scenario);
 	sn_utils::s_str(stream, app_version);
 	sn_utils::ls_uint32(stream, peer_id);
+	sn_utils::ls_uint64(stream, session_token);
 }
 
 void network::server_hello::deserialize(std::istream &stream)
@@ -44,6 +47,7 @@ void network::server_hello::deserialize(std::istream &stream)
     scenario = sn_utils::d_str(stream);
 	app_version = sn_utils::d_str(stream);
 	peer_id = sn_utils::ld_uint32(stream);
+	session_token = sn_utils::ld_uint64(stream);
 }
 
 void network::vehicle_list::serialize(std::ostream &stream) const
@@ -104,6 +108,18 @@ void network::snapshot::deserialize(std::istream &stream)
 	uint32_t const size = sn_utils::ld_uint32(stream);
 	blob.assign(size, '\0');
 	stream.read(blob.data(), size);
+}
+
+void network::request_resync::serialize(std::ostream &stream) const
+{
+	sn_utils::ls_uint64(stream, tick);
+	sn_utils::ls_uint64(stream, state_hash);
+}
+
+void network::request_resync::deserialize(std::istream &stream)
+{
+	tick = sn_utils::ld_uint64(stream);
+	state_hash = sn_utils::ld_uint64(stream);
 }
 
 void network::claim_vehicle::serialize(std::ostream &stream) const
@@ -277,6 +293,8 @@ std::shared_ptr<network::message> network::deserialize_message(std::istream &str
 		msg = std::make_shared<client_ready>();
 	else if (type == message::SNAPSHOT)
 		msg = std::make_shared<snapshot>();
+	else if (type == message::REQUEST_RESYNC)
+		msg = std::make_shared<request_resync>();
 
 	if (!msg) {
 		// unknown message type; hand back a marker the peer handlers treat as a protocol error

--- a/network/message.cpp
+++ b/network/message.cpp
@@ -220,6 +220,9 @@ void network::crew_update::serialize(std::ostream &stream) const
 	sn_utils::ls_uint32(stream, (uint32_t)crew.size());
 	for (PeerId const peer : crew)
 		sn_utils::ls_uint32(stream, peer);
+	sn_utils::ls_uint32(stream, (uint32_t)since.size());
+	for (uint64_t const stamp : since)
+		sn_utils::ls_uint64(stream, stamp);
 }
 
 void network::crew_update::deserialize(std::istream &stream)
@@ -231,6 +234,12 @@ void network::crew_update::deserialize(std::istream &stream)
 	crew.reserve(count);
 	for (uint32_t i = 0; i < count; i++)
 		crew.emplace_back(sn_utils::ld_uint32(stream));
+
+	since.clear();
+	uint32_t const stamps = sn_utils::ld_uint32(stream);
+	since.reserve(stamps);
+	for (uint32_t i = 0; i < stamps; i++)
+		since.emplace_back(sn_utils::ld_uint64(stream));
 }
 
 void ::network::request_command::serialize(std::ostream &stream) const

--- a/network/message.cpp
+++ b/network/message.cpp
@@ -6,12 +6,24 @@ void network::client_hello::serialize(std::ostream &stream) const
 {
 	sn_utils::ls_int32(stream, version);
 	sn_utils::ls_uint32(stream, start_packet);
+	sn_utils::s_str(stream, app_version);
 }
 
 void network::client_hello::deserialize(std::istream &stream)
 {
 	version = sn_utils::ld_int32(stream);
 	start_packet = sn_utils::ld_uint32(stream);
+	app_version = sn_utils::d_str(stream);
+}
+
+void network::server_reject::serialize(std::ostream &stream) const
+{
+	sn_utils::s_str(stream, reason);
+}
+
+void network::server_reject::deserialize(std::istream &stream)
+{
+	reason = sn_utils::d_str(stream);
 }
 
 void network::server_hello::serialize(std::ostream &stream) const
@@ -20,6 +32,7 @@ void network::server_hello::serialize(std::ostream &stream) const
 	sn_utils::ls_int64(stream, timestamp);
     sn_utils::ls_int64(stream, config);
     sn_utils::s_str(stream, scenario);
+	sn_utils::s_str(stream, app_version);
 }
 
 void network::server_hello::deserialize(std::istream &stream)
@@ -28,6 +41,7 @@ void network::server_hello::deserialize(std::istream &stream)
 	timestamp = sn_utils::ld_int64(stream);
     config = sn_utils::ld_int64(stream);
     scenario = sn_utils::d_str(stream);
+	app_version = sn_utils::d_str(stream);
 }
 
 void ::network::request_command::serialize(std::ostream &stream) const
@@ -115,6 +129,13 @@ std::shared_ptr<network::message> network::deserialize_message(std::istream &str
 		msg = std::make_shared<frame_info>();
 	else if (type == message::REQUEST_COMMAND)
 		msg = std::make_shared<request_command>();
+	else if (type == message::SERVER_REJECT)
+		msg = std::make_shared<server_reject>();
+
+	if (!msg) {
+		// unknown message type; hand back a marker the peer handlers treat as a protocol error
+		return std::make_shared<message>(message::TYPE_MAX);
+	}
 
 	msg->deserialize(stream);
 

--- a/network/message.cpp
+++ b/network/message.cpp
@@ -33,6 +33,7 @@ void network::server_hello::serialize(std::ostream &stream) const
     sn_utils::ls_int64(stream, config);
     sn_utils::s_str(stream, scenario);
 	sn_utils::s_str(stream, app_version);
+	sn_utils::ls_uint32(stream, peer_id);
 }
 
 void network::server_hello::deserialize(std::istream &stream)
@@ -42,6 +43,41 @@ void network::server_hello::deserialize(std::istream &stream)
     config = sn_utils::ld_int64(stream);
     scenario = sn_utils::d_str(stream);
 	app_version = sn_utils::d_str(stream);
+	peer_id = sn_utils::ld_uint32(stream);
+}
+
+void network::vehicle_list::serialize(std::ostream &stream) const
+{
+	sn_utils::ls_uint32(stream, (uint32_t)vehicles.size());
+	for (auto const &entry : vehicles)
+	{
+		sn_utils::ls_uint32(stream, entry.id);
+		sn_utils::s_str(stream, entry.name);
+		sn_utils::s_uint8(stream, entry.crew_count);
+		sn_utils::s_uint8(stream, entry.crew_capacity);
+		sn_utils::s_uint8(stream, (uint8_t)((entry.ai_active ? 1 : 0) | (entry.claimable ? 2 : 0)));
+	}
+}
+
+void network::vehicle_list::deserialize(std::istream &stream)
+{
+	vehicles.clear();
+
+	uint32_t const count = sn_utils::ld_uint32(stream);
+	vehicles.reserve(count);
+
+	for (uint32_t i = 0; i < count; i++)
+	{
+		vehicle_entry entry;
+		entry.id = sn_utils::ld_uint32(stream);
+		entry.name = sn_utils::d_str(stream);
+		entry.crew_count = sn_utils::d_uint8(stream);
+		entry.crew_capacity = sn_utils::d_uint8(stream);
+		uint8_t const flags = sn_utils::d_uint8(stream);
+		entry.ai_active = (flags & 1) != 0;
+		entry.claimable = (flags & 2) != 0;
+		vehicles.emplace_back(entry);
+	}
 }
 
 void ::network::request_command::serialize(std::ostream &stream) const
@@ -131,6 +167,8 @@ std::shared_ptr<network::message> network::deserialize_message(std::istream &str
 		msg = std::make_shared<request_command>();
 	else if (type == message::SERVER_REJECT)
 		msg = std::make_shared<server_reject>();
+	else if (type == message::VEHICLE_LIST)
+		msg = std::make_shared<vehicle_list>();
 
 	if (!msg) {
 		// unknown message type; hand back a marker the peer handlers treat as a protocol error

--- a/network/message.cpp
+++ b/network/message.cpp
@@ -57,9 +57,11 @@ void network::vehicle_list::serialize(std::ostream &stream) const
 	{
 		sn_utils::ls_uint32(stream, entry.id);
 		sn_utils::s_str(stream, entry.name);
+		sn_utils::ls_uint32(stream, entry.consist_id);
+		sn_utils::s_uint8(stream, entry.consist_size);
 		sn_utils::s_uint8(stream, entry.crew_count);
 		sn_utils::s_uint8(stream, entry.crew_capacity);
-		sn_utils::s_uint8(stream, (uint8_t)((entry.ai_active ? 1 : 0) | (entry.claimable ? 2 : 0)));
+		sn_utils::s_uint8(stream, (uint8_t)((entry.ai_active ? 1 : 0) | (entry.claimable ? 2 : 0) | (entry.drivable ? 4 : 0) | (entry.consist_lead ? 8 : 0)));
 	}
 }
 
@@ -75,11 +77,15 @@ void network::vehicle_list::deserialize(std::istream &stream)
 		vehicle_entry entry;
 		entry.id = sn_utils::ld_uint32(stream);
 		entry.name = sn_utils::d_str(stream);
+		entry.consist_id = sn_utils::ld_uint32(stream);
+		entry.consist_size = sn_utils::d_uint8(stream);
 		entry.crew_count = sn_utils::d_uint8(stream);
 		entry.crew_capacity = sn_utils::d_uint8(stream);
 		uint8_t const flags = sn_utils::d_uint8(stream);
 		entry.ai_active = (flags & 1) != 0;
 		entry.claimable = (flags & 2) != 0;
+		entry.drivable = (flags & 4) != 0;
+		entry.consist_lead = (flags & 8) != 0;
 		vehicles.emplace_back(entry);
 	}
 }

--- a/network/message.h
+++ b/network/message.h
@@ -13,6 +13,7 @@ struct message
 		SERVER_HELLO,
 		FRAME_INFO,
 		REQUEST_COMMAND,
+		SERVER_REJECT,
 		TYPE_MAX
 	};
 
@@ -32,6 +33,20 @@ struct client_hello : public message
 
 	int32_t version;
 	uint32_t start_packet;
+	// build identification of the connecting simulator, informational only
+	std::string app_version;
+};
+
+// sent by the server instead of SERVER_HELLO when the client cannot join;
+// carries a human readable reason so the player learns what went wrong
+struct server_reject : public message
+{
+	server_reject() : message(SERVER_REJECT) {}
+
+	std::string reason;
+
+	virtual void serialize(std::ostream &stream) const override;
+	virtual void deserialize(std::istream &stream) override;
 };
 
 struct server_hello : public message
@@ -42,6 +57,8 @@ struct server_hello : public message
 	int64_t timestamp;
     int64_t config;
     std::string scenario;
+	// build identification of the server, informational only
+	std::string app_version;
 
 	virtual void serialize(std::ostream &stream) const override;
 	virtual void deserialize(std::istream &stream) override;

--- a/network/message.h
+++ b/network/message.h
@@ -23,6 +23,7 @@ struct message
 		CREW_UPDATE,
 		CLIENT_READY,
 		SNAPSHOT,
+		REQUEST_RESYNC,
 		TYPE_MAX
 	};
 
@@ -44,6 +45,10 @@ struct client_hello : public message
 	uint32_t start_packet;
 	// build identification of the connecting simulator, informational only
 	std::string app_version;
+	// identity handed out by this server on an earlier connection, echoed back so that a
+	// player who dropped out gets their seat and their peer id back. it is a reconnect
+	// token, not a credential - it says "this is the same session", nothing more
+	uint64_t session_token{ 0 };
 };
 
 // sent by the server instead of SERVER_HELLO when the client cannot join;
@@ -70,6 +75,8 @@ struct server_hello : public message
 	std::string app_version;
 	// identity assigned to the joining peer for the rest of the session
 	uint32_t peer_id{ PEER_NONE };
+	// hand this back on a later connection to be recognised as the same participant
+	uint64_t session_token{ 0 };
 
 	virtual void serialize(std::ostream &stream) const override;
 	virtual void deserialize(std::istream &stream) override;
@@ -106,6 +113,19 @@ struct snapshot : public message
 
 	uint64_t tick{ 0 };
 	std::string blob;
+
+	virtual void serialize(std::ostream &stream) const override;
+	virtual void deserialize(std::istream &stream) override;
+};
+
+// a peer telling the server its world has drifted too far to carry on, and asking to be
+// put back in line
+struct request_resync : public message
+{
+	request_resync() : message(REQUEST_RESYNC) {}
+
+	uint64_t tick{ 0 };
+	uint64_t state_hash{ 0 };
 
 	virtual void serialize(std::ostream &stream) const override;
 	virtual void deserialize(std::istream &stream) override;

--- a/network/message.h
+++ b/network/message.h
@@ -222,6 +222,9 @@ struct crew_update : public message
 
 	uint32_t entity_id{ ENTITY_NONE };
 	std::vector<PeerId> crew;
+	// when each of them boarded, on a session-wide counter. it decides which peer runs the
+	// train's physics, so it has to travel with the crew rather than be guessed at
+	std::vector<uint64_t> since;
 
 	virtual void serialize(std::ostream &stream) const override;
 	virtual void deserialize(std::istream &stream) override;

--- a/network/message.h
+++ b/network/message.h
@@ -16,6 +16,11 @@ struct message
 		REQUEST_COMMAND,
 		SERVER_REJECT,
 		VEHICLE_LIST,
+		CLAIM_VEHICLE,
+		CLAIM_GRANTED,
+		CLAIM_DENIED,
+		LEAVE_VEHICLE,
+		CREW_UPDATE,
 		TYPE_MAX
 	};
 
@@ -75,6 +80,63 @@ struct vehicle_list : public message
 	vehicle_list() : message(VEHICLE_LIST) {}
 
 	std::vector<vehicle_entry> vehicles;
+
+	virtual void serialize(std::ostream &stream) const override;
+	virtual void deserialize(std::istream &stream) override;
+};
+
+// a peer asking the server to be put on the crew of a vehicle
+struct claim_vehicle : public message
+{
+	claim_vehicle() : message(CLAIM_VEHICLE) {}
+
+	uint32_t entity_id{ ENTITY_NONE };
+
+	virtual void serialize(std::ostream &stream) const override;
+	virtual void deserialize(std::istream &stream) override;
+};
+
+// answer to a claim the server accepted
+struct claim_granted : public message
+{
+	claim_granted() : message(CLAIM_GRANTED) {}
+
+	uint32_t entity_id{ ENTITY_NONE };
+
+	virtual void serialize(std::ostream &stream) const override;
+	virtual void deserialize(std::istream &stream) override;
+};
+
+// answer to a claim the server refused, with a reason the lobby can show
+struct claim_denied : public message
+{
+	claim_denied() : message(CLAIM_DENIED) {}
+
+	uint32_t entity_id{ ENTITY_NONE };
+	std::string reason;
+
+	virtual void serialize(std::ostream &stream) const override;
+	virtual void deserialize(std::istream &stream) override;
+};
+
+// a peer stepping off the crew of a vehicle
+struct leave_vehicle : public message
+{
+	leave_vehicle() : message(LEAVE_VEHICLE) {}
+
+	uint32_t entity_id{ ENTITY_NONE };
+
+	virtual void serialize(std::ostream &stream) const override;
+	virtual void deserialize(std::istream &stream) override;
+};
+
+// authoritative crew of one vehicle, broadcast whenever it changes
+struct crew_update : public message
+{
+	crew_update() : message(CREW_UPDATE) {}
+
+	uint32_t entity_id{ ENTITY_NONE };
+	std::vector<PeerId> crew;
 
 	virtual void serialize(std::ostream &stream) const override;
 	virtual void deserialize(std::istream &stream) override;

--- a/network/message.h
+++ b/network/message.h
@@ -113,6 +113,9 @@ struct snapshot : public message
 	snapshot() : message(SNAPSHOT) {}
 
 	uint64_t tick{ 0 };
+	// 0 - the peer is joining and takes the world as given
+	// 1 - routine correction on top of a simulation that is already running
+	uint8_t mode{ 0 };
 	std::string blob;
 
 	virtual void serialize(std::ostream &stream) const override;

--- a/network/message.h
+++ b/network/message.h
@@ -24,6 +24,8 @@ struct message
 		CLIENT_READY,
 		SNAPSHOT,
 		REQUEST_RESYNC,
+		PEER_ROSTER,
+		CHAT,
 		TYPE_MAX
 	};
 
@@ -49,6 +51,9 @@ struct client_hello : public message
 	// player who dropped out gets their seat and their peer id back. it is a reconnect
 	// token, not a credential - it says "this is the same session", nothing more
 	uint64_t session_token{ 0 };
+	// what the player would like to be called. a request, not a fact: the server tidies
+	// it up, makes it unique and hands back what it settled on
+	std::string nickname;
 };
 
 // sent by the server instead of SERVER_HELLO when the client cannot join;
@@ -135,6 +140,31 @@ struct request_resync : public message
 
 	uint64_t tick{ 0 };
 	uint64_t state_hash{ 0 };
+
+	virtual void serialize(std::ostream &stream) const override;
+	virtual void deserialize(std::istream &stream) override;
+};
+
+// who is taking part, and what each of them is called. rebroadcast whenever somebody
+// joins or leaves, so that no peer has to guess at a name
+struct peer_roster : public message
+{
+	peer_roster() : message(PEER_ROSTER) {}
+
+	std::vector<peer_entry> peers;
+
+	virtual void serialize(std::ostream &stream) const override;
+	virtual void deserialize(std::istream &stream) override;
+};
+
+// something a participant said. going up it carries only the text - who said it is
+// decided by the connection it arrived on, never by what the sender put in the field
+struct chat_message : public message
+{
+	chat_message() : message(CHAT) {}
+
+	uint32_t peer{ PEER_NONE };
+	std::string text;
 
 	virtual void serialize(std::ostream &stream) const override;
 	virtual void deserialize(std::istream &stream) override;

--- a/network/message.h
+++ b/network/message.h
@@ -69,6 +69,7 @@ struct server_hello : public message
 
 	uint32_t seed;
 	int64_t timestamp;
+    // settings the server imposes on the whole session, see network/session.h
     int64_t config;
     std::string scenario;
 	// build identification of the server, informational only

--- a/network/message.h
+++ b/network/message.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "network/message.h"
+#include "network/entities.h"
 #include "input/command.h"
 #include <queue>
 
@@ -14,6 +15,7 @@ struct message
 		FRAME_INFO,
 		REQUEST_COMMAND,
 		SERVER_REJECT,
+		VEHICLE_LIST,
 		TYPE_MAX
 	};
 
@@ -59,6 +61,20 @@ struct server_hello : public message
     std::string scenario;
 	// build identification of the server, informational only
 	std::string app_version;
+	// identity assigned to the joining peer for the rest of the session
+	uint32_t peer_id{ PEER_NONE };
+
+	virtual void serialize(std::ostream &stream) const override;
+	virtual void deserialize(std::istream &stream) override;
+};
+
+// authoritative roster of the vehicles a player may take over, broadcast by the server
+// whenever it changes (and periodically, so that a peer which just went active gets one)
+struct vehicle_list : public message
+{
+	vehicle_list() : message(VEHICLE_LIST) {}
+
+	std::vector<vehicle_entry> vehicles;
 
 	virtual void serialize(std::ostream &stream) const override;
 	virtual void deserialize(std::istream &stream) override;

--- a/network/message.h
+++ b/network/message.h
@@ -21,6 +21,8 @@ struct message
 		CLAIM_DENIED,
 		LEAVE_VEHICLE,
 		CREW_UPDATE,
+		CLIENT_READY,
+		SNAPSHOT,
 		TYPE_MAX
 	};
 
@@ -80,6 +82,30 @@ struct vehicle_list : public message
 	vehicle_list() : message(VEHICLE_LIST) {}
 
 	std::vector<vehicle_entry> vehicles;
+
+	virtual void serialize(std::ostream &stream) const override;
+	virtual void deserialize(std::istream &stream) override;
+};
+
+// sent once the joining peer has the scenario loaded and can take a snapshot
+struct client_ready : public message
+{
+	client_ready() : message(CLIENT_READY) {}
+
+	std::string scenario;
+
+	virtual void serialize(std::ostream &stream) const override;
+	virtual void deserialize(std::istream &stream) override;
+};
+
+// the state of the world as of one particular tick, handed to a peer that is joining.
+// this is what replaces replaying the whole session from its first frame
+struct snapshot : public message
+{
+	snapshot() : message(SNAPSHOT) {}
+
+	uint64_t tick{ 0 };
+	std::string blob;
 
 	virtual void serialize(std::ostream &stream) const override;
 	virtual void deserialize(std::istream &stream) override;

--- a/network/message.h
+++ b/network/message.h
@@ -78,6 +78,11 @@ struct server_hello : public message
 	uint32_t peer_id{ PEER_NONE };
 	// hand this back on a later connection to be recognised as the same participant
 	uint64_t session_token{ 0 };
+	// how far a train may drift from the session's idea of where it is before it is put
+	// back: while it rolls, and once it has stopped. the client takes these over from the
+	// server, so everybody in a session works to the same margins
+	double sync_running{ 1.5 };
+	double sync_stop{ 0.2 };
 
 	virtual void serialize(std::ostream &stream) const override;
 	virtual void deserialize(std::istream &stream) override;

--- a/network/message.h
+++ b/network/message.h
@@ -148,6 +148,9 @@ struct request_command : public message
 	request_command() : message(REQUEST_COMMAND) {}
 
 	command_queue::commands_map commands;
+	// logical step the sender was on when it produced these. the protocol is anchored to
+	// this counter rather than to whatever frame the renderer happened to be drawing
+	uint64_t tick{ 0 };
 
 	virtual void serialize(std::ostream &stream) const override;
 	virtual void deserialize(std::istream &stream) override;
@@ -159,7 +162,9 @@ struct frame_info : public request_command
 
 	double render_dt;
 	double dt;
-	double sync;
+	// digest of the authoritative world after this step; a client compares its own
+	uint64_t state_hash{ 0 };
+	uint32_t state_hash_version{ 0 };
 
 	virtual void serialize(std::ostream &stream) const override;
 	virtual void deserialize(std::istream &stream) override;

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -17,7 +17,7 @@
 // 3 - handshake carries build identification and an explicit rejection message
 // 4 - peer identity, vehicle roster and crew handshake, command source,
 //     logical simulation tick and a versioned state digest instead of the position sum
-std::uint32_t const EU07_NETWORK_VERSION = 5;
+std::uint32_t const EU07_NETWORK_VERSION = 6;
 
 namespace network {
 
@@ -668,7 +668,7 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 
 	if (msg.type == message::CREW_UPDATE) {
 		const auto& cmd = dynamic_cast<const crew_update&>(msg);
-		Crews.mirror(cmd.entity_id, cmd.crew);
+		Crews.mirror(cmd.entity_id, cmd.crew, cmd.since);
 	}
 
 	if (msg.type == message::CLAIM_GRANTED) {
@@ -676,8 +676,7 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 
 		WriteLog("net: claim of vehicle " + std::to_string(cmd.entity_id) + " granted", logtype::net);
 		Global.network_lobby_message.clear();
-		// the cab itself is built by the replicated entervehicle the server posts;
-		// we only have to walk into it once it shows up
+		// the driver mode builds this peer's own cab for the vehicle and moves in
 		Global.network_pending_vehicle = Entities.name_of(cmd.entity_id);
 	}
 

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "network/network.h"
 #include "network/snapshot.h"
+#include "network/chat.h"
 #include "network/message.h"
 #include "utilities/Logs.h"
 #include "scene/sn_utils.h"
@@ -81,6 +82,7 @@ void network::connection::connected()
 		msg.start_packet = packet_counter;
 		msg.app_version = Global.asVersion;
 		msg.session_token = Global.network_session_token;
+		msg.nickname = local_nickname();
 		send_message(msg);
 	}
 }
@@ -117,19 +119,34 @@ void report_rejected_command(network::PeerId Peer, user_command Command, network
 
 void network::server::prune_clients()
 {
+	bool dropped{false};
+
 	for (auto it = clients.begin(); it != clients.end(); ) {
 		if ((*it)->state == connection::DEAD) {
 			if ((*it)->peer_id != PEER_NONE) {
-				WriteLog("net: peer " + std::to_string((*it)->peer_id) + " disconnected", logtype::net);
+				WriteLog("net: " + Peers.name_of((*it)->peer_id) + " (peer " + std::to_string((*it)->peer_id) + ") disconnected", logtype::net);
 				// the seat is held for a while in case the peer comes straight back. a
 				// vehicle keeps running for whoever is left on board either way; it only
 				// falls back to the AI once the crew really is empty
 				Crews.suspend_peer((*it)->peer_id);
+				Peers.forget((*it)->peer_id);
+				dropped = true;
 			}
 			it = clients.erase(it);
 			continue;
 		}
 		it++;
+	}
+
+	if (dropped) {
+		// whoever is left learns who is left. sent from here rather than through
+		// push_message, which is what called us
+		peer_roster msg;
+		msg.peers = Peers.roster();
+		for (auto const &client : clients) {
+			if (client->state == connection::ACTIVE)
+				client->send_message(msg);
+		}
 	}
 }
 
@@ -151,6 +168,13 @@ void network::server::push_message(const message &msg)
 		if (client->state == connection::ACTIVE)
 			client->send_message(msg);
 	}
+}
+
+void network::server::publish_roster()
+{
+	peer_roster msg;
+	msg.peers = Peers.roster();
+	push_message(msg);
 }
 
 command_queue::commands_map network::server::pop_commands()
@@ -203,6 +227,8 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 		reply.session_token = cmd.session_token;
 		reply.peer_id = resolve_peer_identity(reply.session_token);
 		conn->peer_id = reply.peer_id;
+		// what the player asked to be called, tidied up and made unique within the session
+		auto const name = Peers.assign(conn->peer_id, cmd.nickname);
 		// the peer now goes and loads the scenario. it gets the state of the world as a
 		// snapshot when it reports back, instead of replaying the session frame by frame
 		conn->state = connection::AWAITING_READY;
@@ -210,7 +236,7 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 
 		conn->send_message(reply);
 
-		WriteLog("net: peer " + std::to_string(conn->peer_id) + " connected, build \"" + cmd.app_version
+		WriteLog("net: peer " + std::to_string(conn->peer_id) + " connected as \"" + name + "\", build \"" + cmd.app_version
 		         + "\", scenario \"" + Global.SceneryFile + "\"", logtype::net);
 	}
 	else if (msg.type == message::CLIENT_READY) {
@@ -227,6 +253,11 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 			return;
 		}
 
+		// who is taking part, so that the crew section of the snapshot has names to show
+		peer_roster people;
+		people.peers = Peers.roster();
+		conn->send_message(people);
+
 		// the roster first, so that the crew section of the snapshot resolves to names
 		vehicle_list roster;
 		roster.vehicles = Entities.entries();
@@ -241,11 +272,30 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 		// from here on the peer receives the live stream; there is no backlog to catch up on
 		conn->state = connection::ACTIVE;
 
+		// and everybody already in the session learns who just walked in
+		publish_roster();
+
 		WriteLog("net: snapshot sent to peer " + std::to_string(conn->peer_id) + " at tick "
 		         + std::to_string(reply.tick), logtype::net);
 
 		// and it still has to learn who is where
 		Crews.mark_all_pending();
+	}
+	else if (msg.type == message::CHAT) {
+		const auto& cmd = dynamic_cast<const chat_message&>(msg);
+
+		// the sender is the connection this arrived on, never the field in the packet:
+		// otherwise anybody could put words in anybody's mouth
+		auto const text = tidy_chat(cmd.text);
+		if (text.empty())
+			return;
+
+		chat_message relay;
+		relay.peer = conn->peer_id;
+		relay.text = text;
+
+		note_chat(relay.peer, relay.text);
+		push_message(relay);
 	}
 	else if (msg.type == message::SNAPSHOT) {
 		const auto& cmd = dynamic_cast<const snapshot&>(msg);
@@ -471,6 +521,19 @@ void network::client::send_leave(NetworkEntityId entity_id)
 
 	leave_vehicle msg;
 	msg.entity_id = entity_id;
+	conn->send_message(msg);
+}
+
+void network::client::send_chat(const std::string &text)
+{
+	if (!conn || conn->state != connection::ACTIVE)
+		return;
+
+	chat_message msg;
+	// the peer field is filled in by the server from the connection; whatever we put here
+	// is ignored, which is the point
+	msg.peer = Global.network_peer_id;
+	msg.text = text;
 	conn->send_message(msg);
 }
 

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -6,6 +6,9 @@
 #include "utilities/Timer.h"
 #include "application/application.h"
 #include "utilities/Globals.h"
+#include "simulation/simulation.h"
+#include <set>
+#include <tuple>
 
 // 2 - legacy lockstep protocol
 // 3 - handshake carries build identification and an explicit rejection message
@@ -96,6 +99,23 @@ network::server::server(std::shared_ptr<std::istream> buf) : backbuffer(buf)
 {
 
 }
+
+namespace {
+
+// keeps the log readable: a peer holding a forbidden key would otherwise produce a line
+// every single frame, so each peer/command/verdict combination is reported once
+void report_rejected_command(network::PeerId Peer, user_command Command, network::command_verdict Verdict)
+{
+	static std::set<std::tuple<network::PeerId, user_command, network::command_verdict>> reported;
+
+	if (!reported.emplace(Peer, Command, Verdict).second)
+		return;
+
+	auto const &description = simulation::Commands_descriptions[static_cast<std::size_t>(Command)];
+	ErrorLog("net: command \"" + description.name + "\" from peer " + std::to_string(Peer) + " rejected: " + network::describe(Verdict), logtype::net);
+}
+
+} // namespace
 
 void network::server::prune_clients()
 {
@@ -217,8 +237,22 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 	else if (msg.type == message::REQUEST_COMMAND) {
 		const auto& cmd = dynamic_cast<const request_command&>(msg);
 
-		for (auto const &kv : cmd.commands)
-			client_commands_queue.emplace(kv);
+		for (auto const &kv : cmd.commands) {
+			for (command_data const &data : kv.second) {
+				auto const verdict = validate_command(conn->peer_id, data.command, kv.first);
+				if (verdict != command_verdict::accepted) {
+					report_rejected_command(conn->peer_id, data.command, verdict);
+					continue;
+				}
+
+				command_data accepted = data;
+				// the source is decided here, never taken from what the peer sent
+				accepted.source = conn->peer_id;
+
+				auto lookup = client_commands_queue.emplace(kv.first, command_queue::commanddata_sequence());
+				lookup.first->second.emplace_back(accepted);
+			}
+		}
 	}
 }
 

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -218,6 +218,13 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 		// and it still has to learn who is where
 		Crews.mark_all_pending();
 	}
+	else if (msg.type == message::SNAPSHOT) {
+		const auto& cmd = dynamic_cast<const snapshot&>(msg);
+
+		// a peer telling us what its own trains are doing. the filter is what keeps it to
+		// its own: it cannot shove anybody else's stock around
+		apply_snapshot(cmd.blob, snapshot_mode::correction, conn->peer_id);
+	}
 	else if (msg.type == message::REQUEST_RESYNC) {
 		const auto& cmd = dynamic_cast<const request_resync&>(msg);
 
@@ -321,57 +328,39 @@ void network::client::update()
 }
 
 // client
-network::frame_delta network::client::get_next_delta(int counter)
+network::frame_delta network::client::take_pending(command_queue::commands_map &commands)
 {
-	auto now = std::chrono::high_resolution_clock::now();
-	if (counter == 1) {
-		frame_time = now - last_frame;
-		last_frame = now;
-	}
+	frame_delta delta;
 
-	if (delta_queue.empty()) {
-		// buffer underflow
-		return frame_delta();
-	}
+	while (!delta_queue.empty()) {
+		auto const &entry = delta_queue.front();
 
+		for (auto const &kv : entry.commands) {
+			auto lookup = commands.end();
 
-	float size = delta_queue.size() - consume_counter;
-	const auto& entry = delta_queue.front();
-	float mult = entry.render_dt / std::chrono::duration_cast<std::chrono::duration<float>>(frame_time).count();
+			for (auto const &data : kv.second) {
+				// our own commands for a train we run ourselves were carried out the
+				// moment we issued them; applying the echo would do it a second time
+				if ((data.source == Global.network_peer_id) && is_predictable(kv.first))
+					continue;
 
-	if (counter == 1 && size < MAX_BUFFER_SIZE * 2.0f) {
-		last_target = last_target * TARGET_MIX +
-		        (std::min(TARGET_MIN + jitteriness * JITTERINESS_MULTIPIER, MAX_BUFFER_SIZE)) * (1.0f - TARGET_MIX);
-		float diff = size - last_target;
-		jitteriness = std::max(jitteriness * JITTERINESS_MIX, std::abs(diff));
+				if (lookup == commands.end())
+					lookup = commands.emplace(kv.first, command_queue::commanddata_sequence()).first;
 
-		float speed = 1.0f + diff * CONSUME_MULTIPIER;
-
-		consume_counter += speed;
-	}
-
-	float last_rcv_diff = std::chrono::duration_cast<std::chrono::duration<float>>(now - last_rcv).count();
-
-	if (size > MAX_BUFFER_SIZE || consume_counter > mult || last_rcv_diff > 1.0f) {
-		if (consume_counter > mult) {
-			consume_counter = std::clamp(consume_counter - mult, -MAX_BUFFER_SIZE, MAX_BUFFER_SIZE);
+				lookup->second.emplace_back(data);
+			}
 		}
 
-		frame_delta delta;
 		delta.dt = entry.dt;
 		delta.tick = entry.tick;
 		delta.state_hash = entry.state_hash;
 		delta.state_hash_version = entry.state_hash_version;
-		delta.commands = entry.commands;
 		delta.valid = true;
 
 		delta_queue.pop();
-
-		return delta;
-	} else {
-		// nothing to push
-		return frame_delta();
 	}
+
+	return delta;
 }
 
 void network::client::send_commands(command_queue::commands_map commands)
@@ -397,6 +386,30 @@ void network::client::send_ready()
 	conn->send_message(msg);
 
 	WriteLog("net: scenario loaded, asking the server for a snapshot", logtype::net);
+}
+
+void network::client::publish_state()
+{
+	if (!conn || conn->state != connection::ACTIVE)
+		return;
+
+	if (--state_countdown > 0)
+		return;
+
+	state_countdown = STATE_INTERVAL_FRAMES;
+
+	bool const full = ((state_updates++ % STATE_FULL_EVERY) == 0);
+
+	auto const blob = take_snapshot(full, true);
+	if (blob.empty())
+		return;
+
+	snapshot msg;
+	msg.tick = Global.simulation_tick;
+	msg.mode = 1; // a correction, on top of what the receiver is already running
+	msg.blob = blob;
+
+	conn->send_message(msg);
 }
 
 void network::client::send_resync_request(uint64_t tick, uint64_t state_hash)

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -7,6 +7,7 @@
 #include "utilities/Timer.h"
 #include "application/application.h"
 #include "utilities/Globals.h"
+#include "utilities/utilities.h"
 #include "simulation/simulation.h"
 #include <set>
 #include <tuple>
@@ -15,7 +16,7 @@
 // 3 - handshake carries build identification and an explicit rejection message
 // 4 - peer identity, vehicle roster and crew handshake, command source,
 //     logical simulation tick and a versioned state digest instead of the position sum
-std::uint32_t const EU07_NETWORK_VERSION = 4;
+std::uint32_t const EU07_NETWORK_VERSION = 5;
 
 namespace network {
 
@@ -195,6 +196,8 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 		reply.seed = Global.random_seed;
 		reply.timestamp = Global.starting_timestamp;
         reply.config = pack_session_config();
+        reply.sync_running = Global.multiplayer_sync_running;
+        reply.sync_stop = Global.multiplayer_sync_stop;
         reply.scenario = Global.SceneryFile;
 		reply.app_version = Global.asVersion;
 		reply.session_token = cmd.session_token;
@@ -508,6 +511,17 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 			ErrorLog("net: seed mismatch", logtype::net);
 			conn->disconnect();
 			return;
+		}
+
+		// the session decides how tightly it is kept in step, not the machine that joined it
+		if ((cmd.sync_running > 0.0) && (cmd.sync_stop > 0.0)) {
+			if ((std::abs(Global.multiplayer_sync_running - (float)cmd.sync_running) > 0.001f)
+			 || (std::abs(Global.multiplayer_sync_stop - (float)cmd.sync_stop) > 0.001f)) {
+				WriteLog("net: the session syncs to " + to_string(cmd.sync_running, 2) + " m while running and "
+				         + to_string(cmd.sync_stop, 2) + " m at a stand", logtype::net);
+			}
+			Global.multiplayer_sync_running = (float)cmd.sync_running;
+			Global.multiplayer_sync_stop = (float)cmd.sync_stop;
 		}
 
 		if (cmd.peer_id != PEER_NONE) {

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -205,7 +205,8 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 
 		snapshot reply;
 		reply.tick = Global.simulation_tick;
-		reply.blob = take_snapshot();
+		reply.mode = 0; // joining: take the world as it is
+		reply.blob = take_snapshot(true);
 		conn->send_message(reply);
 
 		// from here on the peer receives the live stream; there is no backlog to catch up on
@@ -225,7 +226,8 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 
 		snapshot reply;
 		reply.tick = Global.simulation_tick;
-		reply.blob = take_snapshot();
+		reply.mode = 0;
+		reply.blob = take_snapshot(true);
 		conn->send_message(reply);
 	}
 	else if (msg.type == message::CLAIM_VEHICLE) {
@@ -256,6 +258,29 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 
 		for (auto const &kv : cmd.commands) {
 			for (command_data const &data : kv.second) {
+				if (data.command == user_command::entervehicle) {
+					// the peer walked into a cab; that is a request for a seat, exactly
+					// like the lobby button, and the crew registry is what decides on it
+					NetworkEntityId entity { ENTITY_NONE };
+					auto const result = claim_by_name(conn->peer_id, data.payload, entity);
+
+					if (result == claim_result::granted || result == claim_result::already_member) {
+						claim_granted reply;
+						reply.entity_id = entity;
+						conn->send_message(reply);
+					}
+					else {
+						WriteLog("net: peer " + std::to_string(conn->peer_id) + " cannot take "
+						         + data.payload + ": " + describe(result), logtype::net);
+
+						claim_denied reply;
+						reply.entity_id = entity;
+						reply.reason = describe(result);
+						conn->send_message(reply);
+					}
+					continue;
+				}
+
 				auto const verdict = validate_command(conn->peer_id, data.command, kv.first);
 				if (verdict != command_verdict::accepted) {
 					report_rejected_command(conn->peer_id, data.command, verdict);
@@ -393,6 +418,8 @@ void network::client::send_claim(NetworkEntityId entity_id)
 	claim_vehicle msg;
 	msg.entity_id = entity_id;
 	conn->send_message(msg);
+
+	WriteLog("net: asking for a seat on vehicle " + std::to_string(entity_id) + " (" + Entities.name_of(entity_id) + ")", logtype::net);
 }
 
 void network::client::send_leave(NetworkEntityId entity_id)
@@ -471,8 +498,16 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 	if (msg.type == message::SNAPSHOT) {
 		const auto& cmd = dynamic_cast<const snapshot&>(msg);
 
-		if (apply_snapshot(cmd.blob)) {
+		auto const mode = (cmd.mode == 0 ? snapshot_mode::join : snapshot_mode::correction);
+		auto const result = apply_snapshot(cmd.blob, mode);
+
+		if (!result.ok) {
+			ErrorLog("net: could not apply the state handed to us", logtype::net);
+			Global.network_status = "The server sent a snapshot this build cannot read";
+		}
+		else if (mode == snapshot_mode::join) {
 			Global.network_snapshot_applied = true;
+			Global.network_position_error = (float)result.worst_position_error;
 
 			// the roster may say we are on a crew already - after a reconnect, or because
 			// the claim was granted while we were still loading. walk into that cab
@@ -484,13 +519,30 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 			}
 		}
 		else {
-			ErrorLog("net: could not apply the snapshot handed to us", logtype::net);
-			Global.network_status = "The server sent a snapshot this build cannot read";
+			Global.network_position_error = (float)result.worst_position_error;
+
+			// the routine correction is what keeps us in line; a full resync is only worth
+			// asking for when even that is not catching up
+			if (result.worst_position_error > RESYNC_POSITION_ERROR) {
+				if (++bad_corrections >= RESYNC_BAD_CORRECTIONS) {
+					bad_corrections = 0;
+					WriteLog("net: " + std::to_string((int)result.worst_position_error)
+					         + " m out of place after a correction, asking for a full resync", logtype::net);
+					send_resync_request(Global.simulation_tick, 0);
+				}
+			}
+			else {
+				bad_corrections = 0;
+			}
 		}
 	}
 
 	if (msg.type == message::VEHICLE_LIST) {
 		const auto& cmd = dynamic_cast<const vehicle_list&>(msg);
+
+		if (Entities.empty() && !cmd.vehicles.empty())
+			WriteLog("net: vehicle roster received, " + std::to_string(cmd.vehicles.size()) + " vehicles to choose from", logtype::net);
+
 		Entities.adopt(cmd.vehicles);
 	}
 

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -53,6 +53,7 @@ void network::connection::connected()
 		msg.version = EU07_NETWORK_VERSION;
 		msg.start_packet = packet_counter;
 		msg.app_version = Global.asVersion;
+		msg.session_token = Global.network_session_token;
 		send_message(msg);
 	}
 }
@@ -93,9 +94,10 @@ void network::server::prune_clients()
 		if ((*it)->state == connection::DEAD) {
 			if ((*it)->peer_id != PEER_NONE) {
 				WriteLog("net: peer " + std::to_string((*it)->peer_id) + " disconnected", logtype::net);
-				// a vehicle keeps running for whoever is left on board; it only falls back
-				// to the AI when the crew becomes empty, which Crews decides on its own
-				Crews.drop_peer((*it)->peer_id);
+				// the seat is held for a while in case the peer comes straight back. a
+				// vehicle keeps running for whoever is left on board either way; it only
+				// falls back to the AI once the crew really is empty
+				Crews.suspend_peer((*it)->peer_id);
 			}
 			it = clients.erase(it);
 			continue;
@@ -169,7 +171,8 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
         reply.config = 0; // TODO: pass bitfield with state of relevant setting switches
         reply.scenario = Global.SceneryFile;
 		reply.app_version = Global.asVersion;
-		reply.peer_id = allocate_peer_id();
+		reply.session_token = cmd.session_token;
+		reply.peer_id = resolve_peer_identity(reply.session_token);
 		conn->peer_id = reply.peer_id;
 		// the peer now goes and loads the scenario. it gets the state of the world as a
 		// snapshot when it reports back, instead of replaying the session frame by frame
@@ -195,6 +198,11 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 			return;
 		}
 
+		// the roster first, so that the crew section of the snapshot resolves to names
+		vehicle_list roster;
+		roster.vehicles = Entities.entries();
+		conn->send_message(roster);
+
 		snapshot reply;
 		reply.tick = Global.simulation_tick;
 		reply.blob = take_snapshot();
@@ -208,6 +216,17 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 
 		// and it still has to learn who is where
 		Crews.mark_all_pending();
+	}
+	else if (msg.type == message::REQUEST_RESYNC) {
+		const auto& cmd = dynamic_cast<const request_resync&>(msg);
+
+		WriteLog("net: resync requested by peer " + std::to_string(conn->peer_id) + " at tick "
+		         + std::to_string(cmd.tick) + " (its digest " + std::to_string(cmd.state_hash) + ")", logtype::net);
+
+		snapshot reply;
+		reply.tick = Global.simulation_tick;
+		reply.blob = take_snapshot();
+		conn->send_message(reply);
 	}
 	else if (msg.type == message::CLAIM_VEHICLE) {
 		const auto& cmd = dynamic_cast<const claim_vehicle&>(msg);
@@ -355,6 +374,17 @@ void network::client::send_ready()
 	WriteLog("net: scenario loaded, asking the server for a snapshot", logtype::net);
 }
 
+void network::client::send_resync_request(uint64_t tick, uint64_t state_hash)
+{
+	if (!conn || conn->state != connection::ACTIVE)
+		return;
+
+	request_resync msg;
+	msg.tick = tick;
+	msg.state_hash = state_hash;
+	conn->send_message(msg);
+}
+
 void network::client::send_claim(NetworkEntityId entity_id)
 {
 	if (!conn || conn->state != connection::ACTIVE)
@@ -419,6 +449,11 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 			WriteLog("net: assigned peer id " + std::to_string(cmd.peer_id), logtype::net);
 		}
 
+		if (cmd.session_token != 0) {
+			// kept for the next connection, so that a dropout does not cost us our seat
+			Global.network_session_token = cmd.session_token;
+		}
+
 		Global.network_status.clear();
 
 		WriteLog("net: accept received", logtype::net);
@@ -438,6 +473,15 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 
 		if (apply_snapshot(cmd.blob)) {
 			Global.network_snapshot_applied = true;
+
+			// the roster may say we are on a crew already - after a reconnect, or because
+			// the claim was granted while we were still loading. walk into that cab
+			auto const own = Crews.vehicle_of(Global.network_peer_id);
+			if (own != ENTITY_NONE) {
+				auto const name = Entities.name_of(own);
+				if (!name.empty())
+					Global.network_pending_vehicle = name;
+			}
 		}
 		else {
 			ErrorLog("net: could not apply the snapshot handed to us", logtype::net);

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -97,23 +97,37 @@ network::server::server(std::shared_ptr<std::istream> buf) : backbuffer(buf)
 
 }
 
-void network::server::push_delta(const frame_info &msg)
+void network::server::prune_clients()
 {
 	for (auto it = clients.begin(); it != clients.end(); ) {
 		if ((*it)->state == connection::DEAD) {
+			if ((*it)->peer_id != PEER_NONE) {
+				WriteLog("net: peer " + std::to_string((*it)->peer_id) + " disconnected", logtype::net);
+				// a vehicle keeps running for whoever is left on board; it only falls back
+				// to the AI when the crew becomes empty, which Crews decides on its own
+				Crews.drop_peer((*it)->peer_id);
+			}
 			it = clients.erase(it);
 			continue;
 		}
-
-		if ((*it)->state == connection::ACTIVE)
-			(*it)->send_message(msg);
-
 		it++;
+	}
+}
+
+void network::server::push_delta(const frame_info &msg)
+{
+	prune_clients();
+
+	for (auto const &client : clients) {
+		if (client->state == connection::ACTIVE)
+			client->send_message(msg);
 	}
 }
 
 void network::server::push_message(const message &msg)
 {
+	prune_clients();
+
 	for (auto const &client : clients) {
 		if (client->state == connection::ACTIVE)
 			client->send_message(msg);
@@ -176,6 +190,29 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 
 		WriteLog("net: peer " + std::to_string(conn->peer_id) + " connected, build \"" + cmd.app_version
 		         + "\", scenario \"" + Global.SceneryFile + "\"", logtype::net);
+	}
+	else if (msg.type == message::CLAIM_VEHICLE) {
+		const auto& cmd = dynamic_cast<const claim_vehicle&>(msg);
+
+		auto const result = Crews.claim(conn->peer_id, cmd.entity_id);
+		if (result == claim_result::granted || result == claim_result::already_member) {
+			claim_granted reply;
+			reply.entity_id = cmd.entity_id;
+			conn->send_message(reply);
+		}
+		else {
+			WriteLog("net: refused claim of vehicle " + std::to_string(cmd.entity_id) + " by peer "
+			         + std::to_string(conn->peer_id) + ": " + describe(result), logtype::net);
+
+			claim_denied reply;
+			reply.entity_id = cmd.entity_id;
+			reply.reason = describe(result);
+			conn->send_message(reply);
+		}
+	}
+	else if (msg.type == message::LEAVE_VEHICLE) {
+		const auto& cmd = dynamic_cast<const leave_vehicle&>(msg);
+		Crews.leave(conn->peer_id, cmd.entity_id);
 	}
 	else if (msg.type == message::REQUEST_COMMAND) {
 		const auto& cmd = dynamic_cast<const request_command&>(msg);
@@ -267,6 +304,26 @@ void network::client::send_commands(command_queue::commands_map commands)
 	conn->send_message(msg);
 }
 
+void network::client::send_claim(NetworkEntityId entity_id)
+{
+	if (!conn || conn->state != connection::ACTIVE)
+		return;
+
+	claim_vehicle msg;
+	msg.entity_id = entity_id;
+	conn->send_message(msg);
+}
+
+void network::client::send_leave(NetworkEntityId entity_id)
+{
+	if (!conn || conn->state != connection::ACTIVE)
+		return;
+
+	leave_vehicle msg;
+	msg.entity_id = entity_id;
+	conn->send_message(msg);
+}
+
 void network::client::handle_message(std::shared_ptr<connection> conn, const message &msg)
 {
 	if (msg.type >= message::TYPE_MAX)
@@ -320,6 +377,28 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 	if (msg.type == message::VEHICLE_LIST) {
 		const auto& cmd = dynamic_cast<const vehicle_list&>(msg);
 		Entities.adopt(cmd.vehicles);
+	}
+
+	if (msg.type == message::CREW_UPDATE) {
+		const auto& cmd = dynamic_cast<const crew_update&>(msg);
+		Crews.mirror(cmd.entity_id, cmd.crew);
+	}
+
+	if (msg.type == message::CLAIM_GRANTED) {
+		const auto& cmd = dynamic_cast<const claim_granted&>(msg);
+
+		WriteLog("net: claim of vehicle " + std::to_string(cmd.entity_id) + " granted", logtype::net);
+		Global.network_lobby_message.clear();
+		// the cab itself is built by the replicated entervehicle the server posts;
+		// we only have to walk into it once it shows up
+		Global.network_pending_vehicle = Entities.name_of(cmd.entity_id);
+	}
+
+	if (msg.type == message::CLAIM_DENIED) {
+		const auto& cmd = dynamic_cast<const claim_denied&>(msg);
+
+		WriteLog("net: claim of vehicle " + std::to_string(cmd.entity_id) + " denied: " + cmd.reason, logtype::net);
+		Global.network_lobby_message = cmd.reason;
 	}
 
 	if (msg.type == message::FRAME_INFO) {

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -112,6 +112,14 @@ void network::server::push_delta(const frame_info &msg)
 	}
 }
 
+void network::server::push_message(const message &msg)
+{
+	for (auto const &client : clients) {
+		if (client->state == connection::ACTIVE)
+			client->send_message(msg);
+	}
+}
+
 command_queue::commands_map network::server::pop_commands()
 {
 	command_queue::commands_map map(client_commands_queue);
@@ -157,6 +165,8 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
         reply.config = 0; // TODO: pass bitfield with state of relevant setting switches
         reply.scenario = Global.SceneryFile;
 		reply.app_version = Global.asVersion;
+		reply.peer_id = allocate_peer_id();
+		conn->peer_id = reply.peer_id;
 		conn->state = connection::CATCHING_UP;
 		conn->backbuffer = backbuffer;
 		conn->backbuffer_pos = 0;
@@ -164,7 +174,8 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 
 		conn->send_message(reply);
 
-		WriteLog("net: peer connected, build \"" + cmd.app_version + "\", scenario \"" + Global.SceneryFile + "\"", logtype::net);
+		WriteLog("net: peer " + std::to_string(conn->peer_id) + " connected, build \"" + cmd.app_version
+		         + "\", scenario \"" + Global.SceneryFile + "\"", logtype::net);
 	}
 	else if (msg.type == message::REQUEST_COMMAND) {
 		const auto& cmd = dynamic_cast<const request_command&>(msg);
@@ -293,6 +304,11 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 			return;
 		}
 
+		if (cmd.peer_id != PEER_NONE) {
+			Global.network_peer_id = cmd.peer_id;
+			WriteLog("net: assigned peer id " + std::to_string(cmd.peer_id), logtype::net);
+		}
+
 		Global.network_status.clear();
 
 		WriteLog("net: accept received", logtype::net);
@@ -300,6 +316,11 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 
 	if (conn->state != connection::ACTIVE)
 		return;
+
+	if (msg.type == message::VEHICLE_LIST) {
+		const auto& cmd = dynamic_cast<const vehicle_list&>(msg);
+		Entities.adopt(cmd.vehicles);
+	}
 
 	if (msg.type == message::FRAME_INFO) {
 		resume_frame_counter++;

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -12,7 +12,9 @@
 
 // 2 - legacy lockstep protocol
 // 3 - handshake carries build identification and an explicit rejection message
-std::uint32_t const EU07_NETWORK_VERSION = 3;
+// 4 - peer identity, vehicle roster and crew handshake, command source,
+//     logical simulation tick and a versioned state digest instead of the position sum
+std::uint32_t const EU07_NETWORK_VERSION = 4;
 
 namespace network {
 
@@ -279,7 +281,7 @@ void network::client::update()
 }
 
 // client
-std::tuple<double, double, command_queue::commands_map> network::client::get_next_delta(int counter)
+network::frame_delta network::client::get_next_delta(int counter)
 {
 	auto now = std::chrono::high_resolution_clock::now();
 	if (counter == 1) {
@@ -289,8 +291,7 @@ std::tuple<double, double, command_queue::commands_map> network::client::get_nex
 
 	if (delta_queue.empty()) {
 		// buffer underflow
-		return std::tuple<double, double,
-		        command_queue::commands_map>(0.0, 0.0, command_queue::commands_map());
+		return frame_delta();
 	}
 
 
@@ -316,13 +317,20 @@ std::tuple<double, double, command_queue::commands_map> network::client::get_nex
 			consume_counter = std::clamp(consume_counter - mult, -MAX_BUFFER_SIZE, MAX_BUFFER_SIZE);
 		}
 
+		frame_delta delta;
+		delta.dt = entry.dt;
+		delta.tick = entry.tick;
+		delta.state_hash = entry.state_hash;
+		delta.state_hash_version = entry.state_hash_version;
+		delta.commands = entry.commands;
+		delta.valid = true;
+
 		delta_queue.pop();
 
-		return std::make_tuple(entry.dt, entry.sync, entry.commands);
+		return delta;
 	} else {
 		// nothing to push
-		return std::tuple<double, double,
-		        command_queue::commands_map>(0.0, 0.0, command_queue::commands_map());
+		return frame_delta();
 	}
 }
 
@@ -333,6 +341,7 @@ void network::client::send_commands(command_queue::commands_map commands)
 	// eh, maybe queue lost messages
 
 	request_command msg;
+	msg.tick = Global.simulation_tick;
 	msg.commands = commands;
 
 	conn->send_message(msg);

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -19,6 +19,32 @@ std::uint32_t const EU07_NETWORK_VERSION = 4;
 
 namespace network {
 
+traffic_counters Traffic;
+
+void traffic_counters::update()
+{
+	auto const now = Timer::GetTime();
+
+	if (rate_time_mark < 0.0)
+	{
+		rate_time_mark = now;
+		rate_sent_mark = sent_bytes;
+		rate_received_mark = received_bytes;
+		return;
+	}
+
+	auto const elapsed = now - rate_time_mark;
+	if (elapsed < 1.0)
+		return;
+
+	sent_rate = (double)(sent_bytes - rate_sent_mark) / elapsed;
+	received_rate = (double)(received_bytes - rate_received_mark) / elapsed;
+
+	rate_time_mark = now;
+	rate_sent_mark = sent_bytes;
+	rate_received_mark = received_bytes;
+}
+
 backend_list_t& backend_list() {
     // HACK: static initialization order fiasco fix
     // NOTE: potential static deinitialization order fiasco

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -7,7 +7,9 @@
 #include "application/application.h"
 #include "utilities/Globals.h"
 
-std::uint32_t const EU07_NETWORK_VERSION = 2;
+// 2 - legacy lockstep protocol
+// 3 - handshake carries build identification and an explicit rejection message
+std::uint32_t const EU07_NETWORK_VERSION = 3;
 
 namespace network {
 
@@ -44,6 +46,7 @@ void network::connection::connected()
 		client_hello msg;
 		msg.version = EU07_NETWORK_VERSION;
 		msg.start_packet = packet_counter;
+		msg.app_version = Global.asVersion;
 		send_message(msg);
 	}
 }
@@ -127,8 +130,23 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 	if (msg.type == message::CLIENT_HELLO) {
 		const auto& cmd = dynamic_cast<const client_hello&>(msg);
 
-		if (cmd.version != EU07_NETWORK_VERSION // wrong version
-		        || !Global.ready_to_load) { // not ready yet
+		std::string rejection;
+		if (cmd.version != (int32_t)EU07_NETWORK_VERSION) {
+			rejection = "incompatible protocol version: server speaks "
+			        + std::to_string(EU07_NETWORK_VERSION)
+			        + ", client speaks " + std::to_string(cmd.version);
+		}
+		else if (!Global.ready_to_load || Global.SceneryFile.empty()) {
+			// the host has not picked a scenario yet, there is nothing to join
+			rejection = "the server has no scenario running yet";
+		}
+
+		if (!rejection.empty()) {
+			WriteLog("net: rejecting peer: " + rejection, logtype::net);
+
+			server_reject reply;
+			reply.reason = rejection;
+			conn->send_message(reply);
 			conn->disconnect();
 			return;
 		}
@@ -138,6 +156,7 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 		reply.timestamp = Global.starting_timestamp;
         reply.config = 0; // TODO: pass bitfield with state of relevant setting switches
         reply.scenario = Global.SceneryFile;
+		reply.app_version = Global.asVersion;
 		conn->state = connection::CATCHING_UP;
 		conn->backbuffer = backbuffer;
 		conn->backbuffer_pos = 0;
@@ -145,7 +164,7 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 
 		conn->send_message(reply);
 
-		WriteLog("net: client accepted", logtype::net);
+		WriteLog("net: peer connected, build \"" + cmd.app_version + "\", scenario \"" + Global.SceneryFile + "\"", logtype::net);
 	}
 	else if (msg.type == message::REQUEST_COMMAND) {
 		const auto& cmd = dynamic_cast<const request_command&>(msg);
@@ -161,6 +180,11 @@ void network::client::update()
 {
 	if (conn && conn->state == connection::DEAD) {
 		conn.reset();
+	}
+
+	if (!Global.network_reject_reason.empty()) {
+		// the server explicitly refused us; retrying would only spam it
+		return;
 	}
 
 	if (!conn) {
@@ -240,6 +264,16 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 		return;
 	}
 
+	if (msg.type == message::SERVER_REJECT) {
+		const auto& cmd = dynamic_cast<const server_reject&>(msg);
+
+		ErrorLog("net: connection refused by the server: " + cmd.reason, logtype::net);
+		Global.network_reject_reason = cmd.reason;
+		Global.network_status = "Connection refused: " + cmd.reason;
+		conn->disconnect();
+		return;
+	}
+
 	if (msg.type == message::SERVER_HELLO) {
 		const auto& cmd = dynamic_cast<const server_hello&>(msg);
 		conn->state = connection::ACTIVE;
@@ -251,11 +285,15 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
             // TODO: configure simulation settings according to received cmd.config
             Global.SceneryFile = cmd.scenario;
 			Global.ready_to_load = true;
+
+			WriteLog("net: scenario handshake: \"" + cmd.scenario + "\", server build \"" + cmd.app_version + "\"", logtype::net);
 		} else if (Global.random_seed != cmd.seed) {
 			ErrorLog("net: seed mismatch", logtype::net);
 			conn->disconnect();
 			return;
 		}
+
+		Global.network_status.clear();
 
 		WriteLog("net: accept received", logtype::net);
 	}

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -524,8 +524,12 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 			// the routine correction is what keeps us in line; a full resync is only worth
 			// asking for when even that is not catching up
 			if (result.worst_position_error > RESYNC_POSITION_ERROR) {
-				if (++bad_corrections >= RESYNC_BAD_CORRECTIONS) {
+				++bad_corrections;
+
+				if ((bad_corrections >= RESYNC_BAD_CORRECTIONS)
+				 && (last_resync_tick == 0 || Global.simulation_tick > last_resync_tick + RESYNC_COOLDOWN_TICKS)) {
 					bad_corrections = 0;
+					last_resync_tick = Global.simulation_tick;
 					WriteLog("net: " + std::to_string((int)result.worst_position_error)
 					         + " m out of place after a correction, asking for a full resync", logtype::net);
 					send_resync_request(Global.simulation_tick, 0);

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "network/network.h"
+#include "network/snapshot.h"
 #include "network/message.h"
 #include "utilities/Logs.h"
 #include "scene/sn_utils.h"
@@ -56,42 +57,9 @@ void network::connection::connected()
 	}
 }
 
-void network::connection::catch_up()
-{
-	backbuffer->seekg(backbuffer_pos);
-
-	std::vector<std::shared_ptr<message>> messages;
-
-	for (int i = 0; i < CATCHUP_PACKETS; i++) {
-		if (backbuffer->peek() == EOF) {
-			send_messages(messages);
-			state = ACTIVE;
-			backbuffer->seekg(0, std::ios_base::end);
-			return;
-		}
-
-		auto msg = deserialize_message(*backbuffer.get());
-
-		if (packet_counter) {
-			packet_counter--;
-			i--; // TODO: it would be better to skip frames in chunks
-			continue;
-		}
-
-		messages.push_back(msg);
-	}
-
-	backbuffer_pos = backbuffer->tellg();
-	backbuffer->seekg(0, std::ios_base::end);
-
-	send_messages(messages);
-}
-
 void network::connection::send_complete(std::shared_ptr<std::string> buf)
 {
-	if (!is_client && state == CATCHING_UP) {
-		catch_up();
-	}
+	// the shared buffer had to stay alive until asio finished writing it out; now it can go
 }
 
 // --------------
@@ -203,15 +171,43 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 		reply.app_version = Global.asVersion;
 		reply.peer_id = allocate_peer_id();
 		conn->peer_id = reply.peer_id;
-		conn->state = connection::CATCHING_UP;
-		conn->backbuffer = backbuffer;
-		conn->backbuffer_pos = 0;
+		// the peer now goes and loads the scenario. it gets the state of the world as a
+		// snapshot when it reports back, instead of replaying the session frame by frame
+		conn->state = connection::AWAITING_READY;
 		conn->packet_counter = cmd.start_packet;
 
 		conn->send_message(reply);
 
 		WriteLog("net: peer " + std::to_string(conn->peer_id) + " connected, build \"" + cmd.app_version
 		         + "\", scenario \"" + Global.SceneryFile + "\"", logtype::net);
+	}
+	else if (msg.type == message::CLIENT_READY) {
+		const auto& cmd = dynamic_cast<const client_ready&>(msg);
+
+		if (cmd.scenario != Global.SceneryFile) {
+			WriteLog("net: peer " + std::to_string(conn->peer_id) + " loaded \"" + cmd.scenario
+			         + "\" but the session runs \"" + Global.SceneryFile + "\"", logtype::net);
+
+			server_reject reply;
+			reply.reason = "scenario mismatch: the session runs \"" + Global.SceneryFile + "\"";
+			conn->send_message(reply);
+			conn->disconnect();
+			return;
+		}
+
+		snapshot reply;
+		reply.tick = Global.simulation_tick;
+		reply.blob = take_snapshot();
+		conn->send_message(reply);
+
+		// from here on the peer receives the live stream; there is no backlog to catch up on
+		conn->state = connection::ACTIVE;
+
+		WriteLog("net: snapshot sent to peer " + std::to_string(conn->peer_id) + " at tick "
+		         + std::to_string(reply.tick), logtype::net);
+
+		// and it still has to learn who is where
+		Crews.mark_all_pending();
 	}
 	else if (msg.type == message::CLAIM_VEHICLE) {
 		const auto& cmd = dynamic_cast<const claim_vehicle&>(msg);
@@ -347,6 +343,18 @@ void network::client::send_commands(command_queue::commands_map commands)
 	conn->send_message(msg);
 }
 
+void network::client::send_ready()
+{
+	if (!conn || conn->state == connection::DEAD)
+		return;
+
+	client_ready msg;
+	msg.scenario = Global.SceneryFile;
+	conn->send_message(msg);
+
+	WriteLog("net: scenario loaded, asking the server for a snapshot", logtype::net);
+}
+
 void network::client::send_claim(NetworkEntityId entity_id)
 {
 	if (!conn || conn->state != connection::ACTIVE)
@@ -389,6 +397,8 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 		const auto& cmd = dynamic_cast<const server_hello&>(msg);
 		conn->state = connection::ACTIVE;
 
+		bool const firsthandshake { !Global.ready_to_load };
+
 		if (!Global.ready_to_load) {
 			Global.random_seed = cmd.seed;
 			Global.random_engine.seed(Global.random_seed);
@@ -412,10 +422,28 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 		Global.network_status.clear();
 
 		WriteLog("net: accept received", logtype::net);
+
+		if (!firsthandshake && simulation::is_ready) {
+			// we are coming back to a session we already have loaded, so there is nobody
+			// to wait for: ask for a fresh snapshot straight away
+			send_ready();
+		}
 	}
 
 	if (conn->state != connection::ACTIVE)
 		return;
+
+	if (msg.type == message::SNAPSHOT) {
+		const auto& cmd = dynamic_cast<const snapshot&>(msg);
+
+		if (apply_snapshot(cmd.blob)) {
+			Global.network_snapshot_applied = true;
+		}
+		else {
+			ErrorLog("net: could not apply the snapshot handed to us", logtype::net);
+			Global.network_status = "The server sent a snapshot this build cannot read";
+		}
+	}
 
 	if (msg.type == message::VEHICLE_LIST) {
 		const auto& cmd = dynamic_cast<const vehicle_list&>(msg);

--- a/network/network.cpp
+++ b/network/network.cpp
@@ -168,7 +168,7 @@ void network::server::handle_message(std::shared_ptr<connection> conn, const mes
 		server_hello reply;
 		reply.seed = Global.random_seed;
 		reply.timestamp = Global.starting_timestamp;
-        reply.config = 0; // TODO: pass bitfield with state of relevant setting switches
+        reply.config = pack_session_config();
         reply.scenario = Global.SceneryFile;
 		reply.app_version = Global.asVersion;
 		reply.session_token = cmd.session_token;
@@ -433,7 +433,7 @@ void network::client::handle_message(std::shared_ptr<connection> conn, const mes
 			Global.random_seed = cmd.seed;
 			Global.random_engine.seed(Global.random_seed);
 			Global.starting_timestamp = cmd.timestamp;
-            // TODO: configure simulation settings according to received cmd.config
+            apply_session_config(cmd.config);
             Global.SceneryFile = cmd.scenario;
 			Global.ready_to_load = true;
 

--- a/network/network.h
+++ b/network/network.h
@@ -18,17 +18,13 @@ namespace network
 		friend class client;
 
 	private:
-		const int CATCHUP_PACKETS = 300;
-
 		bool is_client;
 
 	protected:
-		std::shared_ptr<std::istream> backbuffer;
-		size_t backbuffer_pos;
 		size_t packet_counter;
 
+		// exists only to keep the send buffer alive until asio is done with it
 		void send_complete(std::shared_ptr<std::string> buf);
-		void catch_up();
 
 	public:
 		std::function<void(const message &msg)> message_handler;
@@ -44,7 +40,9 @@ namespace network
 
 		enum peer_state {
 			AWAITING_HELLO,
-			CATCHING_UP,
+			// handshake done, the peer is loading the scenario; it gets a snapshot and
+			// goes live the moment it says it is ready
+			AWAITING_READY,
 			ACTIVE,
 			DEAD
 		};
@@ -57,6 +55,8 @@ namespace network
 	class server
 	{
 	private:
+		// the session log is still written out, it is handy when picking a desync apart,
+		// but joining no longer means replaying it
 		std::shared_ptr<std::istream> backbuffer;
 
 	protected:
@@ -122,6 +122,8 @@ namespace network
 		void update();
 		frame_delta get_next_delta(int counter);
 		void send_commands(command_queue::commands_map commands);
+		// tells the server the scenario is loaded and a snapshot can be applied
+		void send_ready();
 		// lobby requests; the server is the one that decides
 		void send_claim(NetworkEntityId entity_id);
 		void send_leave(NetworkEntityId entity_id);

--- a/network/network.h
+++ b/network/network.h
@@ -110,6 +110,12 @@ namespace network
 
 		std::queue<frame_info> delta_queue;
 
+		// how far out of place a correction found us, in a row. a full resync is only
+		// worth asking for when the routine stream is not catching up on its own
+		int bad_corrections = 0;
+		static constexpr double RESYNC_POSITION_ERROR = 25.0;
+		static constexpr int RESYNC_BAD_CORRECTIONS = 5;
+
 		float last_target = 20.0f;
 		float jitteriness = 1.0f;
 		float consume_counter = 0.0f;

--- a/network/network.h
+++ b/network/network.h
@@ -11,6 +11,31 @@
 
 namespace network
 {
+	// what has gone over the wire so far, and how fast it is going now. the transport
+	// layer feeds it; the debug panel reads it
+	struct traffic_counters
+	{
+		uint64_t sent_bytes { 0 };
+		uint64_t received_bytes { 0 };
+		uint64_t sent_messages { 0 };
+		uint64_t received_messages { 0 };
+		// bytes per second, averaged over the last second
+		double sent_rate { 0.0 };
+		double received_rate { 0.0 };
+
+		void sent(size_t Bytes) { sent_bytes += Bytes; ++sent_messages; }
+		void received(size_t Bytes) { received_bytes += Bytes; ++received_messages; }
+		// recomputes the rates; called once per frame
+		void update();
+
+	private:
+		uint64_t rate_sent_mark { 0 };
+		uint64_t rate_received_mark { 0 };
+		double rate_time_mark { -1.0 };
+	};
+
+	extern traffic_counters Traffic;
+
     //m7todo: separate client/server connection class?
     class connection
 	{

--- a/network/network.h
+++ b/network/network.h
@@ -101,6 +101,8 @@ namespace network
 		// sends an out of band message to every active peer. unlike push_delta this is not
 		// written to the backbuffer, so it does not become part of the replayed history
 		void push_message(const message &msg);
+		// tells every peer who is taking part and what each of them is called
+		void publish_roster();
 		command_queue::commands_map pop_commands();
 	};
 
@@ -165,6 +167,7 @@ namespace network
 		// lobby requests; the server is the one that decides
 		void send_claim(NetworkEntityId entity_id);
 		void send_leave(NetworkEntityId entity_id);
+		void send_chat(const std::string &text);
 		int get_frame_counter() {
 			return resume_frame_counter;
 		}

--- a/network/network.h
+++ b/network/network.h
@@ -79,6 +79,18 @@ namespace network
 		command_queue::commands_map pop_commands();
 	};
 
+	// one authoritative simulation step handed to the client
+	struct frame_delta
+	{
+		double dt { 0.0 };
+		uint64_t tick { 0 };
+		uint64_t state_hash { 0 };
+		uint32_t state_hash_version { 0 };
+		command_queue::commands_map commands;
+		// false when there was nothing ready to consume in this pass
+		bool valid { false };
+	};
+
 	class client
 	{
 	protected:
@@ -108,7 +120,7 @@ namespace network
 
 	public:
 		void update();
-		std::tuple<double, double, command_queue::commands_map> get_next_delta(int counter);
+		frame_delta get_next_delta(int counter);
 		void send_commands(command_queue::commands_map commands);
 		// lobby requests; the server is the one that decides
 		void send_claim(NetworkEntityId entity_id);

--- a/network/network.h
+++ b/network/network.h
@@ -101,41 +101,40 @@ namespace network
 		size_t reconnect_delay = 0;
 
 		const size_t RECONNECT_DELAY_FRAMES = 60;
-		// the queue of authoritative frames waiting to be played out. every frame sitting
-		// in here is a frame of delay between pressing a key and seeing it happen, so it
-		// is kept as short as the connection allows rather than a comfortable second deep
-		const float MAX_BUFFER_SIZE = 12.0f;
-		const float JITTERINESS_MIX = 0.998f;
-		const float TARGET_MIN = 1.0f;
-		const float TARGET_MIX = 0.98f;
-		const float JITTERINESS_MULTIPIER = 2.0f;
-		const float CONSUME_MULTIPIER = 0.05f;
 
+		// authoritative frames that have arrived and not been handed to the simulation yet.
+		// they are taken in full every render: nothing is held back on purpose. the old
+		// design played them out one per frame at the server's pace, which meant the world
+		// ran at the wrong speed whenever the two machines drew at different rates, and
+		// every frame kept in reserve was a frame of delay on the player's own controls
 		std::queue<frame_info> delta_queue;
 
 		// how far out of place a correction found us, in a row. a full resync is only
 		// worth asking for when the routine stream is not catching up on its own
 		int bad_corrections = 0;
 		uint64_t last_resync_tick = 0;
+		int state_countdown = 0;
+		int state_updates = 0;
+		static constexpr int STATE_INTERVAL_FRAMES = 6;
+		static constexpr int STATE_FULL_EVERY = 100;
 		static constexpr double RESYNC_POSITION_ERROR = 25.0;
 		static constexpr int RESYNC_BAD_CORRECTIONS = 5;
 		// a correction needs time to take hold; asking again before it has is pointless
 		static constexpr uint64_t RESYNC_COOLDOWN_TICKS = 600;
 
-		float last_target = 2.0f;
-		float jitteriness = 1.0f;
-		float consume_counter = 0.0f;
-
 		std::chrono::high_resolution_clock::time_point last_rcv;
-		std::chrono::high_resolution_clock::time_point last_frame;
-		std::chrono::high_resolution_clock::duration frame_time;
 
 	public:
 		void update();
-		frame_delta get_next_delta(int counter);
+		// hands over everything the authority has sent since the last call, merging the
+		// commands into the map. returns what the newest of those frames said about itself
+		frame_delta take_pending(command_queue::commands_map &commands);
 		void send_commands(command_queue::commands_map commands);
 		// tells the server the scenario is loaded and a snapshot can be applied
 		void send_ready();
+		// publishes what our own trains are doing, so that the rest of the session can see
+		// them. we run their physics, so this is the authority on them
+		void publish_state();
 		// our world has drifted too far to carry on; ask to be put back in line
 		void send_resync_request(uint64_t tick, uint64_t state_hash);
 		// lobby requests; the server is the one that decides

--- a/network/network.h
+++ b/network/network.h
@@ -101,9 +101,12 @@ namespace network
 		size_t reconnect_delay = 0;
 
 		const size_t RECONNECT_DELAY_FRAMES = 60;
-		const float MAX_BUFFER_SIZE = 60.0f;
+		// the queue of authoritative frames waiting to be played out. every frame sitting
+		// in here is a frame of delay between pressing a key and seeing it happen, so it
+		// is kept as short as the connection allows rather than a comfortable second deep
+		const float MAX_BUFFER_SIZE = 12.0f;
 		const float JITTERINESS_MIX = 0.998f;
-		const float TARGET_MIN = 2.0f;
+		const float TARGET_MIN = 1.0f;
 		const float TARGET_MIX = 0.98f;
 		const float JITTERINESS_MULTIPIER = 2.0f;
 		const float CONSUME_MULTIPIER = 0.05f;
@@ -113,10 +116,13 @@ namespace network
 		// how far out of place a correction found us, in a row. a full resync is only
 		// worth asking for when the routine stream is not catching up on its own
 		int bad_corrections = 0;
+		uint64_t last_resync_tick = 0;
 		static constexpr double RESYNC_POSITION_ERROR = 25.0;
 		static constexpr int RESYNC_BAD_CORRECTIONS = 5;
+		// a correction needs time to take hold; asking again before it has is pointless
+		static constexpr uint64_t RESYNC_COOLDOWN_TICKS = 600;
 
-		float last_target = 20.0f;
+		float last_target = 2.0f;
 		float jitteriness = 1.0f;
 		float consume_counter = 0.0f;
 

--- a/network/network.h
+++ b/network/network.h
@@ -124,6 +124,8 @@ namespace network
 		void send_commands(command_queue::commands_map commands);
 		// tells the server the scenario is loaded and a snapshot can be applied
 		void send_ready();
+		// our world has drifted too far to carry on; ask to be put back in line
+		void send_resync_request(uint64_t tick, uint64_t state_hash);
 		// lobby requests; the server is the one that decides
 		void send_claim(NetworkEntityId entity_id);
 		void send_leave(NetworkEntityId entity_id);

--- a/network/network.h
+++ b/network/network.h
@@ -5,6 +5,7 @@
 #include <queue>
 #include <chrono>
 #include "network/message.h"
+#include "network/entities.h"
 #include "input/command.h"
 
 namespace network
@@ -47,6 +48,9 @@ namespace network
 			DEAD
 		};
 		peer_state state;
+
+		// session identity of the peer on the other side of this connection
+		PeerId peer_id { PEER_NONE };
 	};
 
 	class server
@@ -64,6 +68,9 @@ namespace network
 	public:
 		server(std::shared_ptr<std::istream> buf);
 		void push_delta(const frame_info &msg);
+		// sends an out of band message to every active peer. unlike push_delta this is not
+		// written to the backbuffer, so it does not become part of the replayed history
+		void push_message(const message &msg);
 		command_queue::commands_map pop_commands();
 	};
 

--- a/network/network.h
+++ b/network/network.h
@@ -6,6 +6,7 @@
 #include <chrono>
 #include "network/message.h"
 #include "network/entities.h"
+#include "network/session.h"
 #include "input/command.h"
 
 namespace network
@@ -65,6 +66,10 @@ namespace network
 
 		command_queue::commands_map client_commands_queue;
 
+	protected:
+		// drops peers whose socket is gone, together with their crew memberships
+		void prune_clients();
+
 	public:
 		server(std::shared_ptr<std::istream> buf);
 		void push_delta(const frame_info &msg);
@@ -105,6 +110,9 @@ namespace network
 		void update();
 		std::tuple<double, double, command_queue::commands_map> get_next_delta(int counter);
 		void send_commands(command_queue::commands_map commands);
+		// lobby requests; the server is the one that decides
+		void send_claim(NetworkEntityId entity_id);
+		void send_leave(NetworkEntityId entity_id);
 		int get_frame_counter() {
 			return resume_frame_counter;
 		}

--- a/network/session.cpp
+++ b/network/session.cpp
@@ -86,6 +86,24 @@ command_verdict validate_command(PeerId Peer, user_command Command, uint32_t Rec
 	return command_verdict::unsupported_target;
 }
 
+claim_result claim_by_name(PeerId Peer, std::string const &Vehicle, NetworkEntityId &Entity)
+{
+	Entity = Entities.id_of(Vehicle);
+	if (Entity == ENTITY_NONE)
+		return claim_result::unknown_vehicle;
+
+	auto const previous = Crews.vehicle_of(Peer);
+	auto const result = Crews.claim(Peer, Entity);
+
+	if ((result == claim_result::granted) && (previous != ENTITY_NONE) && (previous != Entity))
+	{
+		// nobody works two vehicles at once
+		Crews.leave(Peer, previous);
+	}
+
+	return result;
+}
+
 void filter_commands(PeerId Peer, command_queue::commands_map &Commands)
 {
 	for (auto it = Commands.begin(); it != Commands.end();)
@@ -94,6 +112,27 @@ void filter_commands(PeerId Peer, command_queue::commands_map &Commands)
 
 		for (auto command = sequence.begin(); command != sequence.end();)
 		{
+			if (command->source == PEER_NONE)
+			{
+				// posted by the authority itself rather than by a person; it is already
+				// the decision, not a request for one
+				++command;
+				continue;
+			}
+
+			if (command->command == user_command::entervehicle)
+			{
+				// the local player walked into a cab. that is a crew request; the cab
+				// itself is built by the authority once the seat is granted
+				NetworkEntityId entity{ENTITY_NONE};
+				auto const result = claim_by_name(Peer, command->payload, entity);
+				if (result != claim_result::granted && result != claim_result::already_member)
+					WriteLog("net: cannot take " + command->payload + ": " + describe(result), logtype::net);
+
+				command = sequence.erase(command);
+				continue;
+			}
+
 			if (validate_command(Peer, command->command, it->first) != command_verdict::accepted)
 			{
 				command = sequence.erase(command);

--- a/network/session.cpp
+++ b/network/session.cpp
@@ -70,8 +70,7 @@ command_verdict validate_command(PeerId Peer, user_command Command, uint32_t Rec
 
 	if (target == command_target::vehicle)
 	{
-		// a player works the controls of the vehicle they are on, and of no other
-		return Crews.is_member(Peer, (NetworkEntityId)(Recipient & 0xffff)) ? command_verdict::accepted : command_verdict::not_in_crew;
+		return may_control(Peer, (NetworkEntityId)(Recipient & 0xffff)) ? command_verdict::accepted : command_verdict::not_in_crew;
 	}
 
 	if (target == command_target::simulation)
@@ -93,11 +92,24 @@ claim_result claim_by_name(PeerId Peer, std::string const &Vehicle, NetworkEntit
 		return claim_result::unknown_vehicle;
 
 	auto const previous = Crews.vehicle_of(Peer);
+	if (previous == Entity)
+		return claim_result::already_member;
+
+	if ((previous != ENTITY_NONE) && (Entities.consist_of(previous) == Entities.consist_of(Entity)))
+	{
+		// walking to another car of the train you are already working is not a new claim,
+		// so it asks nothing of the capacity. the seat still moves, because which car a
+		// player sits in decides which half they keep when the train comes apart
+		Crews.leave(Peer, previous);
+		Crews.take_seat(Peer, Entity);
+		return claim_result::granted;
+	}
+
 	auto const result = Crews.claim(Peer, Entity);
 
-	if ((result == claim_result::granted) && (previous != ENTITY_NONE) && (previous != Entity))
+	if ((result == claim_result::granted) && (previous != ENTITY_NONE))
 	{
-		// nobody works two vehicles at once
+		// nobody works two trains at once
 		Crews.leave(Peer, previous);
 	}
 
@@ -152,6 +164,21 @@ void filter_commands(PeerId Peer, command_queue::commands_map &Commands)
 	}
 }
 
+bool may_control(PeerId Peer, NetworkEntityId Entity)
+{
+	auto const seat = Crews.vehicle_of(Peer);
+	if (seat == ENTITY_NONE)
+		return false;
+
+	auto const train = Entities.consist_of(Entity);
+	if (train == ENTITY_NONE)
+		return false;
+
+	// the whole set the player is sitting in, so that the desk of a driving trailer works
+	// on the motor cars behind it and the cab switches of a multiple unit go through
+	return Entities.consist_of(seat) == train;
+}
+
 vehicle_crew &crew_registry::entry(NetworkEntityId Id)
 {
 	auto lookup = m_vehicles.find(Id);
@@ -178,7 +205,8 @@ claim_result crew_registry::claim(PeerId Peer, NetworkEntityId Id)
 	if (std::find(vehicle.crew.begin(), vehicle.crew.end(), Peer) != vehicle.crew.end())
 		return claim_result::already_member;
 
-	if (vehicle.crew.size() >= published->crew_capacity)
+	// capacity counts the people on the whole train, not on this one car
+	if (published->crew_count >= published->crew_capacity)
 		return claim_result::crew_full;
 
 	if (vehicle.crew.empty())
@@ -373,6 +401,23 @@ void crew_registry::mirror(NetworkEntityId Id, std::vector<PeerId> const &Crew)
 	entry(Id).crew = Crew;
 }
 
+void crew_registry::take_seat(PeerId Peer, NetworkEntityId Id)
+{
+	auto &vehicle = entry(Id);
+	if (std::find(vehicle.crew.begin(), vehicle.crew.end(), Peer) != vehicle.crew.end())
+		return;
+
+	if (vehicle.crew.empty())
+	{
+		TDynamicObject const *dynamic = Entities.resolve(Id);
+		vehicle.ai_before_claim = (dynamic != nullptr && dynamic->Mechanik != nullptr && dynamic->Mechanik->AIControllFlag);
+		vehicle.ai_restore_pending = false;
+	}
+
+	vehicle.crew.emplace_back(Peer);
+	m_pending.emplace_back(Id);
+}
+
 std::vector<NetworkEntityId> crew_registry::take_pending_updates()
 {
 	std::vector<NetworkEntityId> pending;
@@ -425,6 +470,8 @@ void post_authority_command(user_command Command, uint32_t Recipient, glm::vec3 
 
 // frames to wait before repeating an authority request that has not taken effect yet
 static int const ACTION_COOLDOWN_FRAMES = 30;
+// how many times to ask a vehicle's AI driver to step aside before giving up on it
+static int const AI_HANDOVER_ATTEMPTS = 5;
 
 void crew_registry::reconcile()
 {
@@ -457,10 +504,26 @@ void crew_registry::reconcile()
 
 			if (dynamic->Mechanik != nullptr && dynamic->Mechanik->AIControllFlag)
 			{
-				// first human on board takes over from the AI
-				WriteLog("net: " + dynamic->name() + " taken over from the AI driver", logtype::net);
-				post_authority_command(user_command::aidriverdisable, (uint32_t)command_target::vehicle | train->id(), dynamic->GetPosition(), std::string());
-				vehicle.action_cooldown = ACTION_COOLDOWN_FRAMES;
+				if (vehicle.ai_attempts < AI_HANDOVER_ATTEMPTS)
+				{
+					// first human on board takes over from the AI
+					if (vehicle.ai_attempts == 0)
+						WriteLog("net: " + dynamic->name() + " taken over from the AI driver", logtype::net);
+
+					++vehicle.ai_attempts;
+					post_authority_command(user_command::aidriverdisable, (uint32_t)command_target::vehicle | train->id(), dynamic->GetPosition(), std::string());
+					vehicle.action_cooldown = ACTION_COOLDOWN_FRAMES;
+				}
+				else if (vehicle.ai_attempts == AI_HANDOVER_ATTEMPTS)
+				{
+					// asking again would only fill the log; say so once and leave it
+					++vehicle.ai_attempts;
+					ErrorLog("net: " + dynamic->name() + " will not let go of its AI driver", logtype::net);
+				}
+			}
+			else
+			{
+				vehicle.ai_attempts = 0;
 			}
 			continue;
 		}

--- a/network/session.cpp
+++ b/network/session.cpp
@@ -24,6 +24,19 @@ namespace network
 
 crew_registry Crews;
 
+namespace
+{
+
+// counts up for as long as the session lasts; the number a crew member is stamped with is
+// the whole of their claim to running the train
+uint64_t next_join_stamp()
+{
+	static uint64_t stamp{0};
+	return ++stamp;
+}
+
+} // namespace
+
 std::string describe(claim_result Result)
 {
 	switch (Result)
@@ -185,21 +198,29 @@ PeerId simulation_owner(NetworkEntityId Entity)
 	if (train == ENTITY_NONE)
 		return PEER_HOST;
 
-	// the crew of the lowest numbered car decides, so that every peer works it out the
-	// same way without having to be told
+	// whoever boarded this train first runs it. not the lowest numbered car, not the
+	// newest arrival: the physics has to stay with one person for as long as they are
+	// aboard, because every handover is a stutter in somebody's ride - and the person
+	// who has been driving is the one who would notice it
 	PeerId owner{PEER_NONE};
-	NetworkEntityId lowest{ENTITY_NONE};
+	uint64_t earliest{0};
 
 	for (auto const id : Entities.consist_members(train))
 	{
 		auto const crew = Crews.crew_of(id);
-		if (crew.empty())
-			continue;
+		auto const since = Crews.crew_since_of(id);
 
-		if (lowest == ENTITY_NONE || id < lowest)
+		for (size_t i = 0; i < crew.size(); ++i)
 		{
-			lowest = id;
-			owner = crew.front();
+			// a stamp of zero is a crew we were told about by an older peer, or one that
+			// somehow lost its order; it sorts behind anything stamped properly
+			uint64_t const stamp = (i < since.size() && since[i] != 0 ? since[i] : ~0ull - crew[i]);
+
+			if (owner == PEER_NONE || stamp < earliest)
+			{
+				earliest = stamp;
+				owner = crew[i];
+			}
 		}
 	}
 
@@ -274,6 +295,7 @@ claim_result crew_registry::claim(PeerId Peer, NetworkEntityId Id)
 	}
 
 	vehicle.crew.emplace_back(Peer);
+	vehicle.crew_since.emplace_back(next_join_stamp());
 	m_pending.emplace_back(Id);
 
 	WriteLog("net: peer " + std::to_string(Peer) + " joined the crew of " + published->name + " (" + std::to_string(vehicle.crew.size()) + "/" +
@@ -294,7 +316,10 @@ bool crew_registry::leave(PeerId Peer, NetworkEntityId Id)
 	if (member == crew.end())
 		return false;
 
+	auto const index = (size_t)std::distance(crew.begin(), member);
 	crew.erase(member);
+	if (index < lookup->second.crew_since.size())
+		lookup->second.crew_since.erase(lookup->second.crew_since.begin() + index);
 	m_pending.emplace_back(Id);
 
 	WriteLog("net: peer " + std::to_string(Peer) + " left the crew of " + Entities.name_of(Id) + " (" + std::to_string(crew.size()) + " left)", logtype::net);
@@ -332,6 +357,28 @@ void apply_session_config(int64_t Config)
 
 	Global.FullPhysics = fullphysics;
 	Global.RealisticControlMode = realisticcontrol;
+}
+
+TTrain *ensure_local_cab(TDynamicObject *Vehicle)
+{
+	if (Vehicle == nullptr)
+		return nullptr;
+
+	TTrain *train = simulation::Trains.find(Vehicle->name());
+	if (train != nullptr)
+		return train;
+
+	train = new TTrain();
+	if (false == train->Init(Vehicle))
+	{
+		delete train;
+		ErrorLog("net: could not build a cab for " + Vehicle->name(), logtype::net);
+		return nullptr;
+	}
+
+	simulation::Trains.insert(train);
+
+	return train;
 }
 
 void enforce_session_settings()
@@ -451,9 +498,18 @@ NetworkEntityId crew_registry::vehicle_of(PeerId Peer) const
 	return ENTITY_NONE;
 }
 
-void crew_registry::mirror(NetworkEntityId Id, std::vector<PeerId> const &Crew)
+void crew_registry::mirror(NetworkEntityId Id, std::vector<PeerId> const &Crew, std::vector<uint64_t> const &Since)
 {
-	entry(Id).crew = Crew;
+	auto &vehicle = entry(Id);
+	vehicle.crew = Crew;
+	vehicle.crew_since = Since;
+	vehicle.crew_since.resize(Crew.size(), 0);
+}
+
+std::vector<uint64_t> crew_registry::crew_since_of(NetworkEntityId Id) const
+{
+	auto const lookup = m_vehicles.find(Id);
+	return lookup != m_vehicles.end() ? lookup->second.crew_since : std::vector<uint64_t>();
 }
 
 void crew_registry::take_seat(PeerId Peer, NetworkEntityId Id)
@@ -470,6 +526,7 @@ void crew_registry::take_seat(PeerId Peer, NetworkEntityId Id)
 	}
 
 	vehicle.crew.emplace_back(Peer);
+	vehicle.crew_since.emplace_back(next_join_stamp());
 	m_pending.emplace_back(Id);
 }
 
@@ -550,11 +607,15 @@ void crew_registry::reconcile()
 		{
 			if (train == nullptr)
 			{
-				// the cab has to exist on every peer, so the authority asks for it with the
-				// ordinary replicated command instead of building it locally
-				post_authority_command(user_command::entervehicle, (uint32_t)command_target::simulation, dynamic->GetPosition(), dynamic->name());
-				vehicle.action_cooldown = ACTION_COOLDOWN_FRAMES;
-				continue;
+				// the authority needs a cab of its own to address the AI commands to. it
+				// is built here and not replicated: a cab belongs to the peer it is on,
+				// and every peer that is actually aboard builds its own
+				train = ensure_local_cab(dynamic);
+				if (train == nullptr)
+				{
+					vehicle.action_cooldown = ACTION_COOLDOWN_FRAMES;
+					continue;
+				}
 			}
 
 			if (dynamic->Mechanik != nullptr && dynamic->Mechanik->AIControllFlag)

--- a/network/session.cpp
+++ b/network/session.cpp
@@ -1,0 +1,266 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "network/session.h"
+
+#include "input/command.h"
+#include "simulation/simulation.h"
+#include "utilities/Globals.h"
+#include "utilities/Logs.h"
+#include "utilities/Timer.h"
+#include "vehicle/Driver.h"
+#include "vehicle/DynObj.h"
+#include "vehicle/Train.h"
+
+namespace network
+{
+
+crew_registry Crews;
+
+std::string describe(claim_result Result)
+{
+	switch (Result)
+	{
+	case claim_result::granted:
+		return "granted";
+	case claim_result::already_member:
+		return "already a crew member";
+	case claim_result::unknown_vehicle:
+		return "no such vehicle in this session";
+	case claim_result::vehicle_missing:
+		return "the vehicle is not present in the scenario";
+	case claim_result::crew_full:
+		return "the crew of this vehicle is full";
+	}
+	return "unknown";
+}
+
+vehicle_crew &crew_registry::entry(NetworkEntityId Id)
+{
+	auto lookup = m_vehicles.find(Id);
+	if (lookup == m_vehicles.end())
+	{
+		vehicle_crew fresh;
+		fresh.entity_id = Id;
+		lookup = m_vehicles.emplace(Id, fresh).first;
+	}
+	return lookup->second;
+}
+
+claim_result crew_registry::claim(PeerId Peer, NetworkEntityId Id)
+{
+	vehicle_entry const *published = Entities.find(Id);
+	if (published == nullptr)
+		return claim_result::unknown_vehicle;
+
+	if (Entities.resolve(Id) == nullptr)
+		return claim_result::vehicle_missing;
+
+	vehicle_crew &vehicle = entry(Id);
+
+	if (std::find(vehicle.crew.begin(), vehicle.crew.end(), Peer) != vehicle.crew.end())
+		return claim_result::already_member;
+
+	if (vehicle.crew.size() >= published->crew_capacity)
+		return claim_result::crew_full;
+
+	if (vehicle.crew.empty())
+	{
+		// remember whether this vehicle was actually being driven by the AI, so that it is
+		// handed back only to a driver that was really there before
+		TDynamicObject const *dynamic = Entities.resolve(Id);
+		vehicle.ai_before_claim = (dynamic != nullptr && dynamic->Mechanik != nullptr && dynamic->Mechanik->AIControllFlag);
+		vehicle.ai_restore_pending = false;
+	}
+
+	vehicle.crew.emplace_back(Peer);
+	m_pending.emplace_back(Id);
+
+	WriteLog("net: peer " + std::to_string(Peer) + " joined the crew of " + published->name + " (" + std::to_string(vehicle.crew.size()) + "/" +
+	             std::to_string((int)published->crew_capacity) + ")",
+	         logtype::net);
+
+	return claim_result::granted;
+}
+
+bool crew_registry::leave(PeerId Peer, NetworkEntityId Id)
+{
+	auto lookup = m_vehicles.find(Id);
+	if (lookup == m_vehicles.end())
+		return false;
+
+	auto &crew = lookup->second.crew;
+	auto member = std::find(crew.begin(), crew.end(), Peer);
+	if (member == crew.end())
+		return false;
+
+	crew.erase(member);
+	m_pending.emplace_back(Id);
+
+	WriteLog("net: peer " + std::to_string(Peer) + " left the crew of " + Entities.name_of(Id) + " (" + std::to_string(crew.size()) + " left)", logtype::net);
+
+	if (crew.empty() && lookup->second.ai_before_claim)
+	{
+		// the vehicle came with an AI driver, so it gets one back
+		lookup->second.ai_restore_pending = true;
+	}
+
+	return true;
+}
+
+void crew_registry::drop_peer(PeerId Peer)
+{
+	for (auto &pair : m_vehicles)
+	{
+		if (std::find(pair.second.crew.begin(), pair.second.crew.end(), Peer) != pair.second.crew.end())
+			leave(Peer, pair.first);
+	}
+}
+
+std::vector<PeerId> crew_registry::crew_of(NetworkEntityId Id) const
+{
+	auto const lookup = m_vehicles.find(Id);
+	return lookup != m_vehicles.end() ? lookup->second.crew : std::vector<PeerId>();
+}
+
+bool crew_registry::is_member(PeerId Peer, NetworkEntityId Id) const
+{
+	auto const lookup = m_vehicles.find(Id);
+	if (lookup == m_vehicles.end())
+		return false;
+	return std::find(lookup->second.crew.begin(), lookup->second.crew.end(), Peer) != lookup->second.crew.end();
+}
+
+uint8_t crew_registry::count(NetworkEntityId Id) const
+{
+	auto const lookup = m_vehicles.find(Id);
+	return lookup != m_vehicles.end() ? (uint8_t)lookup->second.crew.size() : (uint8_t)0;
+}
+
+NetworkEntityId crew_registry::vehicle_of(PeerId Peer) const
+{
+	for (auto const &pair : m_vehicles)
+	{
+		if (std::find(pair.second.crew.begin(), pair.second.crew.end(), Peer) != pair.second.crew.end())
+			return pair.first;
+	}
+	return ENTITY_NONE;
+}
+
+void crew_registry::mirror(NetworkEntityId Id, std::vector<PeerId> const &Crew)
+{
+	entry(Id).crew = Crew;
+}
+
+std::vector<NetworkEntityId> crew_registry::take_pending_updates()
+{
+	std::vector<NetworkEntityId> pending;
+	pending.swap(m_pending);
+
+	// the same vehicle can change more than once between two publications
+	std::sort(pending.begin(), pending.end());
+	pending.erase(std::unique(pending.begin(), pending.end()), pending.end());
+
+	return pending;
+}
+
+void crew_registry::mark_all_pending()
+{
+	for (auto const &pair : m_vehicles)
+	{
+		if (!pair.second.crew.empty())
+			m_pending.emplace_back(pair.first);
+	}
+}
+
+void crew_registry::clear()
+{
+	m_vehicles.clear();
+	m_pending.clear();
+}
+
+namespace
+{
+
+// posts a command the way an input source would, but without going through command_relay:
+// the authority acts on behalf of the session, not on behalf of the local camera, so it
+// must not be filtered by the local free fly state
+void post_authority_command(user_command Command, uint32_t Recipient, glm::vec3 const &Location, std::string const &Payload)
+{
+	command_data data;
+	data.command = Command;
+	data.action = GLFW_PRESS;
+	data.param1 = 0.0;
+	data.param2 = 0.0;
+	data.time_delta = Timer::GetDeltaTime();
+	data.freefly = true;
+	data.location = Location;
+	data.payload = Payload;
+
+	simulation::Commands.push(data, Recipient);
+}
+
+} // namespace
+
+// frames to wait before repeating an authority request that has not taken effect yet
+static int const ACTION_COOLDOWN_FRAMES = 30;
+
+void crew_registry::reconcile()
+{
+	for (auto &pair : m_vehicles)
+	{
+		vehicle_crew &vehicle = pair.second;
+
+		TDynamicObject *dynamic = Entities.resolve(vehicle.entity_id);
+		if (dynamic == nullptr)
+			continue;
+
+		if (vehicle.action_cooldown > 0)
+		{
+			--vehicle.action_cooldown;
+			continue;
+		}
+
+		TTrain *train = simulation::Trains.find(dynamic->name());
+
+		if (!vehicle.crew.empty())
+		{
+			if (train == nullptr)
+			{
+				// the cab has to exist on every peer, so the authority asks for it with the
+				// ordinary replicated command instead of building it locally
+				post_authority_command(user_command::entervehicle, (uint32_t)command_target::simulation, dynamic->GetPosition(), dynamic->name());
+				vehicle.action_cooldown = ACTION_COOLDOWN_FRAMES;
+				continue;
+			}
+
+			if (dynamic->Mechanik != nullptr && dynamic->Mechanik->AIControllFlag)
+			{
+				// first human on board takes over from the AI
+				WriteLog("net: " + dynamic->name() + " taken over from the AI driver", logtype::net);
+				post_authority_command(user_command::aidriverdisable, (uint32_t)command_target::vehicle | train->id(), dynamic->GetPosition(), std::string());
+				vehicle.action_cooldown = ACTION_COOLDOWN_FRAMES;
+			}
+			continue;
+		}
+
+		if (vehicle.ai_restore_pending && train != nullptr)
+		{
+			// aidriverenable resets the driver, so it must happen exactly once
+			vehicle.ai_restore_pending = false;
+			vehicle.ai_before_claim = false;
+			WriteLog("net: handing " + dynamic->name() + " back to the AI driver", logtype::net);
+			post_authority_command(user_command::aidriverenable, (uint32_t)command_target::vehicle | train->id(), dynamic->GetPosition(), std::string());
+			vehicle.action_cooldown = ACTION_COOLDOWN_FRAMES;
+		}
+	}
+}
+
+} // namespace network

--- a/network/session.cpp
+++ b/network/session.cpp
@@ -179,6 +179,61 @@ bool may_control(PeerId Peer, NetworkEntityId Entity)
 	return Entities.consist_of(seat) == train;
 }
 
+PeerId simulation_owner(NetworkEntityId Entity)
+{
+	auto const train = Entities.consist_of(Entity);
+	if (train == ENTITY_NONE)
+		return PEER_HOST;
+
+	// the crew of the lowest numbered car decides, so that every peer works it out the
+	// same way without having to be told
+	PeerId owner{PEER_NONE};
+	NetworkEntityId lowest{ENTITY_NONE};
+
+	for (auto const id : Entities.consist_members(train))
+	{
+		auto const crew = Crews.crew_of(id);
+		if (crew.empty())
+			continue;
+
+		if (lowest == ENTITY_NONE || id < lowest)
+		{
+			lowest = id;
+			owner = crew.front();
+		}
+	}
+
+	return owner != PEER_NONE ? owner : PEER_HOST;
+}
+
+bool is_locally_simulated(NetworkEntityId Entity)
+{
+	auto const self = (Global.network_peer_id != PEER_NONE ? Global.network_peer_id : PEER_HOST);
+	return simulation_owner(Entity) == self;
+}
+
+bool is_predictable(uint32_t Recipient)
+{
+	if ((command_target)(Recipient & ~0xffff) != command_target::vehicle)
+		return false;
+
+	auto const entity = (NetworkEntityId)(Recipient & 0xffff);
+	return is_locally_simulated(entity) && may_control(Global.network_peer_id, entity);
+}
+
+void collect_predictable(command_queue::commands_map const &Commands, command_queue::commands_map &Predicted)
+{
+	for (auto const &kv : Commands)
+	{
+		if (!is_predictable(kv.first))
+			continue;
+
+		auto lookup = Predicted.emplace(kv.first, command_queue::commanddata_sequence());
+		for (auto const &data : kv.second)
+			lookup.first->second.emplace_back(data);
+	}
+}
+
 vehicle_crew &crew_registry::entry(NetworkEntityId Id)
 {
 	auto lookup = m_vehicles.find(Id);

--- a/network/session.cpp
+++ b/network/session.cpp
@@ -184,6 +184,73 @@ bool crew_registry::leave(PeerId Peer, NetworkEntityId Id)
 	return true;
 }
 
+PeerId resolve_peer_identity(uint64_t &Token)
+{
+	static std::unordered_map<uint64_t, PeerId> known;
+
+	if (Token != 0)
+	{
+		auto const lookup = known.find(Token);
+		if (lookup != known.end())
+		{
+			WriteLog("net: peer " + std::to_string(lookup->second) + " recognised, reconnecting", logtype::net);
+			Crews.resume_peer(lookup->second);
+			return lookup->second;
+		}
+	}
+
+	auto const peer = allocate_peer_id();
+
+	// only has to be hard to collide with, not hard to guess: it decides who is who
+	// across a dropped connection, nothing more
+	Token = ((uint64_t)Global.local_random_engine() << 32) ^ (uint64_t)Global.local_random_engine() ^ ((uint64_t)peer << 8);
+	if (Token == 0)
+		Token = peer;
+
+	known.emplace(Token, peer);
+
+	return peer;
+}
+
+void crew_registry::suspend_peer(PeerId Peer)
+{
+	if (vehicle_of(Peer) == ENTITY_NONE)
+		return;
+
+	m_absent[Peer] = Timer::GetTime() + RECONNECT_GRACE_SECONDS;
+
+	WriteLog("net: peer " + std::to_string(Peer) + " lost its connection, holding its seat for " + std::to_string((int)RECONNECT_GRACE_SECONDS) + " s", logtype::net);
+}
+
+void crew_registry::resume_peer(PeerId Peer)
+{
+	m_absent.erase(Peer);
+}
+
+bool crew_registry::is_absent(PeerId Peer) const
+{
+	return m_absent.find(Peer) != m_absent.end();
+}
+
+void crew_registry::expire_absences()
+{
+	auto const now = Timer::GetTime();
+
+	for (auto it = m_absent.begin(); it != m_absent.end();)
+	{
+		if (now < it->second)
+		{
+			++it;
+			continue;
+		}
+
+		WriteLog("net: peer " + std::to_string(it->first) + " did not come back, giving up its seat", logtype::net);
+		auto const peer = it->first;
+		it = m_absent.erase(it);
+		drop_peer(peer);
+	}
+}
+
 void crew_registry::drop_peer(PeerId Peer)
 {
 	for (auto &pair : m_vehicles)

--- a/network/session.cpp
+++ b/network/session.cpp
@@ -42,6 +42,75 @@ std::string describe(claim_result Result)
 	return "unknown";
 }
 
+std::string describe(command_verdict Verdict)
+{
+	switch (Verdict)
+	{
+	case command_verdict::accepted:
+		return "accepted";
+	case command_verdict::not_in_crew:
+		return "not a member of the crew of that vehicle";
+	case command_verdict::privileged:
+		return "reserved for the session host";
+	case command_verdict::unsupported_target:
+		return "command target not allowed over the network";
+	}
+	return "unknown";
+}
+
+command_verdict validate_command(PeerId Peer, user_command Command, uint32_t Recipient)
+{
+	if (Peer == PEER_HOST)
+	{
+		// the host runs the session and holds every right in it
+		return command_verdict::accepted;
+	}
+
+	auto const target = (command_target)(Recipient & ~0xffff);
+
+	if (target == command_target::vehicle)
+	{
+		// a player works the controls of the vehicle they are on, and of no other
+		return Crews.is_member(Peer, (NetworkEntityId)(Recipient & 0xffff)) ? command_verdict::accepted : command_verdict::not_in_crew;
+	}
+
+	if (target == command_target::simulation)
+	{
+		// setweather, setdatetime, spawntrainset, destroytrainset, queueevent, the pause
+		// and the debug commands all reach the whole world, so they stay with the authority.
+		// TODO: open a subset of them once dispatcher and admin roles exist
+		(void)Command;
+		return command_verdict::privileged;
+	}
+
+	return command_verdict::unsupported_target;
+}
+
+void filter_commands(PeerId Peer, command_queue::commands_map &Commands)
+{
+	for (auto it = Commands.begin(); it != Commands.end();)
+	{
+		auto &sequence = it->second;
+
+		for (auto command = sequence.begin(); command != sequence.end();)
+		{
+			if (validate_command(Peer, command->command, it->first) != command_verdict::accepted)
+			{
+				command = sequence.erase(command);
+				continue;
+			}
+
+			command->source = Peer;
+			++command;
+		}
+
+		if (sequence.empty())
+			it = Commands.erase(it);
+		else
+			++it;
+	}
+}
+
 vehicle_crew &crew_registry::entry(NetworkEntityId Id)
 {
 	auto lookup = m_vehicles.find(Id);

--- a/network/session.cpp
+++ b/network/session.cpp
@@ -184,6 +184,43 @@ bool crew_registry::leave(PeerId Peer, NetworkEntityId Id)
 	return true;
 }
 
+int64_t pack_session_config()
+{
+	int64_t config{0};
+
+	if (Global.FullPhysics)
+		config |= CONFIG_FULLPHYSICS;
+	if (Global.RealisticControlMode)
+		config |= CONFIG_REALISTICCONTROL;
+
+	return config;
+}
+
+void apply_session_config(int64_t Config)
+{
+	bool const fullphysics{(Config & CONFIG_FULLPHYSICS) != 0};
+	bool const realisticcontrol{(Config & CONFIG_REALISTICCONTROL) != 0};
+
+	if (Global.FullPhysics != fullphysics)
+		WriteLog(std::string("net: the session runs with full physics ") + (fullphysics ? "on" : "off"), logtype::net);
+	if (Global.RealisticControlMode != realisticcontrol)
+		WriteLog(std::string("net: the session runs with realistic control ") + (realisticcontrol ? "on" : "off"), logtype::net);
+
+	Global.FullPhysics = fullphysics;
+	Global.RealisticControlMode = realisticcontrol;
+}
+
+void enforce_session_settings()
+{
+	if (Global.trainThreads != 0)
+	{
+		// the order vehicles are stepped in must not depend on how threads happen to be
+		// scheduled; a session cannot afford that kind of drift
+		WriteLog("net: multiplayer session, running the vehicle physics on one thread", logtype::net);
+		Global.trainThreads = 0;
+	}
+}
+
 PeerId resolve_peer_identity(uint64_t &Token)
 {
 	static std::unordered_map<uint64_t, PeerId> known;

--- a/network/session.cpp
+++ b/network/session.cpp
@@ -120,10 +120,12 @@ void filter_commands(PeerId Peer, command_queue::commands_map &Commands)
 				continue;
 			}
 
-			if (command->command == user_command::entervehicle)
+			if ((command->command == user_command::entervehicle) && (Entities.id_of(command->payload) != ENTITY_NONE))
 			{
 				// the local player walked into a cab. that is a crew request; the cab
-				// itself is built by the authority once the seat is granted
+				// itself is built by the authority once the seat is granted.
+				// a vehicle the session does not list falls through to the ordinary path,
+				// so a scenario that starts its host in something unusual still works
 				NetworkEntityId entity{ENTITY_NONE};
 				auto const result = claim_by_name(Peer, command->payload, entity);
 				if (result != claim_result::granted && result != claim_result::already_member)

--- a/network/session.h
+++ b/network/session.h
@@ -138,6 +138,11 @@ std::string describe(command_verdict Verdict);
 // simply holds every right - there is no separate path for the local participant
 command_verdict validate_command(PeerId Peer, user_command Command, uint32_t Recipient);
 
+// walking into a cab with the in-game key is the same request as pressing the button in
+// the lobby, so it goes through the crew registry rather than being treated as a command
+// that reaches the whole world. returns the vehicle it resolved to, if any
+claim_result claim_by_name(PeerId Peer, std::string const &Vehicle, NetworkEntityId &Entity);
+
 // drops everything the peer is not allowed to ask for and stamps the rest with its
 // identity. used for the local participant as well, so that host input goes through the
 // very same authority layer as input arriving over the wire, only without the transport

--- a/network/session.h
+++ b/network/session.h
@@ -1,0 +1,90 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include "network/entities.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace network
+{
+
+// who is working on a given vehicle. a vehicle can hold more than one person, which is
+// the whole point of the crew model - the container is not limited by design, only by
+// the capacity the server advertises
+struct vehicle_crew
+{
+	NetworkEntityId entity_id{ENTITY_NONE};
+	std::vector<PeerId> crew;
+	// whether the AI was actually driving before the first human arrived. a vehicle that
+	// nobody was driving must not suddenly acquire an AI driver when its crew leaves
+	bool ai_before_claim{false};
+	// set on the 1 -> 0 transition, cleared once the AI has been handed the vehicle back
+	bool ai_restore_pending{false};
+	// keeps reconcile() from re-posting the same request every single frame while the
+	// previous one is still on its way through the command queue
+	int action_cooldown{0};
+};
+
+enum class claim_result
+{
+	granted,
+	already_member,
+	unknown_vehicle,
+	vehicle_missing,
+	crew_full
+};
+
+std::string describe(claim_result Result);
+
+// crew bookkeeping. authoritative on the server; on a client this is a read only mirror
+// fed by CREW_UPDATE, used by the lobby
+class crew_registry
+{
+public:
+	claim_result claim(PeerId Peer, NetworkEntityId Id);
+	// returns true when the peer really was part of the crew
+	bool leave(PeerId Peer, NetworkEntityId Id);
+	// removes a peer from every crew it belonged to, e.g. after a disconnect
+	void drop_peer(PeerId Peer);
+
+	std::vector<PeerId> crew_of(NetworkEntityId Id) const;
+	bool is_member(PeerId Peer, NetworkEntityId Id) const;
+	uint8_t count(NetworkEntityId Id) const;
+	NetworkEntityId vehicle_of(PeerId Peer) const;
+
+	// client side: takes over the crew of one vehicle as published by the server
+	void mirror(NetworkEntityId Id, std::vector<PeerId> const &Crew);
+
+	// server side: brings the world in line with the crew roster - creates the cab of a
+	// claimed vehicle, hands the vehicle over from the AI and hands it back when the last
+	// person leaves. safe to call every frame, it only acts when something is out of place
+	void reconcile();
+
+	// ids whose crew changed since the last call
+	std::vector<NetworkEntityId> take_pending_updates();
+	// queues every crew for republication, so that a peer which just went active learns
+	// about the vehicles that were taken over before it arrived
+	void mark_all_pending();
+
+	void clear();
+
+private:
+	vehicle_crew &entry(NetworkEntityId Id);
+
+	std::unordered_map<NetworkEntityId, vehicle_crew> m_vehicles;
+	std::vector<NetworkEntityId> m_pending;
+};
+
+extern crew_registry Crews;
+
+} // namespace network

--- a/network/session.h
+++ b/network/session.h
@@ -34,6 +34,9 @@ struct vehicle_crew
 	// keeps reconcile() from re-posting the same request every single frame while the
 	// previous one is still on its way through the command queue
 	int action_cooldown{0};
+	// how many times we have asked the AI to hand this vehicle over. if it will not, that
+	// is worth saying once rather than asking forever
+	int ai_attempts{0};
 };
 
 enum class claim_result
@@ -74,6 +77,9 @@ public:
 
 	// client side: takes over the crew of one vehicle as published by the server
 	void mirror(NetworkEntityId Id, std::vector<PeerId> const &Crew);
+	// puts a peer on a vehicle without asking about capacity; used when somebody walks to
+	// another car of the train they are already working
+	void take_seat(PeerId Peer, NetworkEntityId Id);
 
 	// server side: brings the world in line with the crew roster - creates the cab of a
 	// claimed vehicle, hands the vehicle over from the AI and hands it back when the last
@@ -137,6 +143,10 @@ std::string describe(command_verdict Verdict);
 // the whole of the authority check for an incoming command. the host passes it too, it
 // simply holds every right - there is no separate path for the local participant
 command_verdict validate_command(PeerId Peer, user_command Command, uint32_t Recipient);
+
+// a player works a train, not a single car: they may operate anything coupled into the
+// set they are sitting in, which is what makes the cab switches of a multiple unit work
+bool may_control(PeerId Peer, NetworkEntityId Entity);
 
 // walking into a cab with the in-game key is the same request as pressing the button in
 // the lobby, so it goes through the crew registry rather than being treated as a command

--- a/network/session.h
+++ b/network/session.h
@@ -10,6 +10,7 @@ http://mozilla.org/MPL/2.0/.
 #pragma once
 
 #include "network/entities.h"
+#include "input/command.h"
 
 #include <string>
 #include <unordered_map>
@@ -86,5 +87,25 @@ private:
 };
 
 extern crew_registry Crews;
+
+// what a peer is allowed to ask the simulation for
+enum class command_verdict
+{
+	accepted,
+	not_in_crew,
+	privileged,
+	unsupported_target
+};
+
+std::string describe(command_verdict Verdict);
+
+// the whole of the authority check for an incoming command. the host passes it too, it
+// simply holds every right - there is no separate path for the local participant
+command_verdict validate_command(PeerId Peer, user_command Command, uint32_t Recipient);
+
+// drops everything the peer is not allowed to ask for and stamps the rest with its
+// identity. used for the local participant as well, so that host input goes through the
+// very same authority layer as input arriving over the wire, only without the transport
+void filter_commands(PeerId Peer, command_queue::commands_map &Commands);
 
 } // namespace network

--- a/network/session.h
+++ b/network/session.h
@@ -55,8 +55,17 @@ public:
 	claim_result claim(PeerId Peer, NetworkEntityId Id);
 	// returns true when the peer really was part of the crew
 	bool leave(PeerId Peer, NetworkEntityId Id);
-	// removes a peer from every crew it belonged to, e.g. after a disconnect
+	// removes a peer from every crew it belonged to
 	void drop_peer(PeerId Peer);
+	// the peer lost its connection. its seat is held for a while, so that a short dropout
+	// does not empty a cab and hand a vehicle back to the AI under the other driver's nose
+	void suspend_peer(PeerId Peer);
+	// the peer made it back in time and keeps everything it had
+	void resume_peer(PeerId Peer);
+	// actually removes the peers whose grace period ran out
+	void expire_absences();
+	// true while the peer is gone but still holding its seat
+	bool is_absent(PeerId Peer) const;
 
 	std::vector<PeerId> crew_of(NetworkEntityId Id) const;
 	bool is_member(PeerId Peer, NetworkEntityId Id) const;
@@ -84,9 +93,20 @@ private:
 
 	std::unordered_map<NetworkEntityId, vehicle_crew> m_vehicles;
 	std::vector<NetworkEntityId> m_pending;
+	// peers that dropped out, with the moment their seat stops being held
+	std::unordered_map<PeerId, double> m_absent;
 };
 
 extern crew_registry Crews;
+
+// how long a disconnected peer keeps its place in the crew
+constexpr double RECONNECT_GRACE_SECONDS = 60.0;
+
+// resolves the identity of a connecting peer. an unknown or empty token means somebody
+// new and gets a fresh peer id together with a token of their own; a token this server
+// handed out before brings back the peer id that went with it, and with it the seat in
+// whatever crew the peer was on
+PeerId resolve_peer_identity(uint64_t &Token);
 
 // what a peer is allowed to ask the simulation for
 enum class command_verdict

--- a/network/session.h
+++ b/network/session.h
@@ -148,6 +148,19 @@ command_verdict validate_command(PeerId Peer, user_command Command, uint32_t Rec
 // set they are sitting in, which is what makes the cab switches of a multiple unit work
 bool may_control(PeerId Peer, NetworkEntityId Entity);
 
+// whose machine actually runs the physics of a given train. the first person aboard does,
+// so their own train moves smoothly for them and only its result travels to the others;
+// a train with nobody in it is run by the host
+PeerId simulation_owner(NetworkEntityId Entity);
+// true when this peer is the one running it, and therefore must not have it corrected
+bool is_locally_simulated(NetworkEntityId Entity);
+// true for a command this peer may carry out at once instead of waiting for the round
+// trip: it addresses a train this peer both runs and is allowed to work
+bool is_predictable(uint32_t Recipient);
+// copies out of Commands everything that qualifies, leaving the original alone - it still
+// has to reach the server so that everybody else sees it
+void collect_predictable(command_queue::commands_map const &Commands, command_queue::commands_map &Predicted);
+
 // walking into a cab with the in-game key is the same request as pressing the button in
 // the lobby, so it goes through the crew registry rather than being treated as a command
 // that reaches the whole world. returns the vehicle it resolved to, if any

--- a/network/session.h
+++ b/network/session.h
@@ -16,6 +16,9 @@ http://mozilla.org/MPL/2.0/.
 #include <unordered_map>
 #include <vector>
 
+class TDynamicObject;
+class TTrain;
+
 namespace network
 {
 
@@ -26,6 +29,11 @@ struct vehicle_crew
 {
 	NetworkEntityId entity_id{ENTITY_NONE};
 	std::vector<PeerId> crew;
+	// when each of them sat down, on a counter that runs across the whole session. this
+	// is what settles who runs the physics of a shared train: the one who got there first
+	// keeps it, so their ride stays smooth and nobody's authority changes under them when
+	// somebody else joins or the consist is renumbered
+	std::vector<uint64_t> crew_since;
 	// whether the AI was actually driving before the first human arrived. a vehicle that
 	// nobody was driving must not suddenly acquire an AI driver when its crew leaves
 	bool ai_before_claim{false};
@@ -76,7 +84,9 @@ public:
 	NetworkEntityId vehicle_of(PeerId Peer) const;
 
 	// client side: takes over the crew of one vehicle as published by the server
-	void mirror(NetworkEntityId Id, std::vector<PeerId> const &Crew);
+	void mirror(NetworkEntityId Id, std::vector<PeerId> const &Crew, std::vector<uint64_t> const &Since);
+	// the join stamps of a crew, in the same order as crew_of()
+	std::vector<uint64_t> crew_since_of(NetworkEntityId Id) const;
 	// puts a peer on a vehicle without asking about capacity; used when somebody walks to
 	// another car of the train they are already working
 	void take_seat(PeerId Peer, NetworkEntityId Id);
@@ -170,5 +180,12 @@ claim_result claim_by_name(PeerId Peer, std::string const &Vehicle, NetworkEntit
 // identity. used for the local participant as well, so that host input goes through the
 // very same authority layer as input arriving over the wire, only without the transport
 void filter_commands(PeerId Peer, command_queue::commands_map &Commands);
+
+// makes sure this peer has a cab instance for a vehicle, building one if it has none.
+// the cab is a local object - each participant has their own, with their own camera and
+// their own view - so it is never replicated: the second person to board a train finds
+// the cab already built on the peer that got there first and would otherwise wait for a
+// command that is never coming
+TTrain *ensure_local_cab(TDynamicObject *Vehicle);
 
 } // namespace network

--- a/network/session.h
+++ b/network/session.h
@@ -102,6 +102,21 @@ extern crew_registry Crews;
 // how long a disconnected peer keeps its place in the crew
 constexpr double RECONNECT_GRACE_SECONDS = 60.0;
 
+// settings the server imposes on everybody, carried in the handshake. only things that
+// change how the physics comes out belong here - looks and comfort stay with the player
+enum session_config_flags : int64_t
+{
+	CONFIG_FULLPHYSICS = 1 << 0,
+	CONFIG_REALISTICCONTROL = 1 << 1
+};
+
+// packs the settings this machine is running, for the server to hand out
+int64_t pack_session_config();
+// takes on the settings the server handed us
+void apply_session_config(int64_t Config);
+// settings a session needs regardless of who set what, applied on every peer
+void enforce_session_settings();
+
 // resolves the identity of a connecting peer. an unknown or empty token means somebody
 // new and gets a fresh peer id together with a token of their own; a token this server
 // handed out before brings back the peer id that went with it, and with it the seat in

--- a/network/snapshot.cpp
+++ b/network/snapshot.cpp
@@ -38,6 +38,45 @@ double const REPOSITION_TOLERANCE_CORRECTION{2.5};
 // ---------------------------------------------------------------------------
 // what the authority last sent, so that a routine correction only carries changes
 
+// most tracks in a scenery carry no name at all, so a name is useless as an identity.
+// their order in the path table comes straight from the scenery file and is therefore the
+// same on every peer, which makes the index a usable one
+std::vector<TTrack *> g_trackindex;
+std::unordered_map<TTrack const *, uint32_t> g_trackids;
+
+void refresh_track_index()
+{
+	auto const &paths = simulation::Paths.sequence();
+	if (g_trackindex.size() == paths.size())
+		return;
+
+	g_trackindex.assign(paths.begin(), paths.end());
+	g_trackids.clear();
+	for (uint32_t i = 0; i < g_trackindex.size(); ++i)
+	{
+		if (g_trackindex[i] != nullptr)
+			g_trackids.emplace(g_trackindex[i], i);
+	}
+}
+
+uint32_t track_id_of(TTrack const *Track)
+{
+	if (Track == nullptr)
+		return 0xffffffff;
+
+	refresh_track_index();
+
+	auto const lookup = g_trackids.find(Track);
+	return lookup != g_trackids.end() ? lookup->second : 0xffffffff;
+}
+
+TTrack *track_by_id(uint32_t const Id)
+{
+	refresh_track_index();
+
+	return (Id < g_trackindex.size() ? g_trackindex[Id] : nullptr);
+}
+
 std::unordered_map<std::string, uint64_t> g_lastvehicles;
 std::unordered_map<std::string, uint64_t> g_lastmemcells;
 std::unordered_map<std::string, int> g_lastswitches;
@@ -137,7 +176,7 @@ void read_session(std::istream &Stream, network::snapshot_mode const Mode)
 struct vehicle_state
 {
 	std::string name;
-	std::string track;
+	uint32_t track{0xffffffff};
 	double translation{0.0};
 	uint8_t axlefirst{0};
 	uint8_t direction{0};
@@ -164,8 +203,6 @@ struct vehicle_state
 	bool battery{false};
 	bool converterallow{false};
 	bool compressorallow{false};
-	int32_t cabactive{0};
-	int32_t caboccupied{0};
 	std::array<bool, 2> pantenabled{{false, false}};
 	std::array<bool, 2> pantdisabled{{false, false}};
 	std::array<bool, 2> pantactive{{false, false}};
@@ -179,7 +216,7 @@ struct vehicle_state
 void serialize_vehicle(std::ostream &Stream, vehicle_state const &State)
 {
 	sn_utils::s_str(Stream, State.name);
-	sn_utils::s_str(Stream, State.track);
+	sn_utils::ls_uint32(Stream, State.track);
 	sn_utils::ls_float64(Stream, State.translation);
 	sn_utils::s_uint8(Stream, State.axlefirst);
 	sn_utils::s_uint8(Stream, State.direction);
@@ -204,8 +241,6 @@ void serialize_vehicle(std::ostream &Stream, vehicle_state const &State)
 	sn_utils::s_bool(Stream, State.battery);
 	sn_utils::s_bool(Stream, State.converterallow);
 	sn_utils::s_bool(Stream, State.compressorallow);
-	sn_utils::ls_int32(Stream, State.cabactive);
-	sn_utils::ls_int32(Stream, State.caboccupied);
 	for (int i = 0; i < 2; ++i)
 	{
 		sn_utils::s_bool(Stream, State.pantenabled[i]);
@@ -227,7 +262,7 @@ vehicle_state deserialize_vehicle(std::istream &Stream)
 	vehicle_state state;
 
 	state.name = sn_utils::d_str(Stream);
-	state.track = sn_utils::d_str(Stream);
+	state.track = sn_utils::ld_uint32(Stream);
 	state.translation = sn_utils::ld_float64(Stream);
 	state.axlefirst = sn_utils::d_uint8(Stream);
 	state.direction = sn_utils::d_uint8(Stream);
@@ -252,8 +287,6 @@ vehicle_state deserialize_vehicle(std::istream &Stream)
 	state.battery = sn_utils::d_bool(Stream);
 	state.converterallow = sn_utils::d_bool(Stream);
 	state.compressorallow = sn_utils::d_bool(Stream);
-	state.cabactive = sn_utils::ld_int32(Stream);
-	state.caboccupied = sn_utils::ld_int32(Stream);
 	for (int i = 0; i < 2; ++i)
 	{
 		state.pantenabled[i] = sn_utils::d_bool(Stream);
@@ -279,7 +312,7 @@ vehicle_state read_from(TDynamicObject const &Vehicle)
 
 	vehicle_state state;
 	state.name = Vehicle.name();
-	state.track = (track != nullptr ? track->name() : std::string());
+	state.track = track_id_of(track);
 	state.translation = Vehicle.RaTranslationGet();
 	state.axlefirst = (uint8_t)(Vehicle.iAxleFirst ? 1 : 0);
 	state.direction = (uint8_t)(Vehicle.iDirection ? 1 : 0);
@@ -304,8 +337,6 @@ vehicle_state read_from(TDynamicObject const &Vehicle)
 	state.battery = mover.Battery;
 	state.converterallow = mover.ConverterAllow;
 	state.compressorallow = mover.CompressorAllow;
-	state.cabactive = mover.CabActive;
-	state.caboccupied = mover.CabOccupied;
 	for (int i = 0; i < 2; ++i)
 	{
 		state.pantenabled[i] = mover.Pantographs[i].valve.is_enabled;
@@ -324,19 +355,41 @@ vehicle_state read_from(TDynamicObject const &Vehicle)
 	return state;
 }
 
+// true for the train the local player is working. its controls are driven by the commands
+// its crew issue, which every peer already receives, so the correction must keep its hands
+// off them - otherwise it keeps snapping a lever back a fraction of a second after the
+// player moved it, and the control looks broken
+bool is_own_train(std::string const &Name)
+{
+	auto const seat = network::Crews.vehicle_of(Global.network_peer_id);
+	if (seat == network::ENTITY_NONE)
+		return false;
+
+	auto const train = network::Entities.consist_of(network::Entities.id_of(Name));
+	return (train != network::ENTITY_NONE) && (network::Entities.consist_of(seat) == train);
+}
+
 // applies everything except where the vehicle is; position is dealt with per consist,
 // because moving one vehicle of a coupled set on its own tears the couplers apart
 void apply_controls(TDynamicObject &Vehicle, vehicle_state const &State)
 {
 	auto &mover = *Vehicle.MoverParameters;
 
+	// what the physics produced is always taken from the authority; what a person set is
+	// not, on the train that person is working
+	bool const ours = is_own_train(State.name);
+
 	mover.V = State.velocity;
 	mover.Vel = State.velocitykmh;
-	mover.DirActive = State.diractive;
-	mover.MainCtrlPos = State.mainctrl;
-	mover.ScndCtrlPos = State.scndctrl;
-	mover.BrakeCtrlPos = State.brakectrl;
-	mover.LocalBrakePosA = State.localbrake;
+
+	if (!ours)
+	{
+		mover.DirActive = State.diractive;
+		mover.MainCtrlPos = State.mainctrl;
+		mover.ScndCtrlPos = State.scndctrl;
+		mover.BrakeCtrlPos = State.brakectrl;
+		mover.LocalBrakePosA = State.localbrake;
+	}
 
 	mover.PipePress = State.pipepress;
 	mover.BrakePress = State.brakepress;
@@ -344,6 +397,14 @@ void apply_controls(TDynamicObject &Vehicle, vehicle_state const &State)
 	mover.EqvtPipePress = State.eqvtpipepress;
 	mover.Compressor = State.compressor;
 	mover.CompressedVolume = State.compressedvolume;
+
+	if (ours)
+	{
+		// the rest of it is what the crew set, and their commands reach us on their own
+		if (Vehicle.Mechanik != nullptr && Vehicle.Mechanik->AIControllFlag != State.aiactive)
+			Vehicle.Mechanik->TakeControl(State.aiactive);
+		return;
+	}
 
 	// the appliances go through the vehicle's own switches wherever it has them, so that
 	// whatever they drag along stays consistent. range local: every vehicle carries its
@@ -357,8 +418,9 @@ void apply_controls(TDynamicObject &Vehicle, vehicle_state const &State)
 	if (mover.CompressorAllow != State.compressorallow)
 		mover.CompressorSwitch(State.compressorallow, range_t::local);
 
-	mover.CabActive = State.cabactive;
-	mover.CabOccupied = State.caboccupied;
+	// CabActive and CabOccupied are deliberately not replicated: which cab a player is
+	// sitting in is theirs alone, and two people sharing a vehicle each have their own.
+	// forcing the server's value on them is what made the camera jump in and out
 
 	for (int i = 0; i < 2; ++i)
 	{
@@ -388,9 +450,17 @@ void apply_controls(TDynamicObject &Vehicle, vehicle_state const &State)
 // its leading bogie; this inverts the arithmetic that function itself does
 void reposition(TDynamicObject &Vehicle, vehicle_state const &State)
 {
-	TTrack *track = (State.track.empty() ? nullptr : simulation::Paths.find(State.track));
+	TTrack *track = track_by_id(State.track);
 	if (track == nullptr)
+	{
+		static bool reported{false};
+		if (!reported)
+		{
+			reported = true;
+			ErrorLog("net: cannot place " + Vehicle.name() + ", track " + std::to_string(State.track) + " is unknown here", logtype::net);
+		}
 		return;
+	}
 
 	double const half = Vehicle.fAxleDist * 0.5;
 	double const axleoffset = (State.axlefirst ? -half : half);

--- a/network/snapshot.cpp
+++ b/network/snapshot.cpp
@@ -1045,10 +1045,15 @@ std::string write_crews()
 		if (crew.empty())
 			continue;
 
+		auto since = network::Crews.crew_since_of(entry.id);
+		since.resize(crew.size(), 0);
+
 		sn_utils::ls_uint32(entries, entry.id);
 		sn_utils::ls_uint32(entries, (uint32_t)crew.size());
 		for (network::PeerId const peer : crew)
 			sn_utils::ls_uint32(entries, peer);
+		for (uint64_t const stamp : since)
+			sn_utils::ls_uint64(entries, stamp);
 
 		++count;
 	}
@@ -1075,7 +1080,12 @@ void read_crews(std::istream &Stream)
 		for (uint32_t p = 0; p < size; ++p)
 			crew.emplace_back(sn_utils::ld_uint32(Stream));
 
-		network::Crews.mirror(id, crew);
+		std::vector<uint64_t> since;
+		since.reserve(size);
+		for (uint32_t p = 0; p < size; ++p)
+			since.emplace_back(sn_utils::ld_uint64(Stream));
+
+		network::Crews.mirror(id, crew, since);
 	}
 }
 

--- a/network/snapshot.cpp
+++ b/network/snapshot.cpp
@@ -79,6 +79,11 @@ TTrack *track_by_id(uint32_t const Id)
 
 // one-shot sound events seen since the last update went out, per vehicle
 std::unordered_map<std::string, int> g_soundevents;
+// the same for the brake unit's own events, plus what was on its bitfield the last time
+// we looked - the flags are only cleared when the vehicle has an accelerator sound to
+// play, so a bit that stays lit is one event, not one per frame
+std::unordered_map<std::string, int> g_brakesoundevents;
+std::unordered_map<std::string, int> g_brakesoundseen;
 
 std::unordered_map<std::string, uint64_t> g_lastvehicles;
 std::unordered_map<std::string, uint64_t> g_lastmemcells;
@@ -221,6 +226,19 @@ struct vehicle_state
 	bool compressorlock{false};
 	bool releaser{false};
 	int32_t soundevents{0};
+	// the brake unit keeps its own event bitfield, and it drives the accelerator and the
+	// cylinder venting
+	int32_t brakesoundevents{0};
+	// outputs of the physics, not settings. a peer that does not run this train computes
+	// its own and gets them wrong, so the authority's values are what it is told to use:
+	// these are what the braking, squealing and relay sounds are built from
+	double unitbrakeforce{0.0};
+	int32_t mainctrlactual{0};
+	int32_t scndctrlactual{0};
+	bool linecontactors{false};
+	bool slippingwheels{false};
+	bool sanddose{false};
+	double enginepower{0.0};
 	int32_t emergencywarningsignal{0};
 	bool alarmchain{false};
 	double wheelrevolutions{0.0};
@@ -230,6 +248,10 @@ struct vehicle_state
 	std::array<bool, 2> doorpermit{{false, false}};
 	bool aiactive{false};
 };
+
+// the authoritative reading for every train somebody else runs, held so that it can be
+// put back after each local physics step
+std::unordered_map<std::string, vehicle_state> g_remotestate;
 
 void serialize_vehicle(std::ostream &Stream, vehicle_state const &State)
 {
@@ -273,6 +295,14 @@ void serialize_vehicle(std::ostream &Stream, vehicle_state const &State)
 	sn_utils::s_bool(Stream, State.compressorlock);
 	sn_utils::s_bool(Stream, State.releaser);
 	sn_utils::ls_int32(Stream, State.soundevents);
+	sn_utils::ls_int32(Stream, State.brakesoundevents);
+	sn_utils::ls_float64(Stream, State.unitbrakeforce);
+	sn_utils::ls_int32(Stream, State.mainctrlactual);
+	sn_utils::ls_int32(Stream, State.scndctrlactual);
+	sn_utils::s_bool(Stream, State.linecontactors);
+	sn_utils::s_bool(Stream, State.slippingwheels);
+	sn_utils::s_bool(Stream, State.sanddose);
+	sn_utils::ls_float64(Stream, State.enginepower);
 	sn_utils::ls_int32(Stream, State.warningsignal);
 	sn_utils::ls_int32(Stream, State.emergencywarningsignal);
 	sn_utils::s_bool(Stream, State.alarmchain);
@@ -330,6 +360,14 @@ vehicle_state deserialize_vehicle(std::istream &Stream)
 	state.compressorlock = sn_utils::d_bool(Stream);
 	state.releaser = sn_utils::d_bool(Stream);
 	state.soundevents = sn_utils::ld_int32(Stream);
+	state.brakesoundevents = sn_utils::ld_int32(Stream);
+	state.unitbrakeforce = sn_utils::ld_float64(Stream);
+	state.mainctrlactual = sn_utils::ld_int32(Stream);
+	state.scndctrlactual = sn_utils::ld_int32(Stream);
+	state.linecontactors = sn_utils::d_bool(Stream);
+	state.slippingwheels = sn_utils::d_bool(Stream);
+	state.sanddose = sn_utils::d_bool(Stream);
+	state.enginepower = sn_utils::ld_float64(Stream);
 	state.warningsignal = sn_utils::ld_int32(Stream);
 	state.emergencywarningsignal = sn_utils::ld_int32(Stream);
 	state.alarmchain = sn_utils::d_bool(Stream);
@@ -393,6 +431,16 @@ vehicle_state read_from(TDynamicObject const &Vehicle)
 
 	auto const events = g_soundevents.find(Vehicle.name());
 	state.soundevents = (events != g_soundevents.end() ? events->second : 0);
+	auto const brakeevents = g_brakesoundevents.find(Vehicle.name());
+	state.brakesoundevents = (brakeevents != g_brakesoundevents.end() ? brakeevents->second : 0);
+
+	state.unitbrakeforce = mover.UnitBrakeForce;
+	state.mainctrlactual = mover.MainCtrlActualPos;
+	state.scndctrlactual = mover.ScndCtrlActualPos;
+	state.linecontactors = mover.StLinFlag;
+	state.slippingwheels = mover.SlippingWheels;
+	state.sanddose = mover.SandDose;
+	state.enginepower = mover.EnginePower;
 
 	state.warningsignal = mover.WarningSignal;
 	state.emergencywarningsignal = mover.EmergencyBrakeWarningSignal;
@@ -407,6 +455,41 @@ vehicle_state read_from(TDynamicObject const &Vehicle)
 	state.aiactive = (Vehicle.Mechanik != nullptr && Vehicle.Mechanik->AIControllFlag);
 
 	return state;
+}
+
+// the readings the sound is built from. these are results of a physics step, and a peer
+// that is not running this train produces its own, wrong, version of them every frame -
+// which is exactly what made the brakes and the squeal come out in shreds, the pitch
+// chasing a speed that fell away between updates and snapped back on the next one.
+// so they are taken from the authority and put back after every local step
+void apply_outputs(TDynamicObject &Vehicle, vehicle_state const &State)
+{
+	auto &mover = *Vehicle.MoverParameters;
+
+	mover.V = State.velocity;
+	mover.Vel = State.velocitykmh;
+	mover.UnitBrakeForce = State.unitbrakeforce;
+	mover.nrot = State.wheelrevolutions;
+	mover.enrot = State.enginerevolutions;
+	mover.EnginePower = State.enginepower;
+	mover.SlippingWheels = State.slippingwheels;
+	mover.SandDose = State.sanddose;
+
+	// the notch the resistors are actually on, as opposed to the one the handle is at.
+	// with this coming from the authority the local automatic notching stays out of it,
+	// and every relay that clicks here is one that clicked over there
+	mover.MainCtrlActualPos = State.mainctrlactual;
+	mover.ScndCtrlActualPos = State.scndctrlactual;
+	mover.StLinFlag = State.linecontactors;
+
+	// the machinery whose sound runs for as long as it does. left to itself the local
+	// physics keeps switching these off, because the conditions it evaluates are not the
+	// ones the owner of the train is evaluating
+	mover.ConverterFlag = State.converterrunning;
+	mover.CompressorFlag = State.compressorrunning;
+	mover.PantCompFlag = State.pantcompressorrunning;
+	mover.CompressorGovernorLock = State.compressorlock;
+	mover.WarningSignal = State.warningsignal;
 }
 
 // applies everything except where the vehicle is; position is dealt with per consist,
@@ -457,25 +540,20 @@ void apply_controls(TDynamicObject &Vehicle, vehicle_state const &State)
 	mover.iLights[0] = State.lights[0];
 	mover.iLights[1] = State.lights[1];
 
-	// the horn, the wheels and the engine note. these are set from a cab this peer does
-	// not have, so nothing but the result of them ever reaches it
-	mover.ConverterFlag = State.converterrunning;
-	mover.CompressorFlag = State.compressorrunning;
-	mover.PantCompFlag = State.pantcompressorrunning;
-	mover.CompressorGovernorLock = State.compressorlock;
-
 	if (mover.Hamulec != nullptr && mover.Hamulec->Releaser() != State.releaser)
 		mover.Hamulec->Releaser(State.releaser ? 1 : 0);
 
 	// the one-shot events are added to whatever this peer's own physics produced; the
 	// vehicle's sound handling plays them once and wipes the lot, as it always does
 	mover.SoundFlag |= State.soundevents;
+	if (mover.Hamulec != nullptr)
+		mover.Hamulec->RaiseSoundFlag(State.brakesoundevents);
 
-	mover.WarningSignal = State.warningsignal;
+	// and the physics outputs the sounds are shaped from
+	apply_outputs(Vehicle, State);
+
 	mover.EmergencyBrakeWarningSignal = State.emergencywarningsignal;
 	mover.AlarmChainFlag = State.alarmchain;
-	mover.nrot = State.wheelrevolutions;
-	mover.enrot = State.enginerevolutions;
 
 	for (int i = 0; i < 2; ++i)
 	{
@@ -579,6 +657,7 @@ std::string write_vehicles(bool const Full, bool const OwnedOnly)
 
 		// the one-shot events have been handed over; they must not go out twice
 		g_soundevents.erase(state.name);
+		g_brakesoundevents.erase(state.name);
 	}
 
 	if (count == 0)
@@ -622,6 +701,9 @@ void read_vehicles(std::istream &Stream, network::snapshot_mode const Mode, netw
 
 		apply_controls(*vehicle, state);
 		states.emplace(vehicle, state);
+		// kept so that the local physics can be overruled again on every frame until the
+		// next update arrives, not only on the frame it lands
+		g_remotestate[state.name] = state;
 
 		Result.worst_position_error = std::max(Result.worst_position_error, glm::length(vehicle->GetPosition() - state.position));
 	}
@@ -882,9 +964,46 @@ void network::note_sound_events(std::string const &Vehicle, int const Events)
 	g_soundevents[Vehicle] |= Events;
 }
 
+void network::note_brake_sound_events(std::string const &Vehicle, int const Events)
+{
+	// what comes in here was peeked, not consumed, so a flag the vehicle never gets round
+	// to clearing would otherwise be reported over and over. only what has just come up
+	// counts as an event
+	auto &seen = g_brakesoundseen[Vehicle];
+	int const fresh = Events & ~seen;
+	seen = Events;
+
+	if (fresh == 0)
+		return;
+
+	g_brakesoundevents[Vehicle] |= fresh;
+}
+
+void network::hold_remote_state()
+{
+	if (g_remotestate.empty())
+		return;
+
+	for (auto &entry : g_remotestate)
+	{
+		TDynamicObject *vehicle = simulation::Vehicles.find(entry.first);
+		if (vehicle == nullptr || vehicle->MoverParameters == nullptr)
+			continue;
+
+		// a train that has come under this peer's own control runs its own physics again
+		if (network::is_locally_simulated(network::Entities.id_of(entry.first)))
+			continue;
+
+		apply_outputs(*vehicle, entry.second);
+	}
+}
+
 void network::reset_snapshot_history()
 {
 	g_soundevents.clear();
+	g_brakesoundevents.clear();
+	g_brakesoundseen.clear();
+	g_remotestate.clear();
 	g_lastvehicles.clear();
 	g_lastmemcells.clear();
 	g_lastswitches.clear();

--- a/network/snapshot.cpp
+++ b/network/snapshot.cpp
@@ -207,6 +207,13 @@ struct vehicle_state
 	std::array<bool, 2> pantdisabled{{false, false}};
 	std::array<bool, 2> pantactive{{false, false}};
 	int32_t lights[2]{0, 0};
+	// what the vehicle is heard and seen doing. a peer that is not in this cab has no
+	// TTrain for it, so the commands that set these never reach it - only the result does
+	int32_t warningsignal{0};
+	int32_t emergencywarningsignal{0};
+	bool alarmchain{false};
+	double wheelrevolutions{0.0};
+	double enginerevolutions{0.0};
 	// door open/close intent, one entry per side; the local model derives the rest
 	std::array<bool, 2> dooropen{{false, false}};
 	std::array<bool, 2> doorpermit{{false, false}};
@@ -249,6 +256,11 @@ void serialize_vehicle(std::ostream &Stream, vehicle_state const &State)
 	}
 	sn_utils::ls_int32(Stream, State.lights[0]);
 	sn_utils::ls_int32(Stream, State.lights[1]);
+	sn_utils::ls_int32(Stream, State.warningsignal);
+	sn_utils::ls_int32(Stream, State.emergencywarningsignal);
+	sn_utils::s_bool(Stream, State.alarmchain);
+	sn_utils::ls_float64(Stream, State.wheelrevolutions);
+	sn_utils::ls_float64(Stream, State.enginerevolutions);
 	for (int i = 0; i < 2; ++i)
 	{
 		sn_utils::s_bool(Stream, State.dooropen[i]);
@@ -295,6 +307,11 @@ vehicle_state deserialize_vehicle(std::istream &Stream)
 	}
 	state.lights[0] = sn_utils::ld_int32(Stream);
 	state.lights[1] = sn_utils::ld_int32(Stream);
+	state.warningsignal = sn_utils::ld_int32(Stream);
+	state.emergencywarningsignal = sn_utils::ld_int32(Stream);
+	state.alarmchain = sn_utils::d_bool(Stream);
+	state.wheelrevolutions = sn_utils::ld_float64(Stream);
+	state.enginerevolutions = sn_utils::ld_float64(Stream);
 	for (int i = 0; i < 2; ++i)
 	{
 		state.dooropen[i] = sn_utils::d_bool(Stream);
@@ -345,6 +362,11 @@ vehicle_state read_from(TDynamicObject const &Vehicle)
 	}
 	state.lights[0] = mover.iLights[0];
 	state.lights[1] = mover.iLights[1];
+	state.warningsignal = mover.WarningSignal;
+	state.emergencywarningsignal = mover.EmergencyBrakeWarningSignal;
+	state.alarmchain = mover.AlarmChainFlag;
+	state.wheelrevolutions = mover.nrot;
+	state.enginerevolutions = mover.enrot;
 	for (int i = 0; i < 2; ++i)
 	{
 		state.dooropen[i] = mover.Doors.instances[i].is_open;
@@ -402,6 +424,14 @@ void apply_controls(TDynamicObject &Vehicle, vehicle_state const &State)
 
 	mover.iLights[0] = State.lights[0];
 	mover.iLights[1] = State.lights[1];
+
+	// the horn, the wheels and the engine note. these are set from a cab this peer does
+	// not have, so nothing but the result of them ever reaches it
+	mover.WarningSignal = State.warningsignal;
+	mover.EmergencyBrakeWarningSignal = State.emergencywarningsignal;
+	mover.AlarmChainFlag = State.alarmchain;
+	mover.nrot = State.wheelrevolutions;
+	mover.enrot = State.enginerevolutions;
 
 	for (int i = 0; i < 2; ++i)
 	{

--- a/network/snapshot.cpp
+++ b/network/snapshot.cpp
@@ -1,0 +1,359 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "network/snapshot.h"
+
+#include "McZapkie/MOVER.h"
+#include "network/entities.h"
+#include "network/session.h"
+#include "scene/sn_utils.h"
+#include "simulation/simulation.h"
+#include "simulation/simulationtime.h"
+#include "utilities/Globals.h"
+#include "utilities/Logs.h"
+#include "vehicle/Driver.h"
+#include "vehicle/DynObj.h"
+#include "world/Track.h"
+
+namespace
+{
+
+uint32_t const SNAPSHOT_MAGIC{0x4e535545}; // 'EUSN'
+
+// a vehicle is only put back on the rails when it really is somewhere else; nudging one
+// that is already in place would only shake it about
+double const REPOSITION_THRESHOLD{0.5};
+
+void write_chunk(std::ostream &Stream, network::snapshot_chunk const Id, std::string const &Body)
+{
+	sn_utils::ls_uint16(Stream, (uint16_t)Id);
+	sn_utils::ls_uint32(Stream, (uint32_t)Body.size());
+	Stream.write(Body.data(), Body.size());
+}
+
+// ---------------------------------------------------------------------------
+// session
+
+std::string write_session()
+{
+	std::ostringstream body;
+
+	sn_utils::ls_uint64(body, Global.simulation_tick);
+	sn_utils::ls_int64(body, Global.starting_timestamp);
+	sn_utils::ls_uint32(body, Global.random_seed);
+
+	auto const &time = simulation::Time.data();
+	sn_utils::ls_uint32(body, (uint32_t)simulation::Time.year_day());
+	sn_utils::ls_uint32(body, (uint32_t)(time.wHour * 60 + time.wMinute));
+	sn_utils::ls_float64(body, simulation::Time.second());
+
+	sn_utils::ls_float64(body, Global.Overcast);
+	sn_utils::ls_float64(body, Global.AirTemperature);
+
+	// the engine drives gameplay randomness, so a joining peer has to pick it up as it is
+	std::ostringstream engine;
+	engine << Global.random_engine;
+	sn_utils::s_str(body, engine.str());
+
+	return body.str();
+}
+
+void read_session(std::istream &Stream)
+{
+	auto const tick = sn_utils::ld_uint64(Stream);
+	auto const timestamp = sn_utils::ld_int64(Stream);
+	auto const seed = sn_utils::ld_uint32(Stream);
+
+	auto const yearday = sn_utils::ld_uint32(Stream);
+	auto const minuteofday = sn_utils::ld_uint32(Stream);
+	auto const second = sn_utils::ld_float64(Stream);
+
+	auto const overcast = sn_utils::ld_float64(Stream);
+	auto const temperature = sn_utils::ld_float64(Stream);
+
+	auto const enginestate = sn_utils::d_str(Stream);
+
+	Global.simulation_tick = tick;
+	Global.starting_timestamp = timestamp;
+	Global.random_seed = seed;
+
+	simulation::Time.set_time((int)yearday, (int)minuteofday);
+	simulation::Time.data().wSecond = (WORD)std::floor(second);
+	simulation::Time.data().wMilliseconds = (WORD)((second - std::floor(second)) * 1000.0);
+
+	Global.Overcast = (float)overcast;
+	Global.AirTemperature = (float)temperature;
+
+	if (!enginestate.empty())
+	{
+		std::istringstream engine(enginestate);
+		engine >> Global.random_engine;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// vehicles
+
+std::string write_vehicles()
+{
+	std::ostringstream body;
+	std::ostringstream entries;
+	uint32_t count{0};
+
+	for (TDynamicObject const *vehicle : simulation::Vehicles.sequence())
+	{
+		if (vehicle == nullptr || vehicle->MoverParameters == nullptr)
+			continue;
+
+		auto const &mover = *vehicle->MoverParameters;
+		auto const *track = vehicle->RaTrackGet();
+
+		sn_utils::s_str(entries, vehicle->name());
+		sn_utils::s_str(entries, track != nullptr ? track->name() : std::string());
+		sn_utils::ls_float64(entries, vehicle->RaTranslationGet());
+		sn_utils::s_uint8(entries, (uint8_t)(vehicle->iAxleFirst ? 1 : 0));
+		sn_utils::s_uint8(entries, (uint8_t)(vehicle->iDirection ? 1 : 0));
+		sn_utils::s_dvec3(entries, vehicle->GetPosition());
+
+		sn_utils::ls_float64(entries, mover.V);
+		sn_utils::ls_float64(entries, mover.Vel);
+		sn_utils::ls_int32(entries, mover.DirActive);
+		sn_utils::ls_int32(entries, mover.MainCtrlPos);
+		sn_utils::ls_int32(entries, mover.ScndCtrlPos);
+		sn_utils::ls_int32(entries, mover.BrakeCtrlPos);
+		sn_utils::ls_float64(entries, mover.LocalBrakePosA);
+		sn_utils::ls_float64(entries, mover.PipePress);
+		sn_utils::ls_float64(entries, mover.BrakePress);
+		sn_utils::ls_float64(entries, mover.ScndPipePress);
+		sn_utils::ls_float64(entries, mover.Compressor);
+		sn_utils::ls_float64(entries, mover.CompressedVolume);
+		sn_utils::s_bool(entries, vehicle->Mechanik != nullptr && vehicle->Mechanik->AIControllFlag);
+
+		++count;
+	}
+
+	sn_utils::ls_uint32(body, count);
+	auto const packed = entries.str();
+	body.write(packed.data(), packed.size());
+
+	return body.str();
+}
+
+void read_vehicles(std::istream &Stream)
+{
+	auto const count = sn_utils::ld_uint32(Stream);
+	uint32_t repositioned{0};
+	uint32_t missing{0};
+
+	for (uint32_t i = 0; i < count; ++i)
+	{
+		auto const name = sn_utils::d_str(Stream);
+		auto const trackname = sn_utils::d_str(Stream);
+		auto const translation = sn_utils::ld_float64(Stream);
+		auto const axlefirst = sn_utils::d_uint8(Stream);
+		auto const direction = sn_utils::d_uint8(Stream);
+		auto const position = sn_utils::d_dvec3(Stream);
+
+		auto const velocity = sn_utils::ld_float64(Stream);
+		auto const velocitykmh = sn_utils::ld_float64(Stream);
+		auto const diractive = sn_utils::ld_int32(Stream);
+		auto const mainctrl = sn_utils::ld_int32(Stream);
+		auto const scndctrl = sn_utils::ld_int32(Stream);
+		auto const brakectrl = sn_utils::ld_int32(Stream);
+		auto const localbrake = sn_utils::ld_float64(Stream);
+		auto const pipepress = sn_utils::ld_float64(Stream);
+		auto const brakepress = sn_utils::ld_float64(Stream);
+		auto const scndpipepress = sn_utils::ld_float64(Stream);
+		auto const compressor = sn_utils::ld_float64(Stream);
+		auto const compressedvolume = sn_utils::ld_float64(Stream);
+		auto const aiactive = sn_utils::d_bool(Stream);
+
+		TDynamicObject *vehicle = simulation::Vehicles.find(name);
+		if (vehicle == nullptr || vehicle->MoverParameters == nullptr)
+		{
+			++missing;
+			continue;
+		}
+
+		auto &mover = *vehicle->MoverParameters;
+
+		mover.V = velocity;
+		mover.Vel = velocitykmh;
+		mover.DirActive = diractive;
+		mover.MainCtrlPos = mainctrl;
+		mover.ScndCtrlPos = scndctrl;
+		mover.BrakeCtrlPos = brakectrl;
+		mover.LocalBrakePosA = localbrake;
+		mover.PipePress = pipepress;
+		mover.BrakePress = brakepress;
+		mover.ScndPipePress = scndpipepress;
+		mover.Compressor = compressor;
+		mover.CompressedVolume = compressedvolume;
+
+		if (vehicle->Mechanik != nullptr && vehicle->Mechanik->AIControllFlag != aiactive)
+		{
+			vehicle->Mechanik->TakeControl(aiactive);
+		}
+
+		if (glm::length(vehicle->GetPosition() - position) <= REPOSITION_THRESHOLD)
+		{
+			// close enough already; leaving it alone avoids shaking a vehicle that is fine
+			continue;
+		}
+
+		TTrack *track = (trackname.empty() ? nullptr : simulation::Paths.find(trackname));
+		if (track == nullptr)
+			continue;
+
+		// place_on_track() takes the distance of the vehicle's nose, while what we recorded
+		// is the offset of its leading bogie. this inverts the arithmetic the placement
+		// itself does, so the two stay in step if that code ever changes
+		double const half = vehicle->fAxleDist * 0.5;
+		double const axleoffset = (axlefirst ? -half : half);
+		double const sign = (direction ? 1.0 : -1.0);
+		double const nose = (translation - axleoffset) * sign + 0.5 * mover.Dim.L;
+
+		vehicle->place_on_track(track, nose, false);
+		++repositioned;
+	}
+
+	WriteLog("net: snapshot restored " + std::to_string(count) + " vehicles, " + std::to_string(repositioned) + " of them put back on the rails" +
+	             (missing > 0 ? ", " + std::to_string(missing) + " unknown here" : ""),
+	         logtype::net);
+}
+
+// ---------------------------------------------------------------------------
+// crews
+
+std::string write_crews()
+{
+	std::ostringstream body;
+	std::ostringstream entries;
+	uint32_t count{0};
+
+	for (auto const &entry : network::Entities.entries())
+	{
+		auto const crew = network::Crews.crew_of(entry.id);
+		if (crew.empty())
+			continue;
+
+		sn_utils::ls_uint32(entries, entry.id);
+		sn_utils::ls_uint32(entries, (uint32_t)crew.size());
+		for (network::PeerId const peer : crew)
+			sn_utils::ls_uint32(entries, peer);
+
+		++count;
+	}
+
+	sn_utils::ls_uint32(body, count);
+	auto const packed = entries.str();
+	body.write(packed.data(), packed.size());
+
+	return body.str();
+}
+
+void read_crews(std::istream &Stream)
+{
+	auto const count = sn_utils::ld_uint32(Stream);
+
+	for (uint32_t i = 0; i < count; ++i)
+	{
+		auto const id = sn_utils::ld_uint32(Stream);
+		auto const size = sn_utils::ld_uint32(Stream);
+
+		std::vector<network::PeerId> crew;
+		crew.reserve(size);
+		for (uint32_t p = 0; p < size; ++p)
+			crew.emplace_back(sn_utils::ld_uint32(Stream));
+
+		network::Crews.mirror(id, crew);
+	}
+}
+
+} // namespace
+
+std::string network::take_snapshot()
+{
+	std::ostringstream stream;
+
+	sn_utils::ls_uint32(stream, SNAPSHOT_MAGIC);
+	sn_utils::ls_uint32(stream, SNAPSHOT_VERSION);
+	sn_utils::ls_uint64(stream, Global.simulation_tick);
+	sn_utils::ls_uint32(stream, 3); // number of chunks that follow
+
+	write_chunk(stream, SNAPSHOT_SESSION, write_session());
+	write_chunk(stream, SNAPSHOT_VEHICLES, write_vehicles());
+	write_chunk(stream, SNAPSHOT_CREWS, write_crews());
+
+	auto const blob = stream.str();
+	WriteLog("net: snapshot taken at tick " + std::to_string(Global.simulation_tick) + ", " + std::to_string(blob.size()) + " bytes", logtype::net);
+
+	return blob;
+}
+
+bool network::apply_snapshot(std::string const &Blob)
+{
+	std::istringstream stream(Blob);
+
+	if (sn_utils::ld_uint32(stream) != SNAPSHOT_MAGIC)
+	{
+		ErrorLog("net: snapshot rejected, not a snapshot", logtype::net);
+		return false;
+	}
+
+	auto const version = sn_utils::ld_uint32(stream);
+	if (version != SNAPSHOT_VERSION)
+	{
+		ErrorLog("net: snapshot rejected, version " + std::to_string(version) + " but this build speaks " + std::to_string(SNAPSHOT_VERSION), logtype::net);
+		return false;
+	}
+
+	auto const tick = sn_utils::ld_uint64(stream);
+	auto const chunks = sn_utils::ld_uint32(stream);
+
+	for (uint32_t i = 0; i < chunks; ++i)
+	{
+		if (!stream.good())
+		{
+			ErrorLog("net: snapshot truncated", logtype::net);
+			return false;
+		}
+
+		auto const id = sn_utils::ld_uint16(stream);
+		auto const length = sn_utils::ld_uint32(stream);
+
+		std::string body(length, '\0');
+		stream.read(body.data(), length);
+
+		std::istringstream chunk(body);
+
+		switch (id)
+		{
+		case SNAPSHOT_SESSION:
+			read_session(chunk);
+			break;
+		case SNAPSHOT_VEHICLES:
+			read_vehicles(chunk);
+			break;
+		case SNAPSHOT_CREWS:
+			read_crews(chunk);
+			break;
+		default:
+			// a section this build knows nothing about; its length is right there, so it
+			// costs nothing to walk past it
+			WriteLog("net: snapshot section " + std::to_string(id) + " skipped, unknown to this build", logtype::net);
+			break;
+		}
+	}
+
+	WriteLog("net: snapshot applied, now at tick " + std::to_string(tick), logtype::net);
+
+	return true;
+}

--- a/network/snapshot.cpp
+++ b/network/snapshot.cpp
@@ -20,6 +20,8 @@ http://mozilla.org/MPL/2.0/.
 #include "utilities/Logs.h"
 #include "vehicle/Driver.h"
 #include "vehicle/DynObj.h"
+#include "world/Event.h"
+#include "world/MemCell.h"
 #include "world/Track.h"
 
 namespace
@@ -27,9 +29,29 @@ namespace
 
 uint32_t const SNAPSHOT_MAGIC{0x4e535545}; // 'EUSN'
 
-// a vehicle is only put back on the rails when it really is somewhere else; nudging one
-// that is already in place would only shake it about
-double const REPOSITION_THRESHOLD{0.5};
+// how far a vehicle may sit from where the authority says it is before it gets put back.
+// a joining peer is placed exactly; a running one is left to its own physics for small
+// errors, because nudging a vehicle every fraction of a second is worse than the error
+double const REPOSITION_TOLERANCE_JOIN{0.5};
+double const REPOSITION_TOLERANCE_CORRECTION{2.5};
+
+// ---------------------------------------------------------------------------
+// what the authority last sent, so that a routine correction only carries changes
+
+std::unordered_map<std::string, uint64_t> g_lastvehicles;
+std::unordered_map<std::string, uint64_t> g_lastmemcells;
+std::unordered_map<std::string, int> g_lastswitches;
+
+uint64_t digest_of(std::string const &Text)
+{
+	uint64_t hash{14695981039346656037ull};
+	for (char const character : Text)
+	{
+		hash ^= (uint64_t)(unsigned char)character;
+		hash *= 1099511628211ull;
+	}
+	return hash;
+}
 
 void write_chunk(std::ostream &Stream, network::snapshot_chunk const Id, std::string const &Body)
 {
@@ -41,7 +63,7 @@ void write_chunk(std::ostream &Stream, network::snapshot_chunk const Id, std::st
 // ---------------------------------------------------------------------------
 // session
 
-std::string write_session()
+std::string write_session(bool const Full)
 {
 	std::ostringstream body;
 
@@ -57,15 +79,20 @@ std::string write_session()
 	sn_utils::ls_float64(body, Global.Overcast);
 	sn_utils::ls_float64(body, Global.AirTemperature);
 
-	// the engine drives gameplay randomness, so a joining peer has to pick it up as it is
-	std::ostringstream engine;
-	engine << Global.random_engine;
-	sn_utils::s_str(body, engine.str());
+	// the engine drives gameplay randomness, so a joining peer has to pick it up as it is.
+	// it is several kilobytes though, far too much to repeat in every routine correction
+	sn_utils::s_bool(body, Full);
+	if (Full)
+	{
+		std::ostringstream engine;
+		engine << Global.random_engine;
+		sn_utils::s_str(body, engine.str());
+	}
 
 	return body.str();
 }
 
-void read_session(std::istream &Stream)
+void read_session(std::istream &Stream, network::snapshot_mode const Mode)
 {
 	auto const tick = sn_utils::ld_uint64(Stream);
 	auto const timestamp = sn_utils::ld_int64(Stream);
@@ -78,7 +105,10 @@ void read_session(std::istream &Stream)
 	auto const overcast = sn_utils::ld_float64(Stream);
 	auto const temperature = sn_utils::ld_float64(Stream);
 
-	auto const enginestate = sn_utils::d_str(Stream);
+	bool const hasengine = sn_utils::d_bool(Stream);
+	std::string enginestate;
+	if (hasengine)
+		enginestate = sn_utils::d_str(Stream);
 
 	Global.simulation_tick = tick;
 	Global.starting_timestamp = timestamp;
@@ -96,14 +126,282 @@ void read_session(std::istream &Stream)
 		std::istringstream engine(enginestate);
 		engine >> Global.random_engine;
 	}
+
+	(void)Mode;
 }
 
 // ---------------------------------------------------------------------------
 // vehicles
 
-std::string write_vehicles()
+// everything about one vehicle the rest of the session needs to agree on
+struct vehicle_state
 {
-	std::ostringstream body;
+	std::string name;
+	std::string track;
+	double translation{0.0};
+	uint8_t axlefirst{0};
+	uint8_t direction{0};
+	glm::dvec3 position{};
+
+	double velocity{0.0};
+	double velocitykmh{0.0};
+	int32_t diractive{0};
+	int32_t mainctrl{0};
+	int32_t scndctrl{0};
+	int32_t brakectrl{0};
+	double localbrake{0.0};
+
+	double pipepress{0.0};
+	double brakepress{0.0};
+	double scndpipepress{0.0};
+	double eqvtpipepress{0.0};
+	double compressor{0.0};
+	double compressedvolume{0.0};
+
+	// switch positions and permissions - the inputs of the vehicle, not its outputs.
+	// getting these right lets the receiving peer derive the rest for itself
+	bool mains{false};
+	bool battery{false};
+	bool converterallow{false};
+	bool compressorallow{false};
+	int32_t cabactive{0};
+	int32_t caboccupied{0};
+	std::array<bool, 2> pantenabled{{false, false}};
+	std::array<bool, 2> pantdisabled{{false, false}};
+	std::array<bool, 2> pantactive{{false, false}};
+	int32_t lights[2]{0, 0};
+	// door open/close intent, one entry per side; the local model derives the rest
+	std::array<bool, 2> dooropen{{false, false}};
+	std::array<bool, 2> doorpermit{{false, false}};
+	bool aiactive{false};
+};
+
+void serialize_vehicle(std::ostream &Stream, vehicle_state const &State)
+{
+	sn_utils::s_str(Stream, State.name);
+	sn_utils::s_str(Stream, State.track);
+	sn_utils::ls_float64(Stream, State.translation);
+	sn_utils::s_uint8(Stream, State.axlefirst);
+	sn_utils::s_uint8(Stream, State.direction);
+	sn_utils::s_dvec3(Stream, State.position);
+
+	sn_utils::ls_float64(Stream, State.velocity);
+	sn_utils::ls_float64(Stream, State.velocitykmh);
+	sn_utils::ls_int32(Stream, State.diractive);
+	sn_utils::ls_int32(Stream, State.mainctrl);
+	sn_utils::ls_int32(Stream, State.scndctrl);
+	sn_utils::ls_int32(Stream, State.brakectrl);
+	sn_utils::ls_float64(Stream, State.localbrake);
+
+	sn_utils::ls_float64(Stream, State.pipepress);
+	sn_utils::ls_float64(Stream, State.brakepress);
+	sn_utils::ls_float64(Stream, State.scndpipepress);
+	sn_utils::ls_float64(Stream, State.eqvtpipepress);
+	sn_utils::ls_float64(Stream, State.compressor);
+	sn_utils::ls_float64(Stream, State.compressedvolume);
+
+	sn_utils::s_bool(Stream, State.mains);
+	sn_utils::s_bool(Stream, State.battery);
+	sn_utils::s_bool(Stream, State.converterallow);
+	sn_utils::s_bool(Stream, State.compressorallow);
+	sn_utils::ls_int32(Stream, State.cabactive);
+	sn_utils::ls_int32(Stream, State.caboccupied);
+	for (int i = 0; i < 2; ++i)
+	{
+		sn_utils::s_bool(Stream, State.pantenabled[i]);
+		sn_utils::s_bool(Stream, State.pantdisabled[i]);
+		sn_utils::s_bool(Stream, State.pantactive[i]);
+	}
+	sn_utils::ls_int32(Stream, State.lights[0]);
+	sn_utils::ls_int32(Stream, State.lights[1]);
+	for (int i = 0; i < 2; ++i)
+	{
+		sn_utils::s_bool(Stream, State.dooropen[i]);
+		sn_utils::s_bool(Stream, State.doorpermit[i]);
+	}
+	sn_utils::s_bool(Stream, State.aiactive);
+}
+
+vehicle_state deserialize_vehicle(std::istream &Stream)
+{
+	vehicle_state state;
+
+	state.name = sn_utils::d_str(Stream);
+	state.track = sn_utils::d_str(Stream);
+	state.translation = sn_utils::ld_float64(Stream);
+	state.axlefirst = sn_utils::d_uint8(Stream);
+	state.direction = sn_utils::d_uint8(Stream);
+	state.position = sn_utils::d_dvec3(Stream);
+
+	state.velocity = sn_utils::ld_float64(Stream);
+	state.velocitykmh = sn_utils::ld_float64(Stream);
+	state.diractive = sn_utils::ld_int32(Stream);
+	state.mainctrl = sn_utils::ld_int32(Stream);
+	state.scndctrl = sn_utils::ld_int32(Stream);
+	state.brakectrl = sn_utils::ld_int32(Stream);
+	state.localbrake = sn_utils::ld_float64(Stream);
+
+	state.pipepress = sn_utils::ld_float64(Stream);
+	state.brakepress = sn_utils::ld_float64(Stream);
+	state.scndpipepress = sn_utils::ld_float64(Stream);
+	state.eqvtpipepress = sn_utils::ld_float64(Stream);
+	state.compressor = sn_utils::ld_float64(Stream);
+	state.compressedvolume = sn_utils::ld_float64(Stream);
+
+	state.mains = sn_utils::d_bool(Stream);
+	state.battery = sn_utils::d_bool(Stream);
+	state.converterallow = sn_utils::d_bool(Stream);
+	state.compressorallow = sn_utils::d_bool(Stream);
+	state.cabactive = sn_utils::ld_int32(Stream);
+	state.caboccupied = sn_utils::ld_int32(Stream);
+	for (int i = 0; i < 2; ++i)
+	{
+		state.pantenabled[i] = sn_utils::d_bool(Stream);
+		state.pantdisabled[i] = sn_utils::d_bool(Stream);
+		state.pantactive[i] = sn_utils::d_bool(Stream);
+	}
+	state.lights[0] = sn_utils::ld_int32(Stream);
+	state.lights[1] = sn_utils::ld_int32(Stream);
+	for (int i = 0; i < 2; ++i)
+	{
+		state.dooropen[i] = sn_utils::d_bool(Stream);
+		state.doorpermit[i] = sn_utils::d_bool(Stream);
+	}
+	state.aiactive = sn_utils::d_bool(Stream);
+
+	return state;
+}
+
+vehicle_state read_from(TDynamicObject const &Vehicle)
+{
+	auto const &mover = *Vehicle.MoverParameters;
+	auto const *track = Vehicle.RaTrackGet();
+
+	vehicle_state state;
+	state.name = Vehicle.name();
+	state.track = (track != nullptr ? track->name() : std::string());
+	state.translation = Vehicle.RaTranslationGet();
+	state.axlefirst = (uint8_t)(Vehicle.iAxleFirst ? 1 : 0);
+	state.direction = (uint8_t)(Vehicle.iDirection ? 1 : 0);
+	state.position = Vehicle.GetPosition();
+
+	state.velocity = mover.V;
+	state.velocitykmh = mover.Vel;
+	state.diractive = mover.DirActive;
+	state.mainctrl = mover.MainCtrlPos;
+	state.scndctrl = mover.ScndCtrlPos;
+	state.brakectrl = mover.BrakeCtrlPos;
+	state.localbrake = mover.LocalBrakePosA;
+
+	state.pipepress = mover.PipePress;
+	state.brakepress = mover.BrakePress;
+	state.scndpipepress = mover.ScndPipePress;
+	state.eqvtpipepress = mover.EqvtPipePress;
+	state.compressor = mover.Compressor;
+	state.compressedvolume = mover.CompressedVolume;
+
+	state.mains = mover.Mains;
+	state.battery = mover.Battery;
+	state.converterallow = mover.ConverterAllow;
+	state.compressorallow = mover.CompressorAllow;
+	state.cabactive = mover.CabActive;
+	state.caboccupied = mover.CabOccupied;
+	for (int i = 0; i < 2; ++i)
+	{
+		state.pantenabled[i] = mover.Pantographs[i].valve.is_enabled;
+		state.pantdisabled[i] = mover.Pantographs[i].valve.is_disabled;
+		state.pantactive[i] = mover.Pantographs[i].is_active;
+	}
+	state.lights[0] = mover.iLights[0];
+	state.lights[1] = mover.iLights[1];
+	for (int i = 0; i < 2; ++i)
+	{
+		state.dooropen[i] = mover.Doors.instances[i].is_open;
+		state.doorpermit[i] = mover.Doors.instances[i].open_permit;
+	}
+	state.aiactive = (Vehicle.Mechanik != nullptr && Vehicle.Mechanik->AIControllFlag);
+
+	return state;
+}
+
+// applies everything except where the vehicle is; position is dealt with per consist,
+// because moving one vehicle of a coupled set on its own tears the couplers apart
+void apply_controls(TDynamicObject &Vehicle, vehicle_state const &State)
+{
+	auto &mover = *Vehicle.MoverParameters;
+
+	mover.V = State.velocity;
+	mover.Vel = State.velocitykmh;
+	mover.DirActive = State.diractive;
+	mover.MainCtrlPos = State.mainctrl;
+	mover.ScndCtrlPos = State.scndctrl;
+	mover.BrakeCtrlPos = State.brakectrl;
+	mover.LocalBrakePosA = State.localbrake;
+
+	mover.PipePress = State.pipepress;
+	mover.BrakePress = State.brakepress;
+	mover.ScndPipePress = State.scndpipepress;
+	mover.EqvtPipePress = State.eqvtpipepress;
+	mover.Compressor = State.compressor;
+	mover.CompressedVolume = State.compressedvolume;
+
+	// the appliances go through the vehicle's own switches wherever it has them, so that
+	// whatever they drag along stays consistent. range local: every vehicle carries its
+	// own state in the update, there is no need to push it down the consist twice
+	if (mover.Battery != State.battery)
+		mover.BatterySwitch(State.battery, range_t::local);
+	if (mover.Mains != State.mains)
+		mover.MainSwitch(State.mains, range_t::local);
+	if (mover.ConverterAllow != State.converterallow)
+		mover.ConverterSwitch(State.converterallow, range_t::local);
+	if (mover.CompressorAllow != State.compressorallow)
+		mover.CompressorSwitch(State.compressorallow, range_t::local);
+
+	mover.CabActive = State.cabactive;
+	mover.CabOccupied = State.caboccupied;
+
+	for (int i = 0; i < 2; ++i)
+	{
+		mover.Pantographs[i].valve.is_enabled = State.pantenabled[i];
+		mover.Pantographs[i].valve.is_disabled = State.pantdisabled[i];
+		mover.Pantographs[i].is_active = State.pantactive[i];
+	}
+
+	mover.iLights[0] = State.lights[0];
+	mover.iLights[1] = State.lights[1];
+
+	for (int i = 0; i < 2; ++i)
+	{
+		auto const side = (i == 0 ? side::right : side::left);
+		if (mover.Doors.instances[i].open_permit != State.doorpermit[i])
+			mover.PermitDoors(side, State.doorpermit[i], range_t::local);
+		if (mover.Doors.instances[i].is_open != State.dooropen[i])
+			mover.OperateDoors(side, State.dooropen[i], range_t::local);
+	}
+
+	if (Vehicle.Mechanik != nullptr && Vehicle.Mechanik->AIControllFlag != State.aiactive)
+		Vehicle.Mechanik->TakeControl(State.aiactive);
+}
+
+// puts a vehicle back where the authority says it is. place_on_track() wants the distance
+// of the vehicle's nose along the track, while what travels in the update is the offset of
+// its leading bogie; this inverts the arithmetic that function itself does
+void reposition(TDynamicObject &Vehicle, vehicle_state const &State)
+{
+	TTrack *track = (State.track.empty() ? nullptr : simulation::Paths.find(State.track));
+	if (track == nullptr)
+		return;
+
+	double const half = Vehicle.fAxleDist * 0.5;
+	double const axleoffset = (State.axlefirst ? -half : half);
+	double const sign = (State.direction ? 1.0 : -1.0);
+	double const nose = (State.translation - axleoffset) * sign + 0.5 * Vehicle.MoverParameters->Dim.L;
+
+	Vehicle.place_on_track(track, nose, false);
+}
+
+std::string write_vehicles(bool const Full)
+{
 	std::ostringstream entries;
 	uint32_t count{0};
 
@@ -112,33 +410,35 @@ std::string write_vehicles()
 		if (vehicle == nullptr || vehicle->MoverParameters == nullptr)
 			continue;
 
-		auto const &mover = *vehicle->MoverParameters;
-		auto const *track = vehicle->RaTrackGet();
+		auto const state = read_from(*vehicle);
 
-		sn_utils::s_str(entries, vehicle->name());
-		sn_utils::s_str(entries, track != nullptr ? track->name() : std::string());
-		sn_utils::ls_float64(entries, vehicle->RaTranslationGet());
-		sn_utils::s_uint8(entries, (uint8_t)(vehicle->iAxleFirst ? 1 : 0));
-		sn_utils::s_uint8(entries, (uint8_t)(vehicle->iDirection ? 1 : 0));
-		sn_utils::s_dvec3(entries, vehicle->GetPosition());
+		std::ostringstream packed;
+		serialize_vehicle(packed, state);
+		auto const record = packed.str();
 
-		sn_utils::ls_float64(entries, mover.V);
-		sn_utils::ls_float64(entries, mover.Vel);
-		sn_utils::ls_int32(entries, mover.DirActive);
-		sn_utils::ls_int32(entries, mover.MainCtrlPos);
-		sn_utils::ls_int32(entries, mover.ScndCtrlPos);
-		sn_utils::ls_int32(entries, mover.BrakeCtrlPos);
-		sn_utils::ls_float64(entries, mover.LocalBrakePosA);
-		sn_utils::ls_float64(entries, mover.PipePress);
-		sn_utils::ls_float64(entries, mover.BrakePress);
-		sn_utils::ls_float64(entries, mover.ScndPipePress);
-		sn_utils::ls_float64(entries, mover.Compressor);
-		sn_utils::ls_float64(entries, mover.CompressedVolume);
-		sn_utils::s_bool(entries, vehicle->Mechanik != nullptr && vehicle->Mechanik->AIControllFlag);
+		if (!Full)
+		{
+			// a vehicle that is standing still and has not been touched needs no update
+			auto const digest = digest_of(record);
+			auto const previous = g_lastvehicles.find(state.name);
+			if (previous != g_lastvehicles.end() && previous->second == digest)
+				continue;
 
+			g_lastvehicles[state.name] = digest;
+		}
+		else
+		{
+			g_lastvehicles[state.name] = digest_of(record);
+		}
+
+		entries.write(record.data(), record.size());
 		++count;
 	}
 
+	if (count == 0)
+		return std::string();
+
+	std::ostringstream body;
 	sn_utils::ls_uint32(body, count);
 	auto const packed = entries.str();
 	body.write(packed.data(), packed.size());
@@ -146,87 +446,98 @@ std::string write_vehicles()
 	return body.str();
 }
 
-void read_vehicles(std::istream &Stream)
+void read_vehicles(std::istream &Stream, network::snapshot_mode const Mode, network::snapshot_result &Result)
 {
 	auto const count = sn_utils::ld_uint32(Stream);
-	uint32_t repositioned{0};
-	uint32_t missing{0};
+	double const tolerance = (Mode == network::snapshot_mode::join ? REPOSITION_TOLERANCE_JOIN : REPOSITION_TOLERANCE_CORRECTION);
+
+	std::unordered_map<TDynamicObject *, vehicle_state> states;
+	states.reserve(count);
 
 	for (uint32_t i = 0; i < count; ++i)
 	{
-		auto const name = sn_utils::d_str(Stream);
-		auto const trackname = sn_utils::d_str(Stream);
-		auto const translation = sn_utils::ld_float64(Stream);
-		auto const axlefirst = sn_utils::d_uint8(Stream);
-		auto const direction = sn_utils::d_uint8(Stream);
-		auto const position = sn_utils::d_dvec3(Stream);
+		auto const state = deserialize_vehicle(Stream);
 
-		auto const velocity = sn_utils::ld_float64(Stream);
-		auto const velocitykmh = sn_utils::ld_float64(Stream);
-		auto const diractive = sn_utils::ld_int32(Stream);
-		auto const mainctrl = sn_utils::ld_int32(Stream);
-		auto const scndctrl = sn_utils::ld_int32(Stream);
-		auto const brakectrl = sn_utils::ld_int32(Stream);
-		auto const localbrake = sn_utils::ld_float64(Stream);
-		auto const pipepress = sn_utils::ld_float64(Stream);
-		auto const brakepress = sn_utils::ld_float64(Stream);
-		auto const scndpipepress = sn_utils::ld_float64(Stream);
-		auto const compressor = sn_utils::ld_float64(Stream);
-		auto const compressedvolume = sn_utils::ld_float64(Stream);
-		auto const aiactive = sn_utils::d_bool(Stream);
-
-		TDynamicObject *vehicle = simulation::Vehicles.find(name);
+		TDynamicObject *vehicle = simulation::Vehicles.find(state.name);
 		if (vehicle == nullptr || vehicle->MoverParameters == nullptr)
-		{
-			++missing;
-			continue;
-		}
-
-		auto &mover = *vehicle->MoverParameters;
-
-		mover.V = velocity;
-		mover.Vel = velocitykmh;
-		mover.DirActive = diractive;
-		mover.MainCtrlPos = mainctrl;
-		mover.ScndCtrlPos = scndctrl;
-		mover.BrakeCtrlPos = brakectrl;
-		mover.LocalBrakePosA = localbrake;
-		mover.PipePress = pipepress;
-		mover.BrakePress = brakepress;
-		mover.ScndPipePress = scndpipepress;
-		mover.Compressor = compressor;
-		mover.CompressedVolume = compressedvolume;
-
-		if (vehicle->Mechanik != nullptr && vehicle->Mechanik->AIControllFlag != aiactive)
-		{
-			vehicle->Mechanik->TakeControl(aiactive);
-		}
-
-		if (glm::length(vehicle->GetPosition() - position) <= REPOSITION_THRESHOLD)
-		{
-			// close enough already; leaving it alone avoids shaking a vehicle that is fine
-			continue;
-		}
-
-		TTrack *track = (trackname.empty() ? nullptr : simulation::Paths.find(trackname));
-		if (track == nullptr)
 			continue;
 
-		// place_on_track() takes the distance of the vehicle's nose, while what we recorded
-		// is the offset of its leading bogie. this inverts the arithmetic the placement
-		// itself does, so the two stay in step if that code ever changes
-		double const half = vehicle->fAxleDist * 0.5;
-		double const axleoffset = (axlefirst ? -half : half);
-		double const sign = (direction ? 1.0 : -1.0);
-		double const nose = (translation - axleoffset) * sign + 0.5 * mover.Dim.L;
+		apply_controls(*vehicle, state);
+		states.emplace(vehicle, state);
 
-		vehicle->place_on_track(track, nose, false);
-		++repositioned;
+		Result.worst_position_error = std::max(Result.worst_position_error, glm::length(vehicle->GetPosition() - state.position));
 	}
 
-	WriteLog("net: snapshot restored " + std::to_string(count) + " vehicles, " + std::to_string(repositioned) + " of them put back on the rails" +
-	             (missing > 0 ? ", " + std::to_string(missing) + " unknown here" : ""),
-	         logtype::net);
+	Result.vehicles = (uint32_t)states.size();
+
+	// a coupled set is put back as a whole or not at all: correcting one vehicle of a
+	// consist while its neighbour stays put is what stretches a coupler until it breaks
+	std::unordered_set<TDynamicObject *> visited;
+
+	for (auto const &pair : states)
+	{
+		if (visited.count(pair.first) > 0)
+			continue;
+
+		// the cap is only there so that a malformed consist cannot spin us forever
+		int const CONSIST_LIMIT{256};
+
+		std::vector<TDynamicObject *> group;
+		TDynamicObject *front = pair.first;
+		for (int step = 0; step < CONSIST_LIMIT; ++step)
+		{
+			TDynamicObject *previous = front->Prev();
+			if (previous == nullptr || previous == pair.first || visited.count(previous) > 0)
+				break;
+			front = previous;
+		}
+
+		TDynamicObject *member = front;
+		for (int step = 0; step < CONSIST_LIMIT && member != nullptr; ++step, member = member->Next())
+		{
+			if (visited.count(member) > 0)
+				break;
+			visited.emplace(member);
+			group.emplace_back(member);
+		}
+
+		bool wanted{false};
+		for (TDynamicObject *member : group)
+		{
+			auto const known = states.find(member);
+			if (known == states.end())
+				continue;
+			if (glm::length(member->GetPosition() - known->second.position) > tolerance)
+			{
+				wanted = true;
+				break;
+			}
+		}
+
+		if (!wanted)
+			continue;
+
+		for (TDynamicObject *member : group)
+		{
+			auto const known = states.find(member);
+			if (known == states.end())
+			{
+				// part of the consist is not in this update, so the set cannot be placed
+				// as a whole; leaving it alone beats tearing it in half
+				wanted = false;
+				break;
+			}
+		}
+
+		if (!wanted)
+			continue;
+
+		for (TDynamicObject *member : group)
+		{
+			reposition(*member, states.at(member));
+			++Result.repositioned;
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -234,7 +545,6 @@ void read_vehicles(std::istream &Stream)
 
 std::string write_crews()
 {
-	std::ostringstream body;
 	std::ostringstream entries;
 	uint32_t count{0};
 
@@ -252,6 +562,7 @@ std::string write_crews()
 		++count;
 	}
 
+	std::ostringstream body;
 	sn_utils::ls_uint32(body, count);
 	auto const packed = entries.str();
 	body.write(packed.data(), packed.size());
@@ -277,42 +588,204 @@ void read_crews(std::istream &Stream)
 	}
 }
 
+// ---------------------------------------------------------------------------
+// memory cells - this is what the signalling reads, so without them a client sees
+// semaphores frozen at whatever the scenario started with
+
+std::string write_memcells(bool const Full)
+{
+	std::ostringstream entries;
+	uint32_t count{0};
+
+	for (TMemCell const *cell : simulation::Memory.sequence())
+	{
+		if (cell == nullptr || cell->name().empty())
+			continue;
+
+		std::ostringstream packed;
+		sn_utils::s_str(packed, cell->name());
+		sn_utils::s_str(packed, cell->Text());
+		sn_utils::ls_float64(packed, cell->Value1());
+		sn_utils::ls_float64(packed, cell->Value2());
+		auto const record = packed.str();
+
+		auto const digest = digest_of(record);
+		if (!Full)
+		{
+			auto const previous = g_lastmemcells.find(cell->name());
+			if (previous != g_lastmemcells.end() && previous->second == digest)
+				continue;
+		}
+		g_lastmemcells[cell->name()] = digest;
+
+		entries.write(record.data(), record.size());
+		++count;
+	}
+
+	if (count == 0)
+		return std::string();
+
+	std::ostringstream body;
+	sn_utils::ls_uint32(body, count);
+	auto const packed = entries.str();
+	body.write(packed.data(), packed.size());
+
+	return body.str();
+}
+
+void read_memcells(std::istream &Stream)
+{
+	auto const count = sn_utils::ld_uint32(Stream);
+
+	for (uint32_t i = 0; i < count; ++i)
+	{
+		auto const name = sn_utils::d_str(Stream);
+		auto const text = sn_utils::d_str(Stream);
+		auto const value1 = sn_utils::ld_float64(Stream);
+		auto const value2 = sn_utils::ld_float64(Stream);
+
+		TMemCell *cell = simulation::Memory.find(name);
+		if (cell == nullptr)
+			continue;
+
+		if (cell->Text() == text && cell->Value1() == value1 && cell->Value2() == value2)
+			continue;
+
+		cell->UpdateValues(text, value1, value2, basic_event::flags::text | basic_event::flags::value1 | basic_event::flags::value2);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// switches
+
+std::string write_switches(bool const Full)
+{
+	std::ostringstream entries;
+	uint32_t count{0};
+
+	for (TTrack *track : simulation::Paths.sequence())
+	{
+		if (track == nullptr || track->name().empty())
+			continue;
+
+		int const state = track->GetSwitchState();
+		if (state < 0)
+			continue;
+
+		if (!Full)
+		{
+			auto const previous = g_lastswitches.find(track->name());
+			if (previous != g_lastswitches.end() && previous->second == state)
+				continue;
+		}
+		g_lastswitches[track->name()] = state;
+
+		sn_utils::s_str(entries, track->name());
+		sn_utils::ls_int32(entries, state);
+		++count;
+	}
+
+	if (count == 0)
+		return std::string();
+
+	std::ostringstream body;
+	sn_utils::ls_uint32(body, count);
+	auto const packed = entries.str();
+	body.write(packed.data(), packed.size());
+
+	return body.str();
+}
+
+void read_switches(std::istream &Stream)
+{
+	auto const count = sn_utils::ld_uint32(Stream);
+
+	for (uint32_t i = 0; i < count; ++i)
+	{
+		auto const name = sn_utils::d_str(Stream);
+		auto const state = sn_utils::ld_int32(Stream);
+
+		TTrack *track = simulation::Paths.find(name);
+		if (track == nullptr)
+			continue;
+
+		if (track->GetSwitchState() != state)
+			track->Switch(state);
+	}
+}
+
 } // namespace
 
-std::string network::take_snapshot()
+void network::reset_snapshot_history()
 {
-	std::ostringstream stream;
+	g_lastvehicles.clear();
+	g_lastmemcells.clear();
+	g_lastswitches.clear();
+}
 
+std::string network::take_snapshot(bool const Full)
+{
+	auto const session = write_session(Full);
+	auto const vehicles = write_vehicles(Full);
+	auto const crews = write_crews();
+	auto const memcells = write_memcells(Full);
+	auto const switches = write_switches(Full);
+
+	if (!Full && vehicles.empty() && memcells.empty() && switches.empty())
+	{
+		// nothing moved and nobody touched anything; the clock alone is not worth a packet
+		return std::string();
+	}
+
+	uint32_t chunks{1}; // the session section always goes along
+	if (!vehicles.empty())
+		++chunks;
+	++chunks; // crews
+	if (!memcells.empty())
+		++chunks;
+	if (!switches.empty())
+		++chunks;
+
+	std::ostringstream stream;
 	sn_utils::ls_uint32(stream, SNAPSHOT_MAGIC);
 	sn_utils::ls_uint32(stream, SNAPSHOT_VERSION);
 	sn_utils::ls_uint64(stream, Global.simulation_tick);
-	sn_utils::ls_uint32(stream, 3); // number of chunks that follow
+	sn_utils::ls_uint32(stream, chunks);
 
-	write_chunk(stream, SNAPSHOT_SESSION, write_session());
-	write_chunk(stream, SNAPSHOT_VEHICLES, write_vehicles());
-	write_chunk(stream, SNAPSHOT_CREWS, write_crews());
+	write_chunk(stream, SNAPSHOT_SESSION, session);
+	if (!vehicles.empty())
+		write_chunk(stream, SNAPSHOT_VEHICLES, vehicles);
+	write_chunk(stream, SNAPSHOT_CREWS, crews);
+	if (!memcells.empty())
+		write_chunk(stream, SNAPSHOT_MEMCELLS, memcells);
+	if (!switches.empty())
+		write_chunk(stream, SNAPSHOT_SWITCHES, switches);
 
 	auto const blob = stream.str();
-	WriteLog("net: snapshot taken at tick " + std::to_string(Global.simulation_tick) + ", " + std::to_string(blob.size()) + " bytes", logtype::net);
+
+	if (Full)
+		WriteLog("net: snapshot taken at tick " + std::to_string(Global.simulation_tick) + ", " + std::to_string(blob.size()) + " bytes", logtype::net);
 
 	return blob;
 }
 
-bool network::apply_snapshot(std::string const &Blob)
+network::snapshot_result network::apply_snapshot(std::string const &Blob, snapshot_mode const Mode)
 {
+	snapshot_result result;
+
 	std::istringstream stream(Blob);
 
 	if (sn_utils::ld_uint32(stream) != SNAPSHOT_MAGIC)
 	{
 		ErrorLog("net: snapshot rejected, not a snapshot", logtype::net);
-		return false;
+		return result;
 	}
 
 	auto const version = sn_utils::ld_uint32(stream);
 	if (version != SNAPSHOT_VERSION)
 	{
 		ErrorLog("net: snapshot rejected, version " + std::to_string(version) + " but this build speaks " + std::to_string(SNAPSHOT_VERSION), logtype::net);
-		return false;
+		return result;
 	}
 
 	auto const tick = sn_utils::ld_uint64(stream);
@@ -323,7 +796,7 @@ bool network::apply_snapshot(std::string const &Blob)
 		if (!stream.good())
 		{
 			ErrorLog("net: snapshot truncated", logtype::net);
-			return false;
+			return result;
 		}
 
 		auto const id = sn_utils::ld_uint16(stream);
@@ -337,23 +810,35 @@ bool network::apply_snapshot(std::string const &Blob)
 		switch (id)
 		{
 		case SNAPSHOT_SESSION:
-			read_session(chunk);
+			read_session(chunk, Mode);
 			break;
 		case SNAPSHOT_VEHICLES:
-			read_vehicles(chunk);
+			read_vehicles(chunk, Mode, result);
 			break;
 		case SNAPSHOT_CREWS:
 			read_crews(chunk);
 			break;
+		case SNAPSHOT_MEMCELLS:
+			read_memcells(chunk);
+			break;
+		case SNAPSHOT_SWITCHES:
+			read_switches(chunk);
+			break;
 		default:
 			// a section this build knows nothing about; its length is right there, so it
 			// costs nothing to walk past it
-			WriteLog("net: snapshot section " + std::to_string(id) + " skipped, unknown to this build", logtype::net);
 			break;
 		}
 	}
 
-	WriteLog("net: snapshot applied, now at tick " + std::to_string(tick), logtype::net);
+	result.ok = true;
 
-	return true;
+	if (Mode == snapshot_mode::join)
+	{
+		WriteLog("net: snapshot applied at tick " + std::to_string(tick) + ", " + std::to_string(result.vehicles) + " vehicles, " +
+		             std::to_string(result.repositioned) + " put back on the rails",
+		         logtype::net);
+	}
+
+	return result;
 }

--- a/network/snapshot.cpp
+++ b/network/snapshot.cpp
@@ -416,29 +416,54 @@ void apply_controls(TDynamicObject &Vehicle, vehicle_state const &State)
 		Vehicle.Mechanik->TakeControl(State.aiactive);
 }
 
-// puts a vehicle back where the authority says it is. place_on_track() wants the distance
-// of the vehicle's nose along the track, while what travels in the update is the offset of
-// its leading bogie; this inverts the arithmetic that function itself does
-void reposition(TDynamicObject &Vehicle, vehicle_state const &State)
+// puts a vehicle where the authority says it is.
+//
+// there are two ways to do that and they are not interchangeable. place_on_track() sets
+// the axles from scratch, which is right for a peer that is joining and has nothing to go
+// on - but doing it to a running train turns the whole set around, because the placement
+// works from the vehicle's own idea of which way it faces and that is not what a moving
+// consist looks like from outside. So a routine correction slides the vehicle along the
+// track it is already on, by the difference between the two bogie offsets. That is the
+// very same operation the physics performs on every step, so nothing gets reoriented and
+// nothing ends up beside the rails
+void correct_position(TDynamicObject &Vehicle, vehicle_state const &State, bool const Absolute)
 {
-	TTrack *track = track_by_id(State.track);
-	if (track == nullptr)
+	if (Absolute)
 	{
-		static bool reported{false};
-		if (!reported)
+		TTrack *track = track_by_id(State.track);
+		if (track == nullptr)
 		{
-			reported = true;
-			ErrorLog("net: cannot place " + Vehicle.name() + ", track " + std::to_string(State.track) + " is unknown here", logtype::net);
+			static bool reported{false};
+			if (!reported)
+			{
+				reported = true;
+				ErrorLog("net: cannot place " + Vehicle.name() + ", track " + std::to_string(State.track) + " is unknown here", logtype::net);
+			}
+			return;
 		}
+
+		double const half = Vehicle.fAxleDist * 0.5;
+		double const axleoffset = (State.axlefirst ? -half : half);
+		double const sign = (State.direction ? 1.0 : -1.0);
+		double const nose = (State.translation - axleoffset) * sign + 0.5 * Vehicle.MoverParameters->Dim.L;
+
+		Vehicle.place_on_track(track, nose, false);
 		return;
 	}
 
-	double const half = Vehicle.fAxleDist * 0.5;
-	double const axleoffset = (State.axlefirst ? -half : half);
-	double const sign = (State.direction ? 1.0 : -1.0);
-	double const nose = (State.translation - axleoffset) * sign + 0.5 * Vehicle.MoverParameters->Dim.L;
+	// both sides have to be talking about the same piece of track for the difference of
+	// the offsets to mean anything. when they are not, the vehicle is left alone until it
+	// gets there - a wrong guess here is what puts a locomotive next to the rails
+	if (track_id_of(Vehicle.RaTrackGet()) != State.track)
+		return;
 
-	Vehicle.place_on_track(track, nose, false);
+	double const delta = State.translation - Vehicle.RaTranslationGet();
+	if (std::abs(delta) < 0.01)
+		return;
+
+	// the offset runs from the track's first point, the move runs along the vehicle, and
+	// the axle's own sense of direction is what converts between the two
+	Vehicle.Move(delta * Vehicle.RaDirectionGet());
 }
 
 std::string write_vehicles(bool const Full, bool const OwnedOnly)
@@ -590,7 +615,7 @@ void read_vehicles(std::istream &Stream, network::snapshot_mode const Mode, netw
 
 		for (TDynamicObject *member : group)
 		{
-			reposition(*member, states.at(member));
+			correct_position(*member, states.at(member), Mode == network::snapshot_mode::join);
 			++Result.repositioned;
 		}
 	}

--- a/network/snapshot.cpp
+++ b/network/snapshot.cpp
@@ -77,6 +77,9 @@ TTrack *track_by_id(uint32_t const Id)
 	return (Id < g_trackindex.size() ? g_trackindex[Id] : nullptr);
 }
 
+// one-shot sound events seen since the last update went out, per vehicle
+std::unordered_map<std::string, int> g_soundevents;
+
 std::unordered_map<std::string, uint64_t> g_lastvehicles;
 std::unordered_map<std::string, uint64_t> g_lastmemcells;
 std::unordered_map<std::string, int> g_lastswitches;
@@ -210,6 +213,14 @@ struct vehicle_state
 	// what the vehicle is heard and seen doing. a peer that is not in this cab has no
 	// TTrain for it, so the commands that set these never reach it - only the result does
 	int32_t warningsignal{0};
+	// devices whose sound runs for as long as they do, and the one-shot events - relays
+	// clicking, air hissing - that happen too fast for an update to catch by sampling
+	bool converterrunning{false};
+	bool compressorrunning{false};
+	bool pantcompressorrunning{false};
+	bool compressorlock{false};
+	bool releaser{false};
+	int32_t soundevents{0};
 	int32_t emergencywarningsignal{0};
 	bool alarmchain{false};
 	double wheelrevolutions{0.0};
@@ -256,6 +267,12 @@ void serialize_vehicle(std::ostream &Stream, vehicle_state const &State)
 	}
 	sn_utils::ls_int32(Stream, State.lights[0]);
 	sn_utils::ls_int32(Stream, State.lights[1]);
+	sn_utils::s_bool(Stream, State.converterrunning);
+	sn_utils::s_bool(Stream, State.compressorrunning);
+	sn_utils::s_bool(Stream, State.pantcompressorrunning);
+	sn_utils::s_bool(Stream, State.compressorlock);
+	sn_utils::s_bool(Stream, State.releaser);
+	sn_utils::ls_int32(Stream, State.soundevents);
 	sn_utils::ls_int32(Stream, State.warningsignal);
 	sn_utils::ls_int32(Stream, State.emergencywarningsignal);
 	sn_utils::s_bool(Stream, State.alarmchain);
@@ -307,6 +324,12 @@ vehicle_state deserialize_vehicle(std::istream &Stream)
 	}
 	state.lights[0] = sn_utils::ld_int32(Stream);
 	state.lights[1] = sn_utils::ld_int32(Stream);
+	state.converterrunning = sn_utils::d_bool(Stream);
+	state.compressorrunning = sn_utils::d_bool(Stream);
+	state.pantcompressorrunning = sn_utils::d_bool(Stream);
+	state.compressorlock = sn_utils::d_bool(Stream);
+	state.releaser = sn_utils::d_bool(Stream);
+	state.soundevents = sn_utils::ld_int32(Stream);
 	state.warningsignal = sn_utils::ld_int32(Stream);
 	state.emergencywarningsignal = sn_utils::ld_int32(Stream);
 	state.alarmchain = sn_utils::d_bool(Stream);
@@ -362,6 +385,15 @@ vehicle_state read_from(TDynamicObject const &Vehicle)
 	}
 	state.lights[0] = mover.iLights[0];
 	state.lights[1] = mover.iLights[1];
+	state.converterrunning = mover.ConverterFlag;
+	state.compressorrunning = mover.CompressorFlag;
+	state.pantcompressorrunning = mover.PantCompFlag;
+	state.compressorlock = mover.CompressorGovernorLock;
+	state.releaser = (mover.Hamulec != nullptr && mover.Hamulec->Releaser());
+
+	auto const events = g_soundevents.find(Vehicle.name());
+	state.soundevents = (events != g_soundevents.end() ? events->second : 0);
+
 	state.warningsignal = mover.WarningSignal;
 	state.emergencywarningsignal = mover.EmergencyBrakeWarningSignal;
 	state.alarmchain = mover.AlarmChainFlag;
@@ -427,6 +459,18 @@ void apply_controls(TDynamicObject &Vehicle, vehicle_state const &State)
 
 	// the horn, the wheels and the engine note. these are set from a cab this peer does
 	// not have, so nothing but the result of them ever reaches it
+	mover.ConverterFlag = State.converterrunning;
+	mover.CompressorFlag = State.compressorrunning;
+	mover.PantCompFlag = State.pantcompressorrunning;
+	mover.CompressorGovernorLock = State.compressorlock;
+
+	if (mover.Hamulec != nullptr && mover.Hamulec->Releaser() != State.releaser)
+		mover.Hamulec->Releaser(State.releaser ? 1 : 0);
+
+	// the one-shot events are added to whatever this peer's own physics produced; the
+	// vehicle's sound handling plays them once and wipes the lot, as it always does
+	mover.SoundFlag |= State.soundevents;
+
 	mover.WarningSignal = State.warningsignal;
 	mover.EmergencyBrakeWarningSignal = State.emergencywarningsignal;
 	mover.AlarmChainFlag = State.alarmchain;
@@ -532,6 +576,9 @@ std::string write_vehicles(bool const Full, bool const OwnedOnly)
 
 		entries.write(record.data(), record.size());
 		++count;
+
+		// the one-shot events have been handed over; they must not go out twice
+		g_soundevents.erase(state.name);
 	}
 
 	if (count == 0)
@@ -827,8 +874,17 @@ void read_switches(std::istream &Stream)
 
 } // namespace
 
+void network::note_sound_events(std::string const &Vehicle, int const Events)
+{
+	if (Events == 0)
+		return;
+
+	g_soundevents[Vehicle] |= Events;
+}
+
 void network::reset_snapshot_history()
 {
+	g_soundevents.clear();
 	g_lastvehicles.clear();
 	g_lastmemcells.clear();
 	g_lastswitches.clear();

--- a/network/snapshot.cpp
+++ b/network/snapshot.cpp
@@ -33,7 +33,7 @@ uint32_t const SNAPSHOT_MAGIC{0x4e535545}; // 'EUSN'
 // a joining peer is placed exactly; a running one is left to its own physics for small
 // errors, because nudging a vehicle every fraction of a second is worse than the error
 double const REPOSITION_TOLERANCE_JOIN{0.5};
-double const REPOSITION_TOLERANCE_CORRECTION{2.5};
+double const REPOSITION_TOLERANCE_CORRECTION{1.5};
 
 // ---------------------------------------------------------------------------
 // what the authority last sent, so that a routine correction only carries changes
@@ -355,41 +355,20 @@ vehicle_state read_from(TDynamicObject const &Vehicle)
 	return state;
 }
 
-// true for the train the local player is working. its controls are driven by the commands
-// its crew issue, which every peer already receives, so the correction must keep its hands
-// off them - otherwise it keeps snapping a lever back a fraction of a second after the
-// player moved it, and the control looks broken
-bool is_own_train(std::string const &Name)
-{
-	auto const seat = network::Crews.vehicle_of(Global.network_peer_id);
-	if (seat == network::ENTITY_NONE)
-		return false;
-
-	auto const train = network::Entities.consist_of(network::Entities.id_of(Name));
-	return (train != network::ENTITY_NONE) && (network::Entities.consist_of(seat) == train);
-}
-
 // applies everything except where the vehicle is; position is dealt with per consist,
-// because moving one vehicle of a coupled set on its own tears the couplers apart
+// because moving one vehicle of a coupled set on its own tears the couplers apart.
+// only ever called for vehicles somebody else is running
 void apply_controls(TDynamicObject &Vehicle, vehicle_state const &State)
 {
 	auto &mover = *Vehicle.MoverParameters;
 
-	// what the physics produced is always taken from the authority; what a person set is
-	// not, on the train that person is working
-	bool const ours = is_own_train(State.name);
-
 	mover.V = State.velocity;
 	mover.Vel = State.velocitykmh;
-
-	if (!ours)
-	{
-		mover.DirActive = State.diractive;
-		mover.MainCtrlPos = State.mainctrl;
-		mover.ScndCtrlPos = State.scndctrl;
-		mover.BrakeCtrlPos = State.brakectrl;
-		mover.LocalBrakePosA = State.localbrake;
-	}
+	mover.DirActive = State.diractive;
+	mover.MainCtrlPos = State.mainctrl;
+	mover.ScndCtrlPos = State.scndctrl;
+	mover.BrakeCtrlPos = State.brakectrl;
+	mover.LocalBrakePosA = State.localbrake;
 
 	mover.PipePress = State.pipepress;
 	mover.BrakePress = State.brakepress;
@@ -397,14 +376,6 @@ void apply_controls(TDynamicObject &Vehicle, vehicle_state const &State)
 	mover.EqvtPipePress = State.eqvtpipepress;
 	mover.Compressor = State.compressor;
 	mover.CompressedVolume = State.compressedvolume;
-
-	if (ours)
-	{
-		// the rest of it is what the crew set, and their commands reach us on their own
-		if (Vehicle.Mechanik != nullptr && Vehicle.Mechanik->AIControllFlag != State.aiactive)
-			Vehicle.Mechanik->TakeControl(State.aiactive);
-		return;
-	}
 
 	// the appliances go through the vehicle's own switches wherever it has them, so that
 	// whatever they drag along stays consistent. range local: every vehicle carries its
@@ -470,7 +441,7 @@ void reposition(TDynamicObject &Vehicle, vehicle_state const &State)
 	Vehicle.place_on_track(track, nose, false);
 }
 
-std::string write_vehicles(bool const Full)
+std::string write_vehicles(bool const Full, bool const OwnedOnly)
 {
 	std::ostringstream entries;
 	uint32_t count{0};
@@ -478,6 +449,9 @@ std::string write_vehicles(bool const Full)
 	for (TDynamicObject const *vehicle : simulation::Vehicles.sequence())
 	{
 		if (vehicle == nullptr || vehicle->MoverParameters == nullptr)
+			continue;
+
+		if (OwnedOnly && !network::is_locally_simulated(network::Entities.id_of(vehicle->name())))
 			continue;
 
 		auto const state = read_from(*vehicle);
@@ -516,7 +490,7 @@ std::string write_vehicles(bool const Full)
 	return body.str();
 }
 
-void read_vehicles(std::istream &Stream, network::snapshot_mode const Mode, network::snapshot_result &Result)
+void read_vehicles(std::istream &Stream, network::snapshot_mode const Mode, network::PeerId const Owner, network::snapshot_result &Result)
 {
 	auto const count = sn_utils::ld_uint32(Stream);
 	double const tolerance = (Mode == network::snapshot_mode::join ? REPOSITION_TOLERANCE_JOIN : REPOSITION_TOLERANCE_CORRECTION);
@@ -530,6 +504,18 @@ void read_vehicles(std::istream &Stream, network::snapshot_mode const Mode, netw
 
 		TDynamicObject *vehicle = simulation::Vehicles.find(state.name);
 		if (vehicle == nullptr || vehicle->MoverParameters == nullptr)
+			continue;
+
+		auto const entity = network::Entities.id_of(state.name);
+
+		// a train this peer runs is not corrected by anybody: its own physics is what the
+		// rest of the session is being told about, and overwriting it would be the thing
+		// that makes the owner's ride stutter
+		if ((Mode == network::snapshot_mode::correction) && network::is_locally_simulated(entity))
+			continue;
+
+		// and a peer may only move what it is entitled to move
+		if ((Owner != network::PEER_NONE) && (network::simulation_owner(entity) != Owner))
 			continue;
 
 		apply_controls(*vehicle, state);
@@ -793,10 +779,28 @@ void network::reset_snapshot_history()
 	g_lastswitches.clear();
 }
 
-std::string network::take_snapshot(bool const Full)
+std::string network::take_snapshot(bool const Full, bool const OwnedOnly)
 {
+	auto const vehicles = write_vehicles(Full, OwnedOnly);
+
+	if (OwnedOnly)
+	{
+		// what a peer says about its own trains, and nothing else: the clock, the crews,
+		// the memory cells and the switches all belong to the authority
+		if (vehicles.empty())
+			return std::string();
+
+		std::ostringstream owned;
+		sn_utils::ls_uint32(owned, SNAPSHOT_MAGIC);
+		sn_utils::ls_uint32(owned, SNAPSHOT_VERSION);
+		sn_utils::ls_uint64(owned, Global.simulation_tick);
+		sn_utils::ls_uint32(owned, 1);
+		write_chunk(owned, SNAPSHOT_VEHICLES, vehicles);
+
+		return owned.str();
+	}
+
 	auto const session = write_session(Full);
-	auto const vehicles = write_vehicles(Full);
 	auto const crews = write_crews();
 	auto const memcells = write_memcells(Full);
 	auto const switches = write_switches(Full);
@@ -839,7 +843,7 @@ std::string network::take_snapshot(bool const Full)
 	return blob;
 }
 
-network::snapshot_result network::apply_snapshot(std::string const &Blob, snapshot_mode const Mode)
+network::snapshot_result network::apply_snapshot(std::string const &Blob, snapshot_mode const Mode, PeerId const Owner)
 {
 	snapshot_result result;
 
@@ -880,19 +884,23 @@ network::snapshot_result network::apply_snapshot(std::string const &Blob, snapsh
 		switch (id)
 		{
 		case SNAPSHOT_SESSION:
-			read_session(chunk, Mode);
+			if (Owner == PEER_NONE)
+				read_session(chunk, Mode);
 			break;
 		case SNAPSHOT_VEHICLES:
-			read_vehicles(chunk, Mode, result);
+			read_vehicles(chunk, Mode, Owner, result);
 			break;
 		case SNAPSHOT_CREWS:
-			read_crews(chunk);
+			if (Owner == PEER_NONE)
+				read_crews(chunk);
 			break;
 		case SNAPSHOT_MEMCELLS:
-			read_memcells(chunk);
+			if (Owner == PEER_NONE)
+				read_memcells(chunk);
 			break;
 		case SNAPSHOT_SWITCHES:
-			read_switches(chunk);
+			if (Owner == PEER_NONE)
+				read_switches(chunk);
 			break;
 		default:
 			// a section this build knows nothing about; its length is right there, so it

--- a/network/snapshot.cpp
+++ b/network/snapshot.cpp
@@ -29,11 +29,26 @@ namespace
 
 uint32_t const SNAPSHOT_MAGIC{0x4e535545}; // 'EUSN'
 
-// how far a vehicle may sit from where the authority says it is before it gets put back.
-// a joining peer is placed exactly; a running one is left to its own physics for small
-// errors, because nudging a vehicle every fraction of a second is worse than the error
-double const REPOSITION_TOLERANCE_JOIN{0.5};
-double const REPOSITION_TOLERANCE_CORRECTION{1.5};
+// how far a train may sit from where the session says it is before it gets put back.
+// two margins, both settable as multiplayer.sync.running / multiplayer.sync.stop and both
+// handed to every client by the server on connect: a generous one while it rolls, because
+// nudging a moving vehicle several times a second is worse than the error itself, and a
+// tight one for the moment it comes to a stand, applied once and then left alone
+double running_tolerance()
+{
+	return std::max(0.05, (double)Global.multiplayer_sync_running);
+}
+
+double stop_tolerance()
+{
+	return std::max(0.01, (double)Global.multiplayer_sync_stop);
+}
+
+// anything slower than this counts as standing still
+double const STANDSTILL_VELOCITY{0.05};
+
+// consists that have had their one precise correction since they last moved
+std::unordered_set<std::string> g_settled;
 
 // ---------------------------------------------------------------------------
 // what the authority last sent, so that a routine correction only carries changes
@@ -618,6 +633,197 @@ void correct_position(TDynamicObject &Vehicle, vehicle_state const &State, bool 
 	Vehicle.Move(delta * Vehicle.RaDirectionGet());
 }
 
+// ---------------------------------------------------------------------------
+// how the trains are made up.
+//
+// every peer loads its own copy of the scenery, which is the only reason joining a
+// session takes seconds rather than minutes - but the copy on disk is not the session.
+// The host may have shunted a set apart, put one together, or simply be running a
+// scenery whose trainsets were edited since. So the composition travels: which coupler
+// of which vehicle is joined to which coupler of which other vehicle, and with what.
+// The vehicles themselves do not - a peer that is missing one cannot be sent a model
+// over the wire, and says so in the log instead
+
+struct coupling_end
+{
+	int32_t flag{0};
+	std::string other;
+	uint8_t otherend{0};
+};
+
+struct consist_entry
+{
+	std::string name;
+	coupling_end ends[2];
+};
+
+std::string write_consists()
+{
+	std::ostringstream entries;
+	uint32_t count{0};
+
+	for (TDynamicObject const *vehicle : simulation::Vehicles.sequence())
+	{
+		if (vehicle == nullptr || vehicle->MoverParameters == nullptr)
+			continue;
+
+		sn_utils::s_str(entries, vehicle->name());
+
+		for (int end = 0; end < 2; ++end)
+		{
+			auto const &coupler = vehicle->MoverParameters->Couplers[end];
+			bool const linked = (coupler.Connected != nullptr) && (coupler.CouplingFlag != coupling::faux) && (coupler.ConnectedNr >= 0) && (coupler.ConnectedNr < 2);
+
+			sn_utils::ls_int32(entries, linked ? (int32_t)coupler.CouplingFlag : 0);
+			sn_utils::s_str(entries, linked ? coupler.Connected->Name : std::string());
+			sn_utils::s_uint8(entries, linked ? (uint8_t)coupler.ConnectedNr : (uint8_t)0);
+		}
+
+		++count;
+	}
+
+	if (count == 0)
+		return std::string();
+
+	std::ostringstream body;
+	sn_utils::ls_uint32(body, count);
+	auto const packed = entries.str();
+	body.write(packed.data(), packed.size());
+
+	return body.str();
+}
+
+// breaks a coupling whatever state the buffers are in. TDynamicObject::Dettach() leaves
+// the mechanical coupler in place unless the vehicles are pressed together, which is the
+// right thing for a player pulling a lever and the wrong thing for putting a peer's world
+// in order
+void force_detach(TDynamicObject &Vehicle, int const End)
+{
+	auto &coupler = Vehicle.MoverParameters->Couplers[End];
+
+	if (coupler.Connected == nullptr)
+	{
+		coupler.CouplingFlag = coupling::faux;
+		coupler.ConnectedNr = -1;
+		return;
+	}
+
+	// hands the consist's driver back, among other housekeeping
+	Vehicle.Dettach(End);
+
+	if ((coupler.Connected != nullptr) && (coupler.ConnectedNr >= 0) && (coupler.ConnectedNr < 2))
+	{
+		auto &othercoupler = coupler.Connected->Couplers[coupler.ConnectedNr];
+		othercoupler.Connected = nullptr;
+		othercoupler.ConnectedNr = -1;
+		othercoupler.CouplingFlag = coupling::faux;
+	}
+
+	coupler.Connected = nullptr;
+	coupler.ConnectedNr = -1;
+	coupler.CouplingFlag = coupling::faux;
+}
+
+void read_consists(std::istream &Stream)
+{
+	auto const count = sn_utils::ld_uint32(Stream);
+
+	std::vector<consist_entry> manifest;
+	manifest.reserve(count);
+
+	for (uint32_t i = 0; i < count; ++i)
+	{
+		consist_entry entry;
+		entry.name = sn_utils::d_str(Stream);
+		for (int end = 0; end < 2; ++end)
+		{
+			entry.ends[end].flag = sn_utils::ld_int32(Stream);
+			entry.ends[end].other = sn_utils::d_str(Stream);
+			entry.ends[end].otherend = sn_utils::d_uint8(Stream);
+		}
+		manifest.emplace_back(std::move(entry));
+	}
+
+	int detached{0};
+	int attached{0};
+	int missing{0};
+
+	// first everything that is coupled here and should not be, or is coupled to the wrong
+	// vehicle. doing this before making the new connections keeps a coupler from being
+	// claimed twice
+	for (auto const &entry : manifest)
+	{
+		TDynamicObject *vehicle = simulation::Vehicles.find(entry.name);
+		if (vehicle == nullptr || vehicle->MoverParameters == nullptr)
+		{
+			++missing;
+			continue;
+		}
+
+		for (int end = 0; end < 2; ++end)
+		{
+			auto const &coupler = vehicle->MoverParameters->Couplers[end];
+			if (coupler.Connected == nullptr)
+				continue;
+
+			auto const &wanted = entry.ends[end];
+			bool const same = (!wanted.other.empty()) && (coupler.Connected->Name == wanted.other) && (coupler.ConnectedNr == (int)wanted.otherend);
+
+			if (same)
+				continue;
+
+			force_detach(*vehicle, end);
+			++detached;
+		}
+	}
+
+	// then everything that should be coupled and is not, or is coupled with the wrong set
+	// of hoses and cables
+	for (auto const &entry : manifest)
+	{
+		TDynamicObject *vehicle = simulation::Vehicles.find(entry.name);
+		if (vehicle == nullptr || vehicle->MoverParameters == nullptr)
+			continue;
+
+		for (int end = 0; end < 2; ++end)
+		{
+			auto const &wanted = entry.ends[end];
+			if (wanted.other.empty() || wanted.flag == coupling::faux)
+				continue;
+
+			TDynamicObject *other = simulation::Vehicles.find(wanted.other);
+			if (other == nullptr || other->MoverParameters == nullptr)
+			{
+				++missing;
+				continue;
+			}
+
+			auto const &coupler = vehicle->MoverParameters->Couplers[end];
+			if ((coupler.Connected == other->MoverParameters) && (coupler.ConnectedNr == (int)wanted.otherend) && (coupler.CouplingFlag == wanted.flag))
+				continue;
+
+			// Enforce, because the two may not be pressed together yet on this peer - the
+			// positions in the same snapshot are what will settle that. Silent, because
+			// nobody here pulled a lever
+			if (false == vehicle->MoverParameters->Attach(end, (int)wanted.otherend, other->MoverParameters, wanted.flag, true, false))
+				continue;
+
+			vehicle->update_neighbours();
+			other->update_neighbours();
+			++attached;
+		}
+	}
+
+	if (detached != 0 || attached != 0)
+	{
+		WriteLog("net: trainsets reconciled with the session: " + std::to_string(detached) + " uncoupled, " + std::to_string(attached) + " coupled", logtype::net);
+	}
+	if (missing != 0)
+	{
+		ErrorLog("net: " + std::to_string(missing) + " vehicle(s) the session runs are not in the scenery loaded here", logtype::net);
+	}
+}
+
 std::string write_vehicles(bool const Full, bool const OwnedOnly)
 {
 	std::ostringstream entries;
@@ -674,7 +880,6 @@ std::string write_vehicles(bool const Full, bool const OwnedOnly)
 void read_vehicles(std::istream &Stream, network::snapshot_mode const Mode, network::PeerId const Owner, network::snapshot_result &Result)
 {
 	auto const count = sn_utils::ld_uint32(Stream);
-	double const tolerance = (Mode == network::snapshot_mode::join ? REPOSITION_TOLERANCE_JOIN : REPOSITION_TOLERANCE_CORRECTION);
 
 	std::unordered_map<TDynamicObject *, vehicle_state> states;
 	states.reserve(count);
@@ -741,41 +946,87 @@ void read_vehicles(std::istream &Stream, network::snapshot_mode const Mode, netw
 			group.emplace_back(member);
 		}
 
-		bool wanted{false};
+		// a rolling train and a standing one are held to different margins. the moving one
+		// is left to its own physics unless it is well out; the standing one is worth
+		// getting right to the centimetre, and is put right once rather than on every
+		// update that arrives while it sits there
+		bool moving{false};
 		for (TDynamicObject *member : group)
 		{
 			auto const known = states.find(member);
-			if (known == states.end())
-				continue;
-			if (glm::length(member->GetPosition() - known->second.position) > tolerance)
+			if ((known != states.end()) && (std::abs(known->second.velocity) > STANDSTILL_VELOCITY))
+			{
+				moving = true;
+				break;
+			}
+		}
+
+		double tolerance{stop_tolerance()};
+
+		if (Mode != network::snapshot_mode::join)
+		{
+			if (moving)
+			{
+				// on the move again: the next stand earns another precise correction
+				for (TDynamicObject *member : group)
+					g_settled.erase(member->name());
+				tolerance = running_tolerance();
+			}
+			else
+			{
+				bool settled{true};
+				for (TDynamicObject *member : group)
+				{
+					if (g_settled.count(member->name()) == 0)
+					{
+						settled = false;
+						break;
+					}
+				}
+				if (settled)
+					continue;
+			}
+		}
+
+		bool complete{true};
+		for (TDynamicObject *member : group)
+		{
+			if (states.find(member) == states.end())
+			{
+				// part of the consist is not in this update, so the set cannot be placed
+				// as a whole; leaving it alone beats tearing it in half
+				complete = false;
+				break;
+			}
+		}
+
+		if (!complete)
+			continue;
+
+		bool wanted{false};
+		for (TDynamicObject *member : group)
+		{
+			if (glm::length(member->GetPosition() - states.at(member).position) > tolerance)
 			{
 				wanted = true;
 				break;
 			}
 		}
 
-		if (!wanted)
-			continue;
-
-		for (TDynamicObject *member : group)
+		if (wanted)
 		{
-			auto const known = states.find(member);
-			if (known == states.end())
+			for (TDynamicObject *member : group)
 			{
-				// part of the consist is not in this update, so the set cannot be placed
-				// as a whole; leaving it alone beats tearing it in half
-				wanted = false;
-				break;
+				correct_position(*member, states.at(member), Mode == network::snapshot_mode::join);
+				++Result.repositioned;
 			}
 		}
 
-		if (!wanted)
-			continue;
-
-		for (TDynamicObject *member : group)
+		if (!moving && (Mode != network::snapshot_mode::join))
 		{
-			correct_position(*member, states.at(member), Mode == network::snapshot_mode::join);
-			++Result.repositioned;
+			// dealt with; nothing more happens to this train until it moves again
+			for (TDynamicObject *member : group)
+				g_settled.emplace(member->name());
 		}
 	}
 }
@@ -1004,6 +1255,7 @@ void network::reset_snapshot_history()
 	g_brakesoundevents.clear();
 	g_brakesoundseen.clear();
 	g_remotestate.clear();
+	g_settled.clear();
 	g_lastvehicles.clear();
 	g_lastmemcells.clear();
 	g_lastswitches.clear();
@@ -1031,6 +1283,9 @@ std::string network::take_snapshot(bool const Full, bool const OwnedOnly)
 	}
 
 	auto const session = write_session(Full);
+	// the make-up of the trains only travels with a full snapshot: it is what a joining
+	// peer needs, and after that it is a slow-moving thing that costs nothing to repeat
+	auto const consists = (Full ? write_consists() : std::string());
 	auto const crews = write_crews();
 	auto const memcells = write_memcells(Full);
 	auto const switches = write_switches(Full);
@@ -1042,6 +1297,8 @@ std::string network::take_snapshot(bool const Full, bool const OwnedOnly)
 	}
 
 	uint32_t chunks{1}; // the session section always goes along
+	if (!consists.empty())
+		++chunks;
 	if (!vehicles.empty())
 		++chunks;
 	++chunks; // crews
@@ -1057,6 +1314,10 @@ std::string network::take_snapshot(bool const Full, bool const OwnedOnly)
 	sn_utils::ls_uint32(stream, chunks);
 
 	write_chunk(stream, SNAPSHOT_SESSION, session);
+	// before the positions: how the trains are made up decides which vehicles get put
+	// back on the rails together
+	if (!consists.empty())
+		write_chunk(stream, SNAPSHOT_CONSISTS, consists);
 	if (!vehicles.empty())
 		write_chunk(stream, SNAPSHOT_VEHICLES, vehicles);
 	write_chunk(stream, SNAPSHOT_CREWS, crews);
@@ -1116,6 +1377,12 @@ network::snapshot_result network::apply_snapshot(std::string const &Blob, snapsh
 		case SNAPSHOT_SESSION:
 			if (Owner == PEER_NONE)
 				read_session(chunk, Mode);
+			break;
+		case SNAPSHOT_CONSISTS:
+			// only the authority says what is coupled to what; an update coming the other
+			// way is one peer talking about its own trains
+			if (Owner == PEER_NONE)
+				read_consists(chunk);
 			break;
 		case SNAPSHOT_VEHICLES:
 			read_vehicles(chunk, Mode, Owner, result);

--- a/network/snapshot.h
+++ b/network/snapshot.h
@@ -16,27 +16,54 @@ namespace network
 {
 
 // layout of the snapshot container. a reader refuses a blob it does not understand
-constexpr uint32_t SNAPSHOT_VERSION = 1;
+constexpr uint32_t SNAPSHOT_VERSION = 2;
 
 // the sections a snapshot is built from. a reader skips over any id it does not know,
 // which is what makes the format extensible: a peer built before a section existed can
 // still read a newer snapshot and simply ignores what it has no use for
 enum snapshot_chunk : uint16_t
 {
-	// tick, clock, weather and the state of the random engine
+	// tick, clock, weather and (in a full snapshot) the state of the random engine
 	SNAPSHOT_SESSION = 1,
-	// where every vehicle is and what its controls and brakes are doing
+	// where every vehicle is, what its controls and appliances are set to, and what its
+	// brakes are doing
 	SNAPSHOT_VEHICLES = 2,
 	// who is working which vehicle
-	SNAPSHOT_CREWS = 3
-	// candidates for the next versions: switches, memcells, the event queue, signals
+	SNAPSHOT_CREWS = 3,
+	// contents of the memory cells - this is what signalling reads
+	SNAPSHOT_MEMCELLS = 4,
+	// which way the switches are thrown
+	SNAPSHOT_SWITCHES = 5
 };
 
-// packs the current state of the world. only ever called on the authority
-std::string take_snapshot();
+// what a peer is meant to do with the blob it received
+enum class snapshot_mode
+{
+	// the peer is coming in cold and takes the world as it is given
+	join,
+	// routine correction on top of a simulation that is already running
+	correction
+};
 
-// restores a snapshot handed to us by the authority. returns false when the blob cannot
-// be used at all - a version we do not know, or damaged content
-bool apply_snapshot(std::string const &Blob);
+struct snapshot_result
+{
+	bool ok{false};
+	// how far the worst vehicle was from where the authority says it is
+	double worst_position_error{0.0};
+	uint32_t vehicles{0};
+	uint32_t repositioned{0};
+};
+
+// packs the state of the world. only ever called on the authority.
+// a full snapshot carries everything and is what a joining peer gets; otherwise only what
+// has changed since the last one goes out, which is what keeps the routine correction
+// stream small
+std::string take_snapshot(bool Full);
+
+// restores state handed to us by the authority
+snapshot_result apply_snapshot(std::string const &Blob, snapshot_mode Mode);
+
+// forgets what was last sent, so that the next delta comes out complete
+void reset_snapshot_history();
 
 } // namespace network

--- a/network/snapshot.h
+++ b/network/snapshot.h
@@ -1,0 +1,42 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace network
+{
+
+// layout of the snapshot container. a reader refuses a blob it does not understand
+constexpr uint32_t SNAPSHOT_VERSION = 1;
+
+// the sections a snapshot is built from. a reader skips over any id it does not know,
+// which is what makes the format extensible: a peer built before a section existed can
+// still read a newer snapshot and simply ignores what it has no use for
+enum snapshot_chunk : uint16_t
+{
+	// tick, clock, weather and the state of the random engine
+	SNAPSHOT_SESSION = 1,
+	// where every vehicle is and what its controls and brakes are doing
+	SNAPSHOT_VEHICLES = 2,
+	// who is working which vehicle
+	SNAPSHOT_CREWS = 3
+	// candidates for the next versions: switches, memcells, the event queue, signals
+};
+
+// packs the current state of the world. only ever called on the authority
+std::string take_snapshot();
+
+// restores a snapshot handed to us by the authority. returns false when the blob cannot
+// be used at all - a version we do not know, or damaged content
+bool apply_snapshot(std::string const &Blob);
+
+} // namespace network

--- a/network/snapshot.h
+++ b/network/snapshot.h
@@ -12,6 +12,8 @@ http://mozilla.org/MPL/2.0/.
 #include <cstdint>
 #include <string>
 
+#include "network/entities.h"
+
 namespace network
 {
 
@@ -58,10 +60,14 @@ struct snapshot_result
 // a full snapshot carries everything and is what a joining peer gets; otherwise only what
 // has changed since the last one goes out, which is what keeps the routine correction
 // stream small
-std::string take_snapshot(bool Full);
+// OwnedOnly limits it to the trains this peer runs itself and leaves out everything that
+// is not a vehicle; that is what a client sends upstream about its own train
+std::string take_snapshot(bool Full, bool OwnedOnly = false);
 
-// restores state handed to us by the authority
-snapshot_result apply_snapshot(std::string const &Blob, snapshot_mode Mode);
+// restores state handed to us. vehicles this peer runs itself are never touched - their
+// physics is the authority, not the other way round. Owner, when given, limits the update
+// to the trains that peer is entitled to move, so a client cannot shove anybody else's
+snapshot_result apply_snapshot(std::string const &Blob, snapshot_mode Mode, PeerId Owner = PEER_NONE);
 
 // forgets what was last sent, so that the next delta comes out complete
 void reset_snapshot_history();

--- a/network/snapshot.h
+++ b/network/snapshot.h
@@ -18,7 +18,7 @@ namespace network
 {
 
 // layout of the snapshot container. a reader refuses a blob it does not understand
-constexpr uint32_t SNAPSHOT_VERSION = 6;
+constexpr uint32_t SNAPSHOT_VERSION = 7;
 
 // the sections a snapshot is built from. a reader skips over any id it does not know,
 // which is what makes the format extensible: a peer built before a section existed can

--- a/network/snapshot.h
+++ b/network/snapshot.h
@@ -18,7 +18,7 @@ namespace network
 {
 
 // layout of the snapshot container. a reader refuses a blob it does not understand
-constexpr uint32_t SNAPSHOT_VERSION = 3;
+constexpr uint32_t SNAPSHOT_VERSION = 4;
 
 // the sections a snapshot is built from. a reader skips over any id it does not know,
 // which is what makes the format extensible: a peer built before a section existed can
@@ -71,5 +71,10 @@ snapshot_result apply_snapshot(std::string const &Blob, snapshot_mode Mode, Peer
 
 // forgets what was last sent, so that the next delta comes out complete
 void reset_snapshot_history();
+
+// remembers the one-shot sound events a vehicle produced. they are set and cleared inside
+// a single frame, so by the time an update is put together they would be long gone; this
+// is called from the vehicle's own sound handling, just before it wipes them
+void note_sound_events(std::string const &Vehicle, int Events);
 
 } // namespace network

--- a/network/snapshot.h
+++ b/network/snapshot.h
@@ -18,7 +18,7 @@ namespace network
 {
 
 // layout of the snapshot container. a reader refuses a blob it does not understand
-constexpr uint32_t SNAPSHOT_VERSION = 2;
+constexpr uint32_t SNAPSHOT_VERSION = 3;
 
 // the sections a snapshot is built from. a reader skips over any id it does not know,
 // which is what makes the format extensible: a peer built before a section existed can

--- a/network/snapshot.h
+++ b/network/snapshot.h
@@ -18,7 +18,7 @@ namespace network
 {
 
 // layout of the snapshot container. a reader refuses a blob it does not understand
-constexpr uint32_t SNAPSHOT_VERSION = 4;
+constexpr uint32_t SNAPSHOT_VERSION = 5;
 
 // the sections a snapshot is built from. a reader skips over any id it does not know,
 // which is what makes the format extensible: a peer built before a section existed can
@@ -76,5 +76,16 @@ void reset_snapshot_history();
 // a single frame, so by the time an update is put together they would be long gone; this
 // is called from the vehicle's own sound handling, just before it wipes them
 void note_sound_events(std::string const &Vehicle, int Events);
+
+// same, for the events the brake unit raises. those are only cleared when the vehicle
+// happens to have an accelerator sound to play, so what is passed here is peeked rather
+// than consumed and only the flags that have just appeared are taken
+void note_brake_sound_events(std::string const &Vehicle, int Events);
+
+// re-asserts, on every frame, the physics outputs of the vehicles somebody else is
+// running. an update arrives ten times a second; between them the local physics carries
+// on computing its own speed and brake force for a train it has no business simulating,
+// and the sawtooth that produces is what the brake and squeal sounds were chasing
+void hold_remote_state();
 
 } // namespace network

--- a/network/snapshot.h
+++ b/network/snapshot.h
@@ -18,7 +18,7 @@ namespace network
 {
 
 // layout of the snapshot container. a reader refuses a blob it does not understand
-constexpr uint32_t SNAPSHOT_VERSION = 5;
+constexpr uint32_t SNAPSHOT_VERSION = 6;
 
 // the sections a snapshot is built from. a reader skips over any id it does not know,
 // which is what makes the format extensible: a peer built before a section existed can
@@ -35,7 +35,10 @@ enum snapshot_chunk : uint16_t
 	// contents of the memory cells - this is what signalling reads
 	SNAPSHOT_MEMCELLS = 4,
 	// which way the switches are thrown
-	SNAPSHOT_SWITCHES = 5
+	SNAPSHOT_SWITCHES = 5,
+	// what is coupled to what. the session, not the copy of the scenery a peer happens to
+	// have on disk, decides how the trains are made up
+	SNAPSHOT_CONSISTS = 6
 };
 
 // what a peer is meant to do with the blob it received

--- a/network/statehash.cpp
+++ b/network/statehash.cpp
@@ -1,0 +1,89 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "network/statehash.h"
+
+#include "McZapkie/MOVER.h"
+#include "simulation/simulation.h"
+#include "simulation/simulationtime.h"
+#include "vehicle/DynObj.h"
+
+namespace
+{
+
+uint64_t const FNV_OFFSET{14695981039346656037ull};
+uint64_t const FNV_PRIME{1099511628211ull};
+
+uint64_t fold(uint64_t Hash, uint64_t Value)
+{
+	for (int i = 0; i < 8; ++i)
+	{
+		Hash ^= (Value >> (i * 8)) & 0xff;
+		Hash *= FNV_PRIME;
+	}
+	return Hash;
+}
+
+uint64_t fold(uint64_t Hash, std::string const &Text)
+{
+	for (char const character : Text)
+	{
+		Hash ^= (uint64_t)(unsigned char)character;
+		Hash *= FNV_PRIME;
+	}
+	return Hash;
+}
+
+// rounding to a fixed step keeps the digest from reacting to the last bits of a float
+int64_t quantize(double Value, double Step)
+{
+	if (!std::isfinite(Value))
+		return std::numeric_limits<int64_t>::min();
+
+	return (int64_t)std::llround(Value / Step);
+}
+
+} // namespace
+
+uint64_t network::state_hash()
+{
+	uint64_t digest{0};
+	uint64_t counted{0};
+
+	for (TDynamicObject const *vehicle : simulation::Vehicles.sequence())
+	{
+		if (vehicle == nullptr || vehicle->MoverParameters == nullptr)
+			continue;
+
+		auto const &mover = *vehicle->MoverParameters;
+		auto const position = vehicle->GetPosition();
+
+		uint64_t entry{FNV_OFFSET};
+		entry = fold(entry, vehicle->name());
+		entry = fold(entry, (uint64_t)quantize(position.x, 0.01));
+		entry = fold(entry, (uint64_t)quantize(position.y, 0.01));
+		entry = fold(entry, (uint64_t)quantize(position.z, 0.01));
+		entry = fold(entry, (uint64_t)quantize(mover.V, 0.001));
+		entry = fold(entry, (uint64_t)(int64_t)mover.DirActive);
+		entry = fold(entry, (uint64_t)quantize(mover.PipePress, 0.001));
+		entry = fold(entry, (uint64_t)quantize(mover.BrakePress, 0.001));
+
+		// summing keeps the whole thing independent of iteration order
+		digest += entry;
+		++counted;
+	}
+
+	digest = fold(digest, counted);
+
+	auto const &time = simulation::Time.data();
+	digest = fold(digest, (uint64_t)(time.wHour * 3600 + time.wMinute * 60 + time.wSecond));
+
+	return digest;
+}

--- a/network/statehash.h
+++ b/network/statehash.h
@@ -1,0 +1,32 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace network
+{
+
+// what goes into the digest. bump it whenever the layout changes, so that two builds
+// cannot silently compare digests that mean different things
+constexpr uint32_t STATE_HASH_VERSION = 1;
+
+// digest of the gameplay critical state of the world, used to notice that two peers have
+// drifted apart. deliberately order independent: every vehicle is folded in under its own
+// identity and the results are summed, so the order the scenario happened to create them
+// in does not matter. values are quantized, so that harmless float noise does not read as
+// a desync
+//
+// version 1 covers vehicle position, speed, direction and the two brake pressures, plus
+// the simulation clock. positions of switches, memcells and the event queue are the
+// obvious next candidates - they go in when the snapshot work of stage 7 defines them
+uint64_t state_hash();
+
+} // namespace network

--- a/scene/scene.cpp
+++ b/scene/scene.cpp
@@ -21,6 +21,7 @@ http://mozilla.org/MPL/2.0/.
 #include "scene/sn_utils.h"
 #include "rendering/renderer.h"
 #include "widgets/map_objects.h"
+#include "network/entities.h"
 
 namespace scene {
 
@@ -121,20 +122,20 @@ basic_cell::update_traction( TDynamicObject *Vehicle, int const Pantographindex 
 
 // legacy method, updates sounds and polls event launchers within radius around specified point
 void
-basic_cell::update_events() {
+basic_cell::update_events( event_poll_point const &Point ) {
 
     // event launchers
     for( auto *launcher : m_eventlaunchers ) {
-        glm::dvec3 campos = Global.pCamera.Pos;
+        glm::dvec3 referencepoint = Point.location;
         double radius = launcher->dRadius;
-        if (launcher->train_triggered && simulation::Train) {
-            campos = simulation::Train->Dynamic()->HeadPosition();
-            radius *= Timer::GetDeltaTime() * simulation::Train->Dynamic()->GetVelocity() * 0.277;
+        if( launcher->train_triggered && Point.vehicle != nullptr ) {
+            referencepoint = Point.vehicle->HeadPosition();
+            radius *= Timer::GetDeltaTime() * Point.vehicle->GetVelocity() * 0.277;
         }
 
         if( launcher->check_conditions()
             && ( radius < 0.0
-                || glm::distance2( launcher->location(), campos ) < launcher->dRadius ) ) {
+                || glm::distance2( launcher->location(), referencepoint ) < launcher->dRadius ) ) {
             if( launcher->check_activation() )
                 launch_event( launcher, true );
             if( launcher->check_activation_key() )
@@ -728,13 +729,17 @@ basic_section::update_traction( TDynamicObject *Vehicle, int const Pantographind
 
 // legacy method, polls event launchers within radius around specified point
 void
-basic_section::update_events( glm::dvec3 const &Location, float const Radius ) {
+basic_section::update_events( std::vector<event_poll_point> const &Points, float const Radius ) {
 
     for( auto &cell : m_cells ) {
 
-        if( glm::length2( cell.area().center - Location ) < sq(cell.area().radius + Radius) ) {
-            // we reject cells which aren't within our area of interest
-            cell.update_events();
+        for( auto const &point : Points ) {
+            if( glm::length2( cell.area().center - point.location ) < sq(cell.area().radius + Radius) ) {
+                cell.update_events( point );
+                // a cell is polled at most once per frame, no matter how many players are
+                // standing near it - launcher activation counters are stateful
+                break;
+            }
         }
     }
 }
@@ -1053,11 +1058,42 @@ basic_region::update_events() {
 
     if( false == simulation::is_ready ) { return; }
 
-    // render events and sounds from sectors near enough to the viewer
+    if( false == network::is_authority() ) {
+        // a client does not decide what fires; it carries out what the server sends it
+        return;
+    }
+
     auto const range = EU07_SECTIONSIZE; // arbitrary range
-    auto const &sectionlist = sections( Global.pCamera.Pos, range );
+
+    std::vector<event_poll_point> points;
+    points.emplace_back( event_poll_point{
+        Global.pCamera.Pos,
+        ( simulation::Train != nullptr ? simulation::Train->Dynamic() : nullptr ) } );
+
+    if( true == network::is_multiplayer() ) {
+        // gameplay may not hang on where the host happens to be looking, so the launchers
+        // are polled around every vehicle somebody is actually working
+        for( auto const &entry : network::Entities.entries() ) {
+            if( entry.crew_count == 0 ) { continue; }
+            auto const *vehicle { simulation::Vehicles.find( entry.name ) };
+            if( vehicle == nullptr ) { continue; }
+            if( simulation::Train != nullptr && simulation::Train->Dynamic() == vehicle ) { continue; }
+
+            points.emplace_back( event_poll_point{ vehicle->HeadPosition(), vehicle } );
+        }
+    }
+
+    // sections() hands back a scratchpad it reuses, so the union has to be collected first
+    std::vector<basic_section *> sectionlist;
+    for( auto const &point : points ) {
+        auto const &nearby = sections( point.location, range );
+        sectionlist.insert( sectionlist.end(), nearby.begin(), nearby.end() );
+    }
+    std::sort( sectionlist.begin(), sectionlist.end() );
+    sectionlist.erase( std::unique( sectionlist.begin(), sectionlist.end() ), sectionlist.end() );
+
     for( auto *section : sectionlist ) {
-        section->update_events( Global.pCamera.Pos, range );
+        section->update_events( points, range );
     }
 }
 

--- a/scene/scene.h
+++ b/scene/scene.h
@@ -31,6 +31,14 @@ class opengl33_renderer;
 
 namespace scene {
 
+// a place the event launchers are polled around. in a single player game there is just
+// one of these - the camera - but a session has to look at every crewed vehicle, because
+// gameplay may not depend on where any single player happens to be pointing their camera
+struct event_poll_point {
+    glm::dvec3 location;
+    TDynamicObject const *vehicle { nullptr };
+};
+
 int constexpr EU07_CELLSIZE = 250;
 int constexpr EU07_SECTIONSIZE = 1000;
 int constexpr EU07_REGIONSIDESECTIONCOUNT = 500; // number of sections along a side of square region
@@ -93,7 +101,7 @@ public:
         update_traction( TDynamicObject *Vehicle, int const Pantographindex );
     // legacy method, polls event launchers within radius around specified point
     void
-        update_events();
+        update_events( event_poll_point const &Point );
     // legacy method, updates sounds within radius around specified point
     void
         update_sounds();
@@ -264,7 +272,7 @@ public:
         update_traction( TDynamicObject *Vehicle, int const Pantographindex );
     // legacy method, updates sounds and polls event launchers within radius around specified point
     void
-        update_events( glm::dvec3 const &Location, float const Radius );
+        update_events( std::vector<event_poll_point> const &Points, float const Radius );
     // legacy method, updates sounds and polls event launchers within radius around specified point
     void
         update_sounds( glm::dvec3 const &Location, float const Radius );

--- a/simulation/simulation.cpp
+++ b/simulation/simulation.cpp
@@ -295,16 +295,26 @@ void state_manager::process_commands() {
 
 			std::string event_name;
 			std::string vehicle_name;
+			std::string delay_text;
 			std::getline(ss, event_name, '%');
 			std::getline(ss, vehicle_name, '%');
+			std::getline(ss, delay_text, '%');
 
 			basic_event *ev = Events.FindEvent(event_name);
 			TDynamicObject *vehicle = nullptr;
 			if (!vehicle_name.empty())
 				vehicle = simulation::Vehicles.find(vehicle_name);
 
+			double delay = 0.0;
+			if (!delay_text.empty()) {
+				try { delay = std::stod(delay_text); }
+				catch (std::exception const &) { delay = 0.0; }
+			}
+
+			// this is the authority speaking, whether it reached us over the wire or came
+			// straight from our own event manager
 			if (ev)
-				Events.AddToQuery(ev, vehicle);
+				Events.AddToQuery(ev, vehicle, delay, event_launch::authority);
 		}
 
 		if (commanddata.command == user_command::setlight) {

--- a/utilities/Globals.cpp
+++ b/utilities/Globals.cpp
@@ -902,6 +902,18 @@ bool global_settings::ConfigParseNetwork(cParser& Parser, const std::string& tok
         return true;
     }
 
+    if (token == "multiplayer.sync.running")
+    {
+        ParseOneClamped(Parser, multiplayer_sync_running, 0.05f, 100.0f, 1, false);
+        return true;
+    }
+
+    if (token == "multiplayer.sync.stop")
+    {
+        ParseOneClamped(Parser, multiplayer_sync_stop, 0.01f, 100.0f, 1, false);
+        return true;
+    }
+
     return false;
 }
 
@@ -1815,6 +1827,8 @@ global_settings::export_as_text( std::ostream &Output ) const {
             << "network.client "
             << network_client->first << " " << network_client->second << "\n";
     }
+    export_as_text( Output, "multiplayer.sync.running", multiplayer_sync_running );
+    export_as_text( Output, "multiplayer.sync.stop", multiplayer_sync_stop );
     export_as_text( Output, "execonexit", exec_on_exit );
 }
 

--- a/utilities/Globals.cpp
+++ b/utilities/Globals.cpp
@@ -914,6 +914,13 @@ bool global_settings::ConfigParseNetwork(cParser& Parser, const std::string& tok
         return true;
     }
 
+    if (token == "multiplayer.nickname")
+    {
+        Parser.getTokens(1, false);
+        Parser >> multiplayer_nickname;
+        return true;
+    }
+
     return false;
 }
 
@@ -1829,6 +1836,7 @@ global_settings::export_as_text( std::ostream &Output ) const {
     }
     export_as_text( Output, "multiplayer.sync.running", multiplayer_sync_running );
     export_as_text( Output, "multiplayer.sync.stop", multiplayer_sync_stop );
+    export_as_text( Output, "multiplayer.nickname", multiplayer_nickname );
     export_as_text( Output, "execonexit", exec_on_exit );
 }
 

--- a/utilities/Globals.cpp
+++ b/utilities/Globals.cpp
@@ -1040,6 +1040,77 @@ bool global_settings::ConfigParseHardware(cParser& Parser, const std::string& to
     }
 #endif
 
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+    // hardware protocol v2 (uart v2). the legacy uart entries above keep working unchanged, both
+    // protocols may be used at the same time as long as they don't share a port
+    if (token == "uart2")
+    {
+        Parser.getTokens(2, false);
+        hardware::serial_link_config link;
+        Parser >> link.port
+               >> link.baud;
+        if (false == link.port.empty())
+        {
+            hardware_conf.serial_links.emplace_back(link);
+            hardware_conf.enable = true;
+        }
+        return true;
+    }
+
+    if (token == "uart2framesize")
+    {
+        int framesize = static_cast<int>(hardware_conf.frame_size);
+        ParseOneClamped(Parser, framesize, static_cast<int>(hardware::protocol_frame_size_min), static_cast<int>(hardware::protocol_frame_size_max));
+        hardware_conf.frame_size = static_cast<std::size_t>(framesize);
+        return true;
+    }
+
+    if (token == "uart2heartbeat")
+    {
+        ParseOneClamped(Parser, hardware_conf.heartbeat_interval_ms, 50, 10000);
+        return true;
+    }
+
+    if (token == "uart2timeout")
+    {
+        ParseOneClamped(Parser, hardware_conf.heartbeat_timeout_count, 2, 100);
+        return true;
+    }
+
+    if (token == "uart2ratelimit")
+    {
+        Parser.getTokens(3);
+        Parser >> hardware_conf.max_frames_per_second
+               >> hardware_conf.max_payload_bytes_per_second
+               >> hardware_conf.max_commands_per_second;
+        return true;
+    }
+
+    if (token == "uart2pollinterval")
+    {
+        ParseOneClamped(Parser, hardware_conf.poll_interval_ms, 1, 100);
+        return true;
+    }
+
+    if (token == "uart2reconnect")
+    {
+        ParseOneClamped(Parser, hardware_conf.reconnect_interval, 0.1f, 60.0f);
+        return true;
+    }
+
+    if (token == "uart2debug")
+    {
+        ParseOne(Parser, hardware_conf.debug, 1);
+        return true;
+    }
+
+    if (token == "uart2debugframes")
+    {
+        ParseOne(Parser, hardware_conf.debug_frames, 1);
+        return true;
+    }
+#endif
+
 #ifdef WITH_ZMQ
     if (token == "zmq.address")
     {

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -366,6 +366,8 @@ struct global_settings {
 	// authoritative frame it is executing; the network timeline hangs off this, not off
 	// the number of frames the renderer happened to draw
 	uint64_t simulation_tick = 0;
+	// set once a joining client has taken over the state of the world from the server
+	bool network_snapshot_applied = false;
 
 	std::unordered_map<int, std::string> trainset_overrides;
 

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -372,6 +372,14 @@ struct global_settings {
 	uint64_t network_session_token = 0;
 	// how far the worst vehicle was out of place when the last correction arrived, metres
 	float network_position_error = 0.0f;
+	// how far a train may be from where the session says it is before it gets put back,
+	// in metres. the first applies while it is rolling, where nudging it too eagerly is
+	// worse than the error itself; the second once it has come to a stand, where it is
+	// worth getting exactly right and is done once rather than every update.
+	// the server hands its own values to every client on connect, so a session is
+	// consistent whatever each player has in their ini
+	float multiplayer_sync_running = 1.5f;
+	float multiplayer_sync_stop = 0.2f;
 	// the scenario has finished loading and the world can be worked with. this is not the
 	// same as simulation::is_ready, which only goes up once the player has a cab
 	bool simulation_loaded = false;

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -370,6 +370,8 @@ struct global_settings {
 	bool network_snapshot_applied = false;
 	// identity handed out by the server, presented again when reconnecting
 	uint64_t network_session_token = 0;
+	// how far the worst vehicle was out of place when the last correction arrived, metres
+	float network_position_error = 0.0f;
 
 	std::unordered_map<int, std::string> trainset_overrides;
 

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -20,6 +20,9 @@ http://mozilla.org/MPL/2.0/.
 #ifdef WITH_UART
 #include "utilities/uart.h"
 #endif
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+#include "hardware/hardware_config.h"
+#endif
 #ifdef WITH_ZMQ
 #include "input/zmq_input.h"
 #endif
@@ -227,6 +230,10 @@ struct global_settings {
         {"radiochannel", &uart_conf.radiochannelenable},
         {"dynamicbrake", &uart_conf.dynamicenable},
     };
+#endif
+#ifdef WITH_HARDWARE_PROTOCOL_V2
+    // hardware protocol v2; independent of the legacy uart link above, both may run at the same time
+    hardware::config hardware_conf;
 #endif
 #ifdef WITH_ZMQ
     std::string zmq_address;

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -354,6 +354,10 @@ struct global_settings {
 	std::string network_status;
 	// set when the server refused us; keeps the reason for the ui and stops reconnect attempts
 	std::string network_reject_reason;
+	// identity of this participant within the session; the host keeps network::PEER_HOST
+	uint32_t network_peer_id = 0;
+	// vehicle the local player asked to enter from the multiplayer lobby
+	std::string network_pending_vehicle;
 
 	std::unordered_map<int, std::string> trainset_overrides;
 

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -81,6 +81,9 @@ struct global_settings {
     std::string szDefaultExt{ szTexturesDDS };
 	std::string SceneryFile;
     std::string local_start_vehicle{ "EU07-424" };
+    // set when the starting vehicle was explicitly requested (command line -v),
+    // so multiplayer clients can tell an intentional choice from the built-in default
+    bool local_start_vehicle_override{ false };
     int iConvertModels{ 0 }; // tworzenie plików binarnych
     int iConvertIndexRange{ 1000 }; // range of duplicate vertex scan
     bool file_binary_terrain{ true }; // enable binary terrain (de)serialization
@@ -347,6 +350,10 @@ struct global_settings {
 	std::vector<std::pair<std::string, std::string>> network_servers;
 	std::optional<std::pair<std::string, std::string>> network_client;
 	float desync = 0.0f;
+	// human readable state of the network session, presented on the connecting/loading screen
+	std::string network_status;
+	// set when the server refused us; keeps the reason for the ui and stops reconnect attempts
+	std::string network_reject_reason;
 
 	std::unordered_map<int, std::string> trainset_overrides;
 

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -380,6 +380,11 @@ struct global_settings {
 	// consistent whatever each player has in their ini
 	float multiplayer_sync_running = 1.5f;
 	float multiplayer_sync_stop = 0.2f;
+	// what this player would like to be called in a session. empty falls back to the
+	// account name, and failing that to "player <n>"
+	std::string multiplayer_nickname;
+	// no window, no renderer and nobody in a cab: the executable as a dedicated server
+	bool headless = false;
 	// the scenario has finished loading and the world can be worked with. this is not the
 	// same as simulation::is_ready, which only goes up once the player has a cab
 	bool simulation_loaded = false;

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -375,6 +375,8 @@ struct global_settings {
 	// the scenario has finished loading and the world can be worked with. this is not the
 	// same as simulation::is_ready, which only goes up once the player has a cab
 	bool simulation_loaded = false;
+	// consecutive steps whose state digest disagreed with the server's; diagnostics only
+	uint64_t network_digest_mismatches = 0;
 
 	std::unordered_map<int, std::string> trainset_overrides;
 

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -372,6 +372,9 @@ struct global_settings {
 	uint64_t network_session_token = 0;
 	// how far the worst vehicle was out of place when the last correction arrived, metres
 	float network_position_error = 0.0f;
+	// the scenario has finished loading and the world can be worked with. this is not the
+	// same as simulation::is_ready, which only goes up once the player has a cab
+	bool simulation_loaded = false;
 
 	std::unordered_map<int, std::string> trainset_overrides;
 

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -358,6 +358,10 @@ struct global_settings {
 	uint32_t network_peer_id = 0;
 	// vehicle the local player asked to enter from the multiplayer lobby
 	std::string network_pending_vehicle;
+	// set when the local player left the crew and should go back to observing
+	bool network_leave_pending = false;
+	// last answer of the server to a lobby request, shown in the lobby
+	std::string network_lobby_message;
 
 	std::unordered_map<int, std::string> trainset_overrides;
 

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -368,6 +368,8 @@ struct global_settings {
 	uint64_t simulation_tick = 0;
 	// set once a joining client has taken over the state of the world from the server
 	bool network_snapshot_applied = false;
+	// identity handed out by the server, presented again when reconnecting
+	uint64_t network_session_token = 0;
 
 	std::unordered_map<int, std::string> trainset_overrides;
 

--- a/utilities/Globals.h
+++ b/utilities/Globals.h
@@ -362,6 +362,10 @@ struct global_settings {
 	bool network_leave_pending = false;
 	// last answer of the server to a lobby request, shown in the lobby
 	std::string network_lobby_message;
+	// logical simulation step. the authority counts it up, a client takes it from the
+	// authoritative frame it is executing; the network timeline hangs off this, not off
+	// the number of frames the renderer happened to draw
+	uint64_t simulation_tick = 0;
 
 	std::unordered_map<int, std::string> trainset_overrides;
 

--- a/vehicle/DynObj.cpp
+++ b/vehicle/DynObj.cpp
@@ -4626,6 +4626,12 @@ void TDynamicObject::RenderSounds() {
     }
 
     // yB: przyspieszacz (moze zadziala, ale dzwiek juz jest)
+    if( ( true == network::is_multiplayer() )
+     && ( MoverParameters->Hamulec != nullptr ) ) {
+        // peeked rather than read: reading the brake unit's flags is what clears them,
+        // and they belong to the vehicle, not to us
+        network::note_brake_sound_events( name(), MoverParameters->Hamulec->PeekSoundFlag() );
+    }
     if( true == bBrakeAcc ) {
         if( true == TestFlag( MoverParameters->Hamulec->GetSoundFlag(), sf_Acc ) ) {
             sBrakeAcc.play( sound_flags::exclusive );

--- a/vehicle/DynObj.cpp
+++ b/vehicle/DynObj.cpp
@@ -23,6 +23,8 @@ http://mozilla.org/MPL/2.0/.
 #include "utilities/Globals.h"
 #include "utilities/Timer.h"
 #include "utilities/Logs.h"
+#include "network/entities.h"
+#include "network/snapshot.h"
 #include "utilities/glmHelpers.h"
 #include "Console.h"
 #include "world/Traction.h"
@@ -5114,6 +5116,12 @@ void TDynamicObject::RenderSounds() {
 
         ++couplerindex;
         coupler.sounds = 0;
+    }
+
+    if( true == network::is_multiplayer() ) {
+        // relays clicking and air hissing are set and cleared inside a single frame, so
+        // they have to be picked up here to have any chance of reaching the other peers
+        network::note_sound_events( name(), MoverParameters->SoundFlag );
     }
 
     MoverParameters->SoundFlag = 0;

--- a/vehicle/Train.cpp
+++ b/vehicle/Train.cpp
@@ -953,7 +953,7 @@ TTrain::state_t TTrain::get_state() const
 	    static_cast<float>(mvPantographUnit->PantPress),
 	    fHVoltage,
 	    {fHCurrent[mvControlled->TrainType & dt_EZT ? 0 : 1], fHCurrent[2], fHCurrent[3]},
-		mvOccupied->EngineVoltage,
+		static_cast<uint32_t>(mvOccupied->EngineVoltage),
 	    ggLVoltage.GetValue(),
 	    mvOccupied->DistCounter,
 	    static_cast<std::uint8_t>(RadioChannel()),

--- a/vehicle/Train.cpp
+++ b/vehicle/Train.cpp
@@ -953,6 +953,7 @@ TTrain::state_t TTrain::get_state() const
 	    static_cast<float>(mvPantographUnit->PantPress),
 	    fHVoltage,
 	    {fHCurrent[mvControlled->TrainType & dt_EZT ? 0 : 1], fHCurrent[2], fHCurrent[3]},
+		mvOccupied->EngineVoltage,
 	    ggLVoltage.GetValue(),
 	    mvOccupied->DistCounter,
 	    static_cast<std::uint8_t>(RadioChannel()),

--- a/vehicle/Train.h
+++ b/vehicle/Train.h
@@ -108,6 +108,7 @@ class TTrain {
         float pantograph_pressure;
         float hv_voltage;
         std::array<float, 3> hv_current;
+    	double enginevoltage;
         float lv_voltage;
 		double distance;
 		std::uint8_t radio_channel;

--- a/vehicle/Train.h
+++ b/vehicle/Train.h
@@ -108,7 +108,7 @@ class TTrain {
         float pantograph_pressure;
         float hv_voltage;
         std::array<float, 3> hv_current;
-    	double enginevoltage;
+    	std::uint32_t enginevoltage;
         float lv_voltage;
 		double distance;
 		std::uint8_t radio_channel;

--- a/widgets/chat_panel.cpp
+++ b/widgets/chat_panel.cpp
@@ -1,0 +1,111 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "widgets/chat_panel.h"
+
+#include "application/application.h"
+#include "network/chat.h"
+#include "network/entities.h"
+#include "utilities/Globals.h"
+#include "utilities/translation.h"
+
+namespace
+{
+
+// keeps the key that opens the panel from ending up in the line being typed
+int filter_input(ImGuiInputTextCallbackData *Data)
+{
+	if (Data->EventChar == '`' || Data->EventChar == '~')
+		return 1;
+	return 0;
+}
+
+} // namespace
+
+ui::chat_panel::chat_panel()
+    : ui_panel(STR_C("Chat"), false)
+{
+	// both bounds have to be set, or imgui gets a maximum below the minimum
+	size_min = {380, 200};
+	size_max = {900, 600};
+}
+
+void ui::chat_panel::focus_input()
+{
+	m_focusrequested = true;
+}
+
+void ui::chat_panel::submit()
+{
+	std::string const text(m_input.data());
+	m_input.fill('\0');
+
+	if (text.empty())
+		return;
+
+	Application.say(text);
+}
+
+void ui::chat_panel::render_contents()
+{
+	if (!network::is_multiplayer())
+	{
+		ImGui::TextUnformatted(STR_C("This is not a multiplayer session."));
+		return;
+	}
+
+	auto const &log = network::chat_log();
+
+	// the conversation, with room left underneath for the box it is typed into
+	float const lineheight = ImGui::GetTextLineHeightWithSpacing();
+	ImGui::BeginChild("chatlog", ImVec2(0.0f, -(lineheight + ImGui::GetStyle().ItemSpacing.y * 2.0f)), false,
+	                  ImGuiWindowFlags_HorizontalScrollbar);
+
+	for (auto const &line : log)
+	{
+		bool const own{line.author == Global.network_peer_id};
+		ImGui::TextColored(own ? ImVec4(0.6f, 0.85f, 1.0f, 1.0f) : ImVec4(1.0f, 0.85f, 0.55f, 1.0f), "%s:", line.name.c_str());
+		ImGui::SameLine();
+		ImGui::TextWrapped("%s", line.text.c_str());
+	}
+
+	// follow the conversation, but only when something new has actually arrived - dragging
+	// the scrollbar back to read something should not be undone every frame
+	if (network::chat_serial() != m_lastserial)
+	{
+		m_lastserial = network::chat_serial();
+		ImGui::SetScrollHereY(1.0f);
+	}
+
+	ImGui::EndChild();
+
+	if (m_focusrequested)
+	{
+		ImGui::SetKeyboardFocusHere();
+		m_focusrequested = false;
+	}
+
+	ImGui::PushItemWidth(-1.0f);
+	if (ImGui::InputText("##chatinput", m_input.data(), m_input.size(),
+	                     ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_CallbackCharFilter, filter_input))
+	{
+		submit();
+		// staying in the box is what anybody expects after sending a line
+		m_focusrequested = true;
+	}
+	ImGui::PopItemWidth();
+
+	// while the box has the keyboard, imgui swallows the key that opened the panel, so
+	// there has to be another way out of it
+	if (ImGui::IsKeyPressed(ImGui::GetIO().KeyMap[ImGuiKey_Escape]))
+	{
+		is_open = false;
+	}
+}

--- a/widgets/chat_panel.h
+++ b/widgets/chat_panel.h
@@ -1,0 +1,38 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include "application/uilayer.h"
+
+namespace ui
+{
+
+// what the participants of a session are saying to one another. opened and closed with the
+// key left of 1, and while it is open the text box holds the keyboard, so typing "d" is
+// typing "d" rather than opening the doors of whatever you happen to be driving
+class chat_panel : public ui_panel
+{
+  public:
+	chat_panel();
+
+	void render_contents() override;
+
+	// called when the panel is opened, so that the cursor lands in the text box
+	void focus_input();
+
+  private:
+	void submit();
+
+	std::array<char, 256> m_input{};
+	bool m_focusrequested{false};
+	uint64_t m_lastserial{0};
+};
+
+} // namespace ui

--- a/widgets/multiplayer_lobby.cpp
+++ b/widgets/multiplayer_lobby.cpp
@@ -24,7 +24,10 @@ http://mozilla.org/MPL/2.0/.
 ui::multiplayer_lobby_panel::multiplayer_lobby_panel()
     : ui_panel(STR_C("Multiplayer lobby"), false)
 {
-	size_min = {520, 280};
+	// both bounds have to be set: ui_panel feeds them straight to imgui, and a maximum
+	// left at its -1 default is smaller than the minimum, which collapses the window
+	size_min = {560, 320};
+	size_max = {1920, 1080};
 }
 
 std::string ui::multiplayer_lobby_panel::describe_crew(network::NetworkEntityId const Entity) const
@@ -62,7 +65,8 @@ void ui::multiplayer_lobby_panel::render_contents()
 	}
 
 	ImGui::Text("%s: %s, peer %u", STR_C("Session"), host ? (client ? "host + client" : "host") : "client", Global.network_peer_id);
-	ImGui::TextUnformatted(Global.SceneryFile.c_str());
+	if (!Global.SceneryFile.empty())
+		ImGui::TextDisabled("%s", Global.SceneryFile.c_str());
 
 	if (!Global.network_lobby_message.empty())
 		ImGui::TextColored(ImVec4(1.0f, 0.6f, 0.3f, 1.0f), "%s", Global.network_lobby_message.c_str());
@@ -72,16 +76,22 @@ void ui::multiplayer_lobby_panel::render_contents()
 	auto const &entries = network::Entities.entries();
 	if (entries.empty())
 	{
-		ImGui::TextUnformatted(STR_C("Waiting for the vehicle list from the server..."));
+		ImGui::TextUnformatted(client ? STR_C("Waiting for the vehicle list from the server...") : STR_C("This scenario has no vehicles anybody could drive."));
 		return;
 	}
 
 	network::NetworkEntityId const ownvehicle{network::Crews.vehicle_of(Global.network_peer_id)};
 
+	float const scale = std::max(1.0f, Global.ui_scale);
+	float const crewwidth = 60.0f * scale;
+	float const statewidth = 150.0f * scale;
+	float const actionwidth = 110.0f * scale;
+
 	ImGui::Columns(4, "mp_vehicles", false);
-	ImGui::SetColumnWidth(1, 70.0f * Global.ui_scale);
-	ImGui::SetColumnWidth(2, 200.0f * Global.ui_scale);
-	ImGui::SetColumnWidth(3, 130.0f * Global.ui_scale);
+	ImGui::SetColumnWidth(0, std::max(120.0f * scale, ImGui::GetWindowWidth() - crewwidth - statewidth - actionwidth - 30.0f * scale));
+	ImGui::SetColumnWidth(1, crewwidth);
+	ImGui::SetColumnWidth(2, statewidth);
+	ImGui::SetColumnWidth(3, actionwidth);
 
 	ImGui::TextDisabled("%s", STR_C("Vehicle"));
 	ImGui::NextColumn();
@@ -111,14 +121,14 @@ void ui::multiplayer_lobby_panel::render_contents()
 
 		if (entry.id == ownvehicle)
 		{
-			if (ImGui::Button(STR_C("Leave"), ImVec2(-1, 0)))
+			if (ImGui::Button(STR_C("Leave")))
 				Application.request_vehicle_leave(entry.id);
 		}
 		else if (entry.claimable)
 		{
 			// a vehicle somebody else is already working on can still be joined, that is
 			// what the crew capacity is for
-			if (ImGui::Button(entry.crew_count > 0 ? STR_C("Join crew") : STR_C("Enter"), ImVec2(-1, 0)))
+			if (ImGui::Button(entry.crew_count > 0 ? STR_C("Join crew") : STR_C("Enter")))
 				claim(entry.id, ownvehicle);
 		}
 		else
@@ -131,6 +141,9 @@ void ui::multiplayer_lobby_panel::render_contents()
 	}
 
 	ImGui::Columns(1);
+
+	ImGui::Separator();
+	ImGui::TextDisabled("%s", STR_C("You can also walk up to a vehicle and use the enter-vehicle key."));
 }
 
 void ui::multiplayer_lobby_panel::claim(network::NetworkEntityId const Entity, network::NetworkEntityId const Current)

--- a/widgets/multiplayer_lobby.cpp
+++ b/widgets/multiplayer_lobby.cpp
@@ -1,0 +1,119 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#include "stdafx.h"
+#include "widgets/multiplayer_lobby.h"
+
+#include "application/application.h"
+#include "network/entities.h"
+#include "simulation/simulation.h"
+#include "utilities/Globals.h"
+#include "utilities/utilities.h"
+#include "utilities/translation.h"
+#include "vehicle/Driver.h"
+#include "vehicle/DynObj.h"
+#include "vehicle/Train.h"
+
+ui::multiplayer_lobby_panel::multiplayer_lobby_panel()
+    : ui_panel(STR_C("Multiplayer lobby"), false)
+{
+	size_min = {480, 260};
+}
+
+void ui::multiplayer_lobby_panel::enter_vehicle(std::string const &Name)
+{
+	TDynamicObject *vehicle = simulation::Vehicles.find(Name);
+	if (vehicle == nullptr)
+		return;
+
+	std::string payload{Name};
+	// the request travels as an ordinary simulation command, so every peer builds the cab
+	m_relay.post(user_command::entervehicle, 0.0, simulation::Train ? simulation::Train->id() : 0, GLFW_PRESS, 0, vehicle->GetPosition(), &payload);
+	// ...and the driver mode moves our own camera in once the cab shows up locally
+	Global.network_pending_vehicle = Name;
+	is_open = false;
+}
+
+void ui::multiplayer_lobby_panel::render_contents()
+{
+	bool const host{Application.is_server()};
+	bool const client{Application.is_client()};
+
+	if (!host && !client)
+	{
+		ImGui::TextUnformatted(STR_C("This is not a multiplayer session."));
+		return;
+	}
+
+	ImGui::Text("%s: %s, peer %u", STR_C("Session"), host ? (client ? "host + client" : "host") : "client", Global.network_peer_id);
+	ImGui::TextUnformatted(Global.SceneryFile.c_str());
+	ImGui::Separator();
+
+	auto const &entries = network::Entities.entries();
+	if (entries.empty())
+	{
+		ImGui::TextUnformatted(STR_C("Waiting for the vehicle list from the server..."));
+		return;
+	}
+
+	std::string const currentvehicle{simulation::Train != nullptr && simulation::Train->Dynamic() != nullptr ? simulation::Train->Dynamic()->name() : std::string()};
+
+	if (!FreeFlyModeFlag)
+	{
+		ImGui::TextUnformatted(STR_C("Leave the cab to change vehicles."));
+		ImGui::Separator();
+	}
+
+	ImGui::Columns(4, "mp_vehicles", false);
+	ImGui::SetColumnWidth(1, 80.0f * Global.ui_scale);
+	ImGui::SetColumnWidth(2, 90.0f * Global.ui_scale);
+	ImGui::SetColumnWidth(3, 130.0f * Global.ui_scale);
+
+	ImGui::TextDisabled("%s", STR_C("Vehicle"));
+	ImGui::NextColumn();
+	ImGui::TextDisabled("%s", STR_C("Crew"));
+	ImGui::NextColumn();
+	ImGui::TextDisabled("%s", STR_C("Driver"));
+	ImGui::NextColumn();
+	ImGui::NextColumn();
+	ImGui::Separator();
+
+	for (auto const &entry : entries)
+	{
+		ImGui::PushID(static_cast<int>(entry.id));
+
+		ImGui::TextUnformatted(entry.name.c_str());
+		ImGui::NextColumn();
+
+		ImGui::Text("%u/%u", (unsigned)entry.crew_count, (unsigned)entry.crew_capacity);
+		ImGui::NextColumn();
+
+		ImGui::TextUnformatted(entry.crew_count > 0 ? STR_C("player") : entry.ai_active ? STR_C("AI") : STR_C("free"));
+		ImGui::NextColumn();
+
+		if (entry.name == currentvehicle)
+		{
+			ImGui::TextUnformatted(STR_C("you"));
+		}
+		else if (entry.claimable && FreeFlyModeFlag && network::Entities.resolve(entry.id) != nullptr)
+		{
+			if (ImGui::Button(STR_C("Enter"), ImVec2(-1, 0)))
+				enter_vehicle(entry.name);
+		}
+		else
+		{
+			ImGui::TextDisabled("%s", entry.claimable ? "-" : STR_C("occupied"));
+		}
+		ImGui::NextColumn();
+
+		ImGui::PopID();
+	}
+
+	ImGui::Columns(1);
+}

--- a/widgets/multiplayer_lobby.cpp
+++ b/widgets/multiplayer_lobby.cpp
@@ -32,7 +32,14 @@ ui::multiplayer_lobby_panel::multiplayer_lobby_panel()
 
 std::string ui::multiplayer_lobby_panel::describe_crew(network::NetworkEntityId const Entity) const
 {
-	auto const crew = network::Crews.crew_of(Entity);
+	// the people on the whole train, wherever in it they happen to be sitting
+	std::vector<network::PeerId> crew;
+	for (auto const member : network::Entities.consist_members(network::Entities.consist_of(Entity)))
+	{
+		for (auto const peer : network::Crews.crew_of(member))
+			crew.emplace_back(peer);
+	}
+
 	if (crew.empty())
 		return std::string();
 
@@ -93,7 +100,7 @@ void ui::multiplayer_lobby_panel::render_contents()
 	ImGui::SetColumnWidth(2, statewidth);
 	ImGui::SetColumnWidth(3, actionwidth);
 
-	ImGui::TextDisabled("%s", STR_C("Vehicle"));
+	ImGui::TextDisabled("%s", STR_C("Train"));
 	ImGui::NextColumn();
 	ImGui::TextDisabled("%s", STR_C("Crew"));
 	ImGui::NextColumn();
@@ -102,11 +109,21 @@ void ui::multiplayer_lobby_panel::render_contents()
 	ImGui::NextColumn();
 	ImGui::Separator();
 
+	network::NetworkEntityId const owntrain{network::Entities.consist_of(ownvehicle)};
+
 	for (auto const &entry : entries)
 	{
+		// one row per train. a player takes the whole set, not a single car, and moves
+		// between its cars freely once they are on it
+		if (!entry.consist_lead)
+			continue;
+
 		ImGui::PushID(static_cast<int>(entry.id));
 
-		ImGui::TextUnformatted(entry.name.c_str());
+		if (entry.consist_size > 1)
+			ImGui::Text("%s +%u", entry.name.c_str(), (unsigned)(entry.consist_size - 1));
+		else
+			ImGui::TextUnformatted(entry.name.c_str());
 		ImGui::NextColumn();
 
 		ImGui::Text("%u/%u", (unsigned)entry.crew_count, (unsigned)entry.crew_capacity);
@@ -119,10 +136,10 @@ void ui::multiplayer_lobby_panel::render_contents()
 			ImGui::TextDisabled("%s", entry.ai_active ? STR_C("AI") : STR_C("free"));
 		ImGui::NextColumn();
 
-		if (entry.id == ownvehicle)
+		if (owntrain != network::ENTITY_NONE && entry.consist_id == owntrain)
 		{
 			if (ImGui::Button(STR_C("Leave")))
-				Application.request_vehicle_leave(entry.id);
+				Application.request_vehicle_leave(ownvehicle);
 		}
 		else if (entry.claimable)
 		{
@@ -143,7 +160,7 @@ void ui::multiplayer_lobby_panel::render_contents()
 	ImGui::Columns(1);
 
 	ImGui::Separator();
-	ImGui::TextDisabled("%s", STR_C("You can also walk up to a vehicle and use the enter-vehicle key."));
+	ImGui::TextDisabled("%s", STR_C("You can also walk up to a train and use the enter-vehicle key."));
 }
 
 void ui::multiplayer_lobby_panel::claim(network::NetworkEntityId const Entity, network::NetworkEntityId const Current)

--- a/widgets/multiplayer_lobby.cpp
+++ b/widgets/multiplayer_lobby.cpp
@@ -12,10 +12,11 @@ http://mozilla.org/MPL/2.0/.
 
 #include "application/application.h"
 #include "network/entities.h"
+#include "network/session.h"
 #include "simulation/simulation.h"
 #include "utilities/Globals.h"
-#include "utilities/utilities.h"
 #include "utilities/translation.h"
+#include "utilities/utilities.h"
 #include "vehicle/Driver.h"
 #include "vehicle/DynObj.h"
 #include "vehicle/Train.h"
@@ -23,21 +24,30 @@ http://mozilla.org/MPL/2.0/.
 ui::multiplayer_lobby_panel::multiplayer_lobby_panel()
     : ui_panel(STR_C("Multiplayer lobby"), false)
 {
-	size_min = {480, 260};
+	size_min = {520, 280};
 }
 
-void ui::multiplayer_lobby_panel::enter_vehicle(std::string const &Name)
+std::string ui::multiplayer_lobby_panel::describe_crew(network::NetworkEntityId const Entity) const
 {
-	TDynamicObject *vehicle = simulation::Vehicles.find(Name);
-	if (vehicle == nullptr)
-		return;
+	auto const crew = network::Crews.crew_of(Entity);
+	if (crew.empty())
+		return std::string();
 
-	std::string payload{Name};
-	// the request travels as an ordinary simulation command, so every peer builds the cab
-	m_relay.post(user_command::entervehicle, 0.0, simulation::Train ? simulation::Train->id() : 0, GLFW_PRESS, 0, vehicle->GetPosition(), &payload);
-	// ...and the driver mode moves our own camera in once the cab shows up locally
-	Global.network_pending_vehicle = Name;
-	is_open = false;
+	std::string description;
+	for (network::PeerId const peer : crew)
+	{
+		if (!description.empty())
+			description += ", ";
+
+		if (peer == Global.network_peer_id)
+			description += STR("you");
+		else if (peer == network::PEER_HOST)
+			description += STR("host");
+		else
+			description += STR("player") + " " + std::to_string(peer);
+	}
+
+	return description;
 }
 
 void ui::multiplayer_lobby_panel::render_contents()
@@ -53,6 +63,10 @@ void ui::multiplayer_lobby_panel::render_contents()
 
 	ImGui::Text("%s: %s, peer %u", STR_C("Session"), host ? (client ? "host + client" : "host") : "client", Global.network_peer_id);
 	ImGui::TextUnformatted(Global.SceneryFile.c_str());
+
+	if (!Global.network_lobby_message.empty())
+		ImGui::TextColored(ImVec4(1.0f, 0.6f, 0.3f, 1.0f), "%s", Global.network_lobby_message.c_str());
+
 	ImGui::Separator();
 
 	auto const &entries = network::Entities.entries();
@@ -62,24 +76,18 @@ void ui::multiplayer_lobby_panel::render_contents()
 		return;
 	}
 
-	std::string const currentvehicle{simulation::Train != nullptr && simulation::Train->Dynamic() != nullptr ? simulation::Train->Dynamic()->name() : std::string()};
-
-	if (!FreeFlyModeFlag)
-	{
-		ImGui::TextUnformatted(STR_C("Leave the cab to change vehicles."));
-		ImGui::Separator();
-	}
+	network::NetworkEntityId const ownvehicle{network::Crews.vehicle_of(Global.network_peer_id)};
 
 	ImGui::Columns(4, "mp_vehicles", false);
-	ImGui::SetColumnWidth(1, 80.0f * Global.ui_scale);
-	ImGui::SetColumnWidth(2, 90.0f * Global.ui_scale);
+	ImGui::SetColumnWidth(1, 70.0f * Global.ui_scale);
+	ImGui::SetColumnWidth(2, 200.0f * Global.ui_scale);
 	ImGui::SetColumnWidth(3, 130.0f * Global.ui_scale);
 
 	ImGui::TextDisabled("%s", STR_C("Vehicle"));
 	ImGui::NextColumn();
 	ImGui::TextDisabled("%s", STR_C("Crew"));
 	ImGui::NextColumn();
-	ImGui::TextDisabled("%s", STR_C("Driver"));
+	ImGui::TextDisabled("%s", STR_C("On board"));
 	ImGui::NextColumn();
 	ImGui::NextColumn();
 	ImGui::Separator();
@@ -94,21 +102,28 @@ void ui::multiplayer_lobby_panel::render_contents()
 		ImGui::Text("%u/%u", (unsigned)entry.crew_count, (unsigned)entry.crew_capacity);
 		ImGui::NextColumn();
 
-		ImGui::TextUnformatted(entry.crew_count > 0 ? STR_C("player") : entry.ai_active ? STR_C("AI") : STR_C("free"));
+		std::string const crew{describe_crew(entry.id)};
+		if (!crew.empty())
+			ImGui::TextUnformatted(crew.c_str());
+		else
+			ImGui::TextDisabled("%s", entry.ai_active ? STR_C("AI") : STR_C("free"));
 		ImGui::NextColumn();
 
-		if (entry.name == currentvehicle)
+		if (entry.id == ownvehicle)
 		{
-			ImGui::TextUnformatted(STR_C("you"));
+			if (ImGui::Button(STR_C("Leave"), ImVec2(-1, 0)))
+				Application.request_vehicle_leave(entry.id);
 		}
-		else if (entry.claimable && FreeFlyModeFlag && network::Entities.resolve(entry.id) != nullptr)
+		else if (entry.claimable)
 		{
-			if (ImGui::Button(STR_C("Enter"), ImVec2(-1, 0)))
-				enter_vehicle(entry.name);
+			// a vehicle somebody else is already working on can still be joined, that is
+			// what the crew capacity is for
+			if (ImGui::Button(entry.crew_count > 0 ? STR_C("Join crew") : STR_C("Enter"), ImVec2(-1, 0)))
+				claim(entry.id, ownvehicle);
 		}
 		else
 		{
-			ImGui::TextDisabled("%s", entry.claimable ? "-" : STR_C("occupied"));
+			ImGui::TextDisabled("%s", STR_C("full"));
 		}
 		ImGui::NextColumn();
 
@@ -116,4 +131,15 @@ void ui::multiplayer_lobby_panel::render_contents()
 	}
 
 	ImGui::Columns(1);
+}
+
+void ui::multiplayer_lobby_panel::claim(network::NetworkEntityId const Entity, network::NetworkEntityId const Current)
+{
+	if (Current != network::ENTITY_NONE)
+	{
+		// one person cannot work two vehicles at once
+		Application.request_vehicle_leave(Current);
+	}
+
+	Application.request_vehicle_claim(Entity);
 }

--- a/widgets/multiplayer_lobby.cpp
+++ b/widgets/multiplayer_lobby.cpp
@@ -51,10 +51,8 @@ std::string ui::multiplayer_lobby_panel::describe_crew(network::NetworkEntityId 
 
 		if (peer == Global.network_peer_id)
 			description += STR("you");
-		else if (peer == network::PEER_HOST)
-			description += STR("host");
 		else
-			description += STR("player") + " " + std::to_string(peer);
+			description += network::Peers.name_of(peer);
 	}
 
 	return description;
@@ -71,7 +69,24 @@ void ui::multiplayer_lobby_panel::render_contents()
 		return;
 	}
 
-	ImGui::Text("%s: %s, peer %u", STR_C("Session"), host ? (client ? "host + client" : "host") : "client", Global.network_peer_id);
+	ImGui::Text("%s: %s, %s (peer %u)", STR_C("Session"), host ? (client ? "host + client" : "host") : "client",
+	            network::Peers.name_of(Global.network_peer_id).c_str(), Global.network_peer_id);
+
+	auto const roster = network::Peers.roster();
+	if (roster.size() > 1)
+	{
+		std::string others;
+		for (auto const &entry : roster)
+		{
+			if (entry.id == Global.network_peer_id)
+				continue;
+			if (!others.empty())
+				others += ", ";
+			others += entry.name;
+		}
+		if (!others.empty())
+			ImGui::TextDisabled("%s: %s", STR_C("Also here"), others.c_str());
+	}
 	if (!Global.SceneryFile.empty())
 		ImGui::TextDisabled("%s", Global.SceneryFile.c_str());
 

--- a/widgets/multiplayer_lobby.h
+++ b/widgets/multiplayer_lobby.h
@@ -10,7 +10,7 @@ http://mozilla.org/MPL/2.0/.
 #pragma once
 
 #include "application/uilayer.h"
-#include "input/command.h"
+#include "network/entities.h"
 
 namespace ui
 {
@@ -27,9 +27,8 @@ public:
 	void render_contents() override;
 
 private:
-	void enter_vehicle(std::string const &Name);
-
-	command_relay m_relay;
+	void claim(network::NetworkEntityId const Entity, network::NetworkEntityId const Current);
+	std::string describe_crew(network::NetworkEntityId const Entity) const;
 };
 
 } // namespace ui

--- a/widgets/multiplayer_lobby.h
+++ b/widgets/multiplayer_lobby.h
@@ -1,0 +1,35 @@
+/*
+This Source Code Form is subject to the
+terms of the Mozilla Public License, v.
+2.0. If a copy of the MPL was not
+distributed with this file, You can
+obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include "application/uilayer.h"
+#include "input/command.h"
+
+namespace ui
+{
+
+// lobby of a multiplayer session: shows the vehicle roster published by the server and
+// lets the player pick the one to work on. it lives inside the driver mode rather than in
+// a mode of its own on purpose - the world has to keep running while somebody is choosing,
+// and the very same screen is what a player uses to change vehicles later on
+class multiplayer_lobby_panel : public ui_panel
+{
+public:
+	multiplayer_lobby_panel();
+
+	void render_contents() override;
+
+private:
+	void enter_vehicle(std::string const &Name);
+
+	command_relay m_relay;
+};
+
+} // namespace ui

--- a/world/Event.cpp
+++ b/world/Event.cpp
@@ -33,6 +33,7 @@ http://mozilla.org/MPL/2.0/.
 #include "utilities/Timer.h"
 #include "utilities/Logs.h"
 #include "widgets/map_objects.h"
+#include "network/entities.h"
 
 void
 basic_event::event_conditions::bind( basic_event::node_sequence *Nodes ) {
@@ -1306,13 +1307,15 @@ multi_event::run_() {
             if( std::get<bool>( childwrapper ) != conditiontest ) { continue; }
 
             if( childevent != this ) {
-                // normalnie dodać
-                simulation::Events.AddToQuery( childevent, m_activator );
+                // normalnie dodać.
+                // the parent already ran on every peer, so its children are not a local
+                // decision any more and must not be sent around a second time
+                simulation::Events.AddToQuery( childevent, m_activator, 0.0, event_launch::authority );
             }
             else {
                 // jeśli ma być rekurencja to musi mieć sensowny okres powtarzania
                 if( m_delay >= 5.0 ) {
-                    simulation::Events.AddToQuery( this, m_activator );
+                    simulation::Events.AddToQuery( this, m_activator, 0.0, event_launch::authority );
                 }
             }
         }
@@ -2288,8 +2291,15 @@ event_manager::queue_receivers( radio_message const Message, glm::dvec3 const &L
 void
 event_manager::update() {
 
-    // process currently queued events
+    // process currently queued events. this runs on every peer: a client still has a
+    // queue to service, with its delays and its execution
     CheckQuery();
+
+    if( false == network::is_authority() ) {
+        // evaluating the conditions, however, is the authority's job alone
+        return;
+    }
+
     // test list of global events for possible new additions to the queue
     for( auto *launcher : m_launcherqueue ) {
 		if (launcher->check_conditions() && launcher->Event1) {
@@ -2357,8 +2367,9 @@ event_manager::insert( basic_event *Event ) {
         m_eventmap.emplace( Event->m_name, m_events.size() - 1 );
         if( Event->m_ignored != true
          && contains(Event->m_name, "onstart") ) {
-            // event uruchamiany automatycznie po starcie
-            AddToQuery( Event, nullptr );
+            // event uruchamiany automatycznie po starcie.
+            // scenario init runs identically on every peer, so it needs no replication
+            AddToQuery( Event, nullptr, 0.0, event_launch::authority );
         }
     }
 
@@ -2393,9 +2404,58 @@ event_manager::FindEvent( std::string const &Name )
 	return FindEventById(GetEventId(Name));
 }
 
+// how long a request handed to the session is considered still on its way. it only has to
+// outlast the round trip through the command queue; the ceiling keeps a request that got
+// lost somewhere from silencing its event for good
+double const REPLICATION_TIMEOUT { 5.0 };
+
+// hands a locally evaluated launch over to the session authority
+bool
+event_manager::defer_to_authority( basic_event *Event, TDynamicObject const *Owner, double delay ) {
+
+    if( Event->m_passive )     { return false; }
+    if( Event->m_inqueue > 0 ) { return false; }
+
+    // an event whose request is still travelling must not be requested again, or a
+    // condition that stays true would flood the session. instant events are exempt: they
+    // are edge driven and every single one of their additions has to get through
+    if( ( false == Event->is_instant() )
+     && ( Event->m_replicationtime >= 0.0 )
+     && ( Timer::GetTime() - Event->m_replicationtime < REPLICATION_TIMEOUT ) ) {
+        return false;
+    }
+
+    Event->m_replicationtime = Timer::GetTime();
+
+    // the very same command a scenario or a script would use; it comes back through the
+    // command queue and is carried out by every peer, this one included
+    auto const payload {
+        Event->m_name
+        + "%" + ( Owner != nullptr ? Owner->name() : std::string() )
+        + "%" + std::to_string( delay ) };
+
+    m_relay.post( user_command::queueevent, 0.0, 0.0, GLFW_PRESS, 0, glm::vec3( 0.0f ), &payload );
+
+    WriteLog( "net: event replicated: " + Event->m_name + ( Owner != nullptr ? " (by " + Owner->name() + ")" : "" ), logtype::net );
+
+    return true;
+}
+
 // legacy method, inserts specified event in the event query
 bool
-event_manager::AddToQuery( basic_event *Event, TDynamicObject const *Owner, double delay ) {
+event_manager::AddToQuery( basic_event *Event, TDynamicObject const *Owner, double delay, event_launch const Source ) {
+
+    if( Event == nullptr )     { return false; }
+
+    if( ( Source == event_launch::evaluation )
+     && ( true == network::is_multiplayer() ) ) {
+        // the world does not decide on its own what happens in a session: the authority
+        // evaluates the condition and hands the outcome to everybody
+        if( false == network::is_authority() ) { return false; }
+        return defer_to_authority( Event, Owner, delay );
+    }
+
+    Event->m_replicationtime = -1.0;
 
     if( Event->m_passive )     { return false; } // jeśli może być dodany do kolejki (nie używany w skanowaniu)
     if( Event->m_inqueue > 0 ) { return false; } // jeśli nie dodany jeszcze do kolejki
@@ -2512,7 +2572,8 @@ event_manager::InitEvents() {
     //łączenie eventów z pozostałymi obiektami
     for( auto *event : m_events ) {
         event->init();
-        if( event->m_delay < 0 ) { AddToQuery( event, nullptr ); }
+        // scenario init runs identically on every peer, so it needs no replication
+        if( event->m_delay < 0 ) { AddToQuery( event, nullptr, 0.0, event_launch::authority ); }
     }
 }
 

--- a/world/Event.h
+++ b/world/Event.h
@@ -21,6 +21,14 @@ http://mozilla.org/MPL/2.0/.
 #include "scripting/lua.h"
 #endif
 
+// where a request to put an event in the queue came from. in a session only the
+// authority evaluates conditions; everybody, the authority included, runs the event when
+// it comes back as a replicated queueevent, so it fires exactly once on every peer
+enum class event_launch {
+    evaluation, // somebody's local condition check
+    authority   // decided by the session authority, or by deterministic scenario init
+};
+
 // common event interface
 class basic_event {
 
@@ -98,6 +106,7 @@ public:
     double m_delay { 0.0 };
     double m_delayrandom { 0.0 }; // zakres dodatkowego opóźnienia // standardowo nie będzie dodatkowego losowego opóźnienia
     double m_delaydeparture { std::numeric_limits<double>::quiet_NaN() }; // departure-based event delay
+    double m_replicationtime { -1.0 }; // when the authority last handed this one to the session
 
 protected:
 // types
@@ -683,7 +692,8 @@ public:
 	}
     // legacy method, inserts specified event in the event query
     bool
-        AddToQuery( basic_event *Event, TDynamicObject const *Owner, double delay = 0.0 );
+        AddToQuery( basic_event *Event, TDynamicObject const *Owner, double delay = 0.0,
+                    event_launch const Source = event_launch::evaluation );
     // legacy method, executes queued events
     bool
         CheckQuery();
@@ -719,6 +729,11 @@ private:
     basic_table<TEventLauncher> m_radiodrivenlaunchers;
     eventlauncher_sequence m_launcherqueue;
 	command_relay m_relay;
+// methods
+    // hands a locally evaluated launch over to the session, so that it reaches every peer
+    // through the ordinary queueevent command instead of firing here alone
+    bool
+        defer_to_authority( basic_event *Event, TDynamicObject const *Owner, double delay );
 };
 
 


### PR DESCRIPTION
Rebuild of old multiplayer mode 
adds cli arguments `--host (ip):(port)` and `--connect (ip):(port)` where connect doesnt require any kind of scenery or vehicle definition.
New ini configurations
```
multiplayer.sync.running  1.5   // sync margin while driving
multiplayer.sync.stop     0.2   // correction on stopped train
```
Still w.i.p.